### PR TITLE
Use consistent file permissions in archives everywhere

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -292,6 +292,15 @@ tasks.named<ShadowJar>("shadowJar") {
 tasks.withType<AbstractArchiveTask>().configureEach {
     isPreserveFileTimestamps = false
     isReproducibleFileOrder = true
+
+    // Set up consistent permissions on files. This is consistent with the permissions on Windows machines and the
+    // Docker image.
+    val permissionsMask = 0x1ED // octal 0755, aka rwxr-xr-x
+    dirMode = permissionsMask
+    eachFile {
+        // Some files are executable, we want to keep them as such, thus we apply the mask.
+        mode = mode and permissionsMask
+    }
 }
 
 // Configure publishing


### PR DESCRIPTION
Without explicit set up the build picks up whatever is set on the files
in the working directory. Turns out it depends on the configuration of
the OS, e.g. on Windows and in the Docker image these are `rw?r-?r-?`
while on my Linux box these are `rw?rw?r-?` (executability depends on
the actual file). This causes hard-to-debug discrepancies so now the
build explicitly discards group-writable attribute.

Fixes #157