### PR TITLE
Revert "Create draft Github release on tag push"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,11 +28,3 @@ jobs:
           LOGVIEW_SNAPSHOT_BUILD: false
       - name: Publish artifacts
         uses: ./.github/actions/publish-gradle-outputs
-      - name: Publish Github release
-        uses: marvinpinto/action-automatic-releases@v1.2.1
-        if: ${{ success() }}
-        with:
-          files: build/distributions/*
-          draft: true
-          prerelease: false
-          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit 35dbdb0465e62486b5570435697d64350409e750.

The automated release action is incompatible with RC tags.