### PR TITLE
Remove build number from embedded build info

### DIFF
--- a/buildSrc/src/main/groovy/name/mlopatkin/andlogview/building/BuildEnvironment.groovy
+++ b/buildSrc/src/main/groovy/name/mlopatkin/andlogview/building/BuildEnvironment.groovy
@@ -48,13 +48,6 @@ class BuildEnvironment {
         return readRevWithGitDescribe()
     }
 
-    String getBuildNumber() {
-        if (isCiBuild()) {
-            return firstNonNull(System.getenv('BITBUCKET_BUILD_NUMBER'), System.getenv('GITHUB_RUN_NUMBER'))
-        }
-        return '-'
-    }
-
     private String readRevWithGitDescribe() {
         List<String> command = [
                 'git',  // Only try to find Git in PATH

--- a/buildSrc/src/main/groovy/name/mlopatkin/andlogview/building/GenerateBuildMetadata.groovy
+++ b/buildSrc/src/main/groovy/name/mlopatkin/andlogview/building/GenerateBuildMetadata.groovy
@@ -50,7 +50,6 @@ class GenerateBuildMetadata extends DefaultTask {
         def fullClassName = ClassName.get(packageName, className)
         def metadataClass = TypeSpec.classBuilder(fullClassName).addModifiers(Modifier.FINAL, Modifier.PUBLIC)
                 .addField(stringConstant('VERSION', version, 'Version of the application.'))
-                .addField(stringConstant('BUILD', buildEnv.buildNumber, 'Build number if the app is built on CI.'))
                 .addField(stringConstant('REVISION', buildEnv.sourceRevision, 'Source revision of which app is built.'))
                 .build()
         JavaFile.builder(fullClassName.packageName(), metadataClass)

--- a/src/name/mlopatkin/andlogview/Main.java
+++ b/src/name/mlopatkin/andlogview/Main.java
@@ -103,7 +103,7 @@ public class Main {
         if (!BuildInfo.VERSION.endsWith("SNAPSHOT")) {
             return BuildInfo.VERSION;
         }
-        return BuildInfo.VERSION + " (build " + BuildInfo.BUILD + " " + BuildInfo.REVISION + ")";
+        return BuildInfo.VERSION + " (rev " + BuildInfo.REVISION + ")";
     }
 
     private MainFrame createAndShowWindow() {


### PR DESCRIPTION
This isn't a particularly useful thing given the migration to Github
where build numbers started from 1 again.

Issue: #157