### PR TITLE
Fix Filter Panel display when going to/from empty panel

### DIFF
--- a/src/name/mlopatkin/andlogview/ui/filterpanel/FilterPanel.java
+++ b/src/name/mlopatkin/andlogview/ui/filterpanel/FilterPanel.java
@@ -63,6 +63,8 @@ public class FilterPanel extends FilterPanelUi implements FilterPanelModel.Filte
         this.model = model;
         this.filterCreator = filterCreator;
 
+        themed.configureFilterPanel(this, content);
+
         filterIcon = themed.getIcon(Icons.FILTER);
         ImageIcon addIcon = themed.getIcon(Icons.ADD);
         ImageIcon nextIcon = themed.getIcon(Icons.NEXT);
@@ -118,7 +120,8 @@ public class FilterPanel extends FilterPanelUi implements FilterPanelModel.Filte
         buttonByFilter.put(newFilter, button);
         content.add(button);
         menuHandler.addPopup(button);
-        validate();
+        revalidate();
+        repaint();
     }
 
     @Override

--- a/src/name/mlopatkin/andlogview/ui/filterpanel/FilterPanelUi.java
+++ b/src/name/mlopatkin/andlogview/ui/filterpanel/FilterPanelUi.java
@@ -19,7 +19,6 @@ package name.mlopatkin.andlogview.ui.filterpanel;
 import name.mlopatkin.andlogview.widgets.UiHelper;
 
 import java.awt.Dimension;
-import java.awt.FlowLayout;
 
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -70,7 +69,6 @@ class FilterPanelUi extends JPanel {
         content = new JPanel();
         content.setBackground(UIManager.getColor("ToolBar.background"));
         content.setBorder(UiHelper.NO_BORDER);
-        ((FlowLayout) content.getLayout()).setAlignment(FlowLayout.LEFT);
         JScrollPane scrollPane =
                 new JScrollPane(content, JScrollPane.VERTICAL_SCROLLBAR_NEVER, JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
         scrollPane.setBorder(UiHelper.NO_BORDER);

--- a/src/name/mlopatkin/andlogview/ui/themes/BasicWidgetFactory.java
+++ b/src/name/mlopatkin/andlogview/ui/themes/BasicWidgetFactory.java
@@ -19,8 +19,11 @@ package name.mlopatkin.andlogview.ui.themes;
 import name.mlopatkin.andlogview.ui.Icons;
 import name.mlopatkin.andlogview.widgets.UiHelper;
 
+import java.awt.FlowLayout;
+
 import javax.swing.AbstractButton;
 import javax.swing.ImageIcon;
+import javax.swing.JPanel;
 
 class BasicWidgetFactory implements ThemedWidgetFactory {
     private static final int SCROLL_BUTTON_WIDTH = 26;
@@ -37,5 +40,10 @@ class BasicWidgetFactory implements ThemedWidgetFactory {
     @Override
     public void configureFilterPanelScrollButton(AbstractButton button) {
         UiHelper.setWidths(button, SCROLL_BUTTON_WIDTH);
+    }
+
+    @Override
+    public void configureFilterPanel(JPanel filterPanel, JPanel filterButtonsPanel) {
+        filterButtonsPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 5, 5));
     }
 }

--- a/src/name/mlopatkin/andlogview/ui/themes/FlatLafWidgetFactory.java
+++ b/src/name/mlopatkin/andlogview/ui/themes/FlatLafWidgetFactory.java
@@ -22,11 +22,14 @@ import com.formdev.flatlaf.FlatClientProperties;
 import com.formdev.flatlaf.extras.FlatSVGIcon;
 
 import java.awt.Color;
+import java.awt.FlowLayout;
 import java.awt.Insets;
 
 import javax.swing.AbstractButton;
 import javax.swing.ImageIcon;
+import javax.swing.JPanel;
 import javax.swing.UIManager;
+import javax.swing.border.EmptyBorder;
 
 class FlatLafWidgetFactory implements ThemedWidgetFactory {
     @Override
@@ -61,5 +64,11 @@ class FlatLafWidgetFactory implements ThemedWidgetFactory {
             return 16;
         }
         return 24;
+    }
+
+    @Override
+    public void configureFilterPanel(JPanel filterPanel, JPanel filterButtonsPanel) {
+        filterPanel.setBorder(new EmptyBorder(5, 5, 5, 5));
+        filterButtonsPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 5, 0));
     }
 }

--- a/src/name/mlopatkin/andlogview/ui/themes/ThemedWidgetFactory.java
+++ b/src/name/mlopatkin/andlogview/ui/themes/ThemedWidgetFactory.java
@@ -20,6 +20,7 @@ import name.mlopatkin.andlogview.ui.Icons;
 
 import javax.swing.AbstractButton;
 import javax.swing.ImageIcon;
+import javax.swing.JPanel;
 
 public interface ThemedWidgetFactory {
     ImageIcon getIcon(Icons iconId);
@@ -27,4 +28,6 @@ public interface ThemedWidgetFactory {
     void configureFilterPanelButton(AbstractButton button);
 
     void configureFilterPanelScrollButton(AbstractButton button);
+
+    void configureFilterPanel(JPanel filterPanel, JPanel filterButtonsPanel);
 }


### PR DESCRIPTION
The JPanel's default FlowLayout adds 5px paddings on top and bottom.
Without any filter buttons it is of no concern as the panel with(out)
buttons has a desired height of 0, so it is stretched out to the size of
the container. When the filter button appears, these paddings are
applied and this caused the FilterPanel to become 10px taller.

The fix is to remove the default paddings from the inner JPanel.
Instead, some paddings were added to the FilterPanel itself to achieve
a more pleasant look.

Additionally, a "revalidate()+repaint()" spell is now used when the
filter is added. Without this, the change in height is not propagated
to the FilterPanel (thought there is no more change in height).

Fixes #218