### PR TITLE
fix: Remove trailing newline from Git Revision string.

### DIFF
--- a/buildSrc/src/main/kotlin/name/mlopatkin/andlogview/building/GitRevisionValueSource.kt
+++ b/buildSrc/src/main/kotlin/name/mlopatkin/andlogview/building/GitRevisionValueSource.kt
@@ -48,7 +48,7 @@ internal abstract class GitRevisionValueSource : ValueSource<String, GitRevision
                 .start()
 
             gitDescribe.use {
-                val result = inputStream.bufferedReader().readText()
+                val result = inputStream.bufferedReader().readText().toString().trim()
                 if (waitForSuccess()) {
                     return result
                 }


### PR DESCRIPTION
Fixes cut off title in Main Window.

Signed-off-by: Dzmitry Neviadomski <nevack.d@gmail.com>