### PR TITLE
Bring existing filter editor to front when trying to edit it twice

### DIFF
--- a/src/name/mlopatkin/andlogview/ui/filterdialog/FilterDialog.java
+++ b/src/name/mlopatkin/andlogview/ui/filterdialog/FilterDialog.java
@@ -173,4 +173,8 @@ class FilterDialog extends BaseFilterDialogUi implements FilterDialogPresenter.F
         ErrorDialogsHelper.showError(this, text);
     }
 
+    @Override
+    public void bringToFront() {
+        this.toFront();
+    }
 }

--- a/src/name/mlopatkin/andlogview/ui/filterdialog/FilterDialogFactory.java
+++ b/src/name/mlopatkin/andlogview/ui/filterdialog/FilterDialogFactory.java
@@ -45,9 +45,11 @@ public class FilterDialogFactory {
         return FilterDialogPresenter.create(dialogView, filter).show();
     }
 
-    public CompletionStage<Optional<FilterFromDialog>> startEditFilterDialog(FilterFromDialog filter) {
+    public FilterDialogHandle startEditFilterDialog(FilterFromDialog filter) {
         FilterDialog dialogView = filterDialogViewFactory.get();
         dialogView.setTitle(EDIT_FILTER_DIALOG_TITLE);
-        return FilterDialogPresenter.create(dialogView, filter).show();
+        FilterDialogPresenter dialogPresenter = FilterDialogPresenter.create(dialogView, filter);
+        dialogPresenter.show();
+        return dialogPresenter;
     }
 }

--- a/src/name/mlopatkin/andlogview/ui/filterdialog/FilterDialogHandle.java
+++ b/src/name/mlopatkin/andlogview/ui/filterdialog/FilterDialogHandle.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.ui.filterdialog;
+
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+
+public interface FilterDialogHandle {
+    void bringToFront();
+
+    CompletionStage<Optional<FilterFromDialog>> getResult();
+}

--- a/src/name/mlopatkin/andlogview/ui/filterdialog/FilterDialogPresenter.java
+++ b/src/name/mlopatkin/andlogview/ui/filterdialog/FilterDialogPresenter.java
@@ -38,7 +38,7 @@ import java.util.stream.Stream;
 /**
  * Presenter for the FilterEditor dialog. Allows to open dialog to create new or edit existing filter.
  */
-class FilterDialogPresenter {
+class FilterDialogPresenter implements FilterDialogHandle {
     /**
      * Presenter talks to view through this interface.
      */
@@ -76,6 +76,8 @@ class FilterDialogPresenter {
         void hide();
 
         void showError(String text);
+
+        void bringToFront();
     }
 
     private final FilterDialogView dialogView;
@@ -164,6 +166,17 @@ class FilterDialogPresenter {
         }
         dialogView.hide();
         editingPromise.complete(Optional.empty());
+    }
+
+    @Override
+    public void bringToFront() {
+        dialogView.bringToFront();
+    }
+
+    @Override
+    public CompletionStage<Optional<FilterFromDialog>> getResult() {
+        Preconditions.checkState(editingPromise != null, "Dialog is not shown");
+        return editingPromise;
     }
 
     public CompletionStage<Optional<FilterFromDialog>> show() {

--- a/test/name/mlopatkin/andlogview/filters/MainFilterControllerTest.java
+++ b/test/name/mlopatkin/andlogview/filters/MainFilterControllerTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -37,6 +38,7 @@ import name.mlopatkin.andlogview.config.FakeDefaultConfigStorage;
 import name.mlopatkin.andlogview.filters.MainFilterController.SavedFilterData;
 import name.mlopatkin.andlogview.liblogcat.LogRecord;
 import name.mlopatkin.andlogview.ui.filterdialog.FilterDialogFactory;
+import name.mlopatkin.andlogview.ui.filterdialog.FilterDialogHandle;
 import name.mlopatkin.andlogview.ui.filterdialog.FilterFromDialog;
 import name.mlopatkin.andlogview.ui.filterpanel.FilterPanelModel;
 import name.mlopatkin.andlogview.ui.filterpanel.PanelFilter;
@@ -151,10 +153,10 @@ public class MainFilterControllerTest {
 
         List<SavedFilterData> savedFilterData = savedFilterDataCaptor.getValue();
 
-        mockStorage = Mockito.mock(ConfigStorage.class);
+        mockStorage = mock(ConfigStorage.class);
         when(mockStorage.loadConfig(Mockito.<FilterListSerializer>any())).thenReturn(savedFilterData);
 
-        filterPanelModel = Mockito.mock(FilterPanelModel.class);
+        filterPanelModel = mock(FilterPanelModel.class);
         controller = new MainFilterController(
                 filterPanelModel, indexFilterCollection, dialogFactory, mockStorage, filterImpl);
 
@@ -191,8 +193,9 @@ public class MainFilterControllerTest {
     }
 
     private PanelFilter editFilterWithDialog(FilterFromDialog newFilter, PanelFilter oldFilter) {
-        when(dialogFactory.startEditFilterDialog(any())).thenReturn(
-                CompletableFuture.completedFuture(Optional.of(newFilter)));
+        FilterDialogHandle dialogHandle = mock(FilterDialogHandle.class);
+        when(dialogHandle.getResult()).thenReturn(CompletableFuture.completedFuture(Optional.of(newFilter)));
+        when(dialogFactory.startEditFilterDialog(any())).thenReturn(dialogHandle);
         oldFilter.openFilterEditor();
 
         order.verify(filterPanelModel).replaceFilter(eq(oldFilter), panelFilterCaptor.capture());
@@ -201,7 +204,9 @@ public class MainFilterControllerTest {
 
     private CompletableFuture<Optional<FilterFromDialog>> openFilterDialog(PanelFilter filter) {
         CompletableFuture<Optional<FilterFromDialog>> future = new CompletableFuture<>();
-        when(dialogFactory.startEditFilterDialog(any())).thenReturn(future);
+        FilterDialogHandle dialogHandle = mock(FilterDialogHandle.class);
+        when(dialogHandle.getResult()).thenReturn(future);
+        when(dialogFactory.startEditFilterDialog(any())).thenReturn(dialogHandle);
         filter.openFilterEditor();
 
         return future;

--- a/test/name/mlopatkin/andlogview/ui/filterdialog/FilterDialogPresenterTest.java
+++ b/test/name/mlopatkin/andlogview/ui/filterdialog/FilterDialogPresenterTest.java
@@ -154,6 +154,10 @@ public class FilterDialogPresenterTest {
             errorText = text;
         }
 
+        @Override
+        public void bringToFront() {
+        }
+
         public void commit() {
             commitAction.run();
         }


### PR DESCRIPTION
While the second editor did nothing, it was still a sub-par UX. New
behavior is much friendlier.

Issue: fixes #155