### PR TITLE
Support kernel buffer where it is available

### DIFF
--- a/resources/name/mlopatkin/andlogview/logview.properties
+++ b/resources/name/mlopatkin/andlogview/logview.properties
@@ -18,6 +18,7 @@ ui.highlight_colors = #D0F0C0, #C7C2FC, #FECBC0, #FCFC96
 ui.buffer_enabled.MAIN = true
 ui.buffer_enabled.SYSTEM = true
 ui.buffer_enabled.CRASH = true
+ui.buffer_enabled.KERNEL = true
 ui.buffer_enabled.RADIO = false
 ui.buffer_enabled.EVENTS = false
 ui.buffer_enabled.UNKNOWN = true
@@ -29,6 +30,7 @@ adb.buffer.CRASH = crash
 adb.buffer.SYSTEM = system
 adb.buffer.EVENTS = events
 adb.buffer.RADIO = radio
+adb.buffer.KERNEL = kernel
 
 dump.buffer.MAIN = MAIN
 dump.buffer.SYSTEM = SYSTEM

--- a/src/name/mlopatkin/andlogview/liblogcat/LogRecord.java
+++ b/src/name/mlopatkin/andlogview/liblogcat/LogRecord.java
@@ -55,7 +55,8 @@ public class LogRecord implements Comparable<LogRecord> {
         SYSTEM("System"),
         RADIO("Radio"),
         EVENTS("Events"),
-        CRASH("Crash");
+        CRASH("Crash"),
+        KERNEL("Kernel");
 
         private final String name;
 


### PR DESCRIPTION
The kernel log buffer is still listed as available even in user builds,
but it is always empty there. We have to live with it though.

Issue: #157