### PR TITLE
Change the build environment on CI to use JDK from Temurin

### DIFF
--- a/.github/workflows/pull-request-test.yaml
+++ b/.github/workflows/pull-request-test.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   run-precommit-tests:
     runs-on: ubuntu-latest
-    container: openjdk:8u302-jdk@sha256:e94c5b7f0f428b581053fbb8c0f994f1a27df570e0f7753fad6dffb06c3baf22
+    container: ghcr.io/mlopatkin/andlogview-build-environment@sha256:e30a7aaba23b1ae1abc90018eba4bdd148baee3faa975d0c84fed4009d4b30f3
     env:
       PYTHON_BINARY: python3
     steps:

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-snapshot:
     runs-on: ubuntu-latest
-    container: openjdk:8u302-jdk@sha256:e94c5b7f0f428b581053fbb8c0f994f1a27df570e0f7753fad6dffb06c3baf22
+    container: ghcr.io/mlopatkin/andlogview-build-environment@sha256:e30a7aaba23b1ae1abc90018eba4bdd148baee3faa975d0c84fed4009d4b30f3
     env:
       PYTHON_BINARY: python3
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-release:
     runs-on: ubuntu-latest
-    container: openjdk:8u302-jdk@sha256:e94c5b7f0f428b581053fbb8c0f994f1a27df570e0f7753fad6dffb06c3baf22
+    container: ghcr.io/mlopatkin/andlogview-build-environment@sha256:e30a7aaba23b1ae1abc90018eba4bdd148baee3faa975d0c84fed4009d4b30f3
     env:
       PYTHON_BINARY: python3
     steps:


### PR DESCRIPTION
The OpenJDK images that I was using before are no longer supported. Moreover, the JDK version is also outdated.

Fixes issue #244.