### PR TITLE
Fix non-snapshot releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,6 @@
 name: Snapshot release build
 on:
   push:
-    tags:
-      - "*"
     tags-ignore:
       - "*-snapshot"
 jobs:


### PR DESCRIPTION
It turns out that you cannot have both tags and tags-ignore. Hope that
ignoring will be enough.

Issue: #175