### PR TITLE
Remove everything related to Eclipse import from build and docs

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -68,12 +68,10 @@ You can specify JDK to use with JAVA_HOME environment variable.
 
 ## Importing into IDE
 #### IDEA
-You can use [IDEA Community Edition][idea] 14 or later. I didn't check earlier versions. Use "File > New Project From
-Existing Sources... > (Select project directory) > Gradle". Do not use "Create separate module per source set".
-Annotation processing should work "out-of-the-box".
-
-For newer versions (I've tested 2019.3.4) use "File > New Project From Existing Sources... > (Select build.gradle in
-project directory)" or use "Import Existing Project..." in the startup wizard.
+You can use [IDEA Community Edition][idea]. Modern versions work out of the box. Just use
+"File > New Project From Existing Sources... > (Select build.gradle in project directory)" or use "Import Existing
+Project..." in the startup wizard. The project tries to use the most recent version of Gradle, so it is preferred to
+use the latest available IDEA version.
 
 There are project-specific codestyle settings that can be imported. Open "File > Settings > Editor > Code Style". Select
 "Project" for "Scheme", then click on Gear icon, select "Import scheme...". Select
@@ -82,9 +80,8 @@ be imported for this project only. You can also import copyright profiles from `
 directory into `.idea` (but not when IDEA is running).
 
 ### Eclipse
-Import project into your Eclipse workspace with "File > Import... > Gradle > Existing Gradle Project". Annotation
-processing should work "out-of-the-box". Eclipse is still a preferred way to work with GUI because of the WindowBuilder
-plugin.
+Editing the project in Eclipse IDE is no longer supported. Contributions are welcomed. I had no success in setting up
+the project with Eclipse 2022-09.
 
 ## Updating the CI build environment
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -280,11 +280,3 @@ if (System.getProperty("os.name").toLowerCase(Locale.US).contains("linux")) {
         }
     }
 }
-
-// Configure IDE support
-
-// Modern gradle support in eclipse (Buildship) doesn't require this task, but it is brought in by eclipse.apt plugin
-disableTasks("eclipse")
-// TODO(mlopatkin) do we need this for modern Buildship versions?
-// Order of tasks is important or generated metadata sources will not be imported
-eclipse.synchronizationTasks("generateBuildMetadata", "eclipseJdtApt", "eclipseFactorypath", "eclipseJdt")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -29,6 +29,5 @@ dependencies {
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 
     implementation(libs.build.errorprone.plugin)
-    implementation(libs.build.eclipseAptPlugin)
     implementation(libs.build.javapoet)
 }

--- a/buildSrc/src/main/kotlin/name/mlopatkin/andlogview/building/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/name/mlopatkin/andlogview/building/java-conventions.gradle.kts
@@ -23,7 +23,6 @@ plugins {
     checkstyle
 
     // It is not possible to use a constant from the version catalog there
-    id("com.diffplug.eclipse.apt")
     id("net.ltgt.errorprone")
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,6 @@ andlogview = "0.22"
 checkstyle = "8.45.1"
 dagger = "2.40.5"
 errorpronePlugin = "2.0.2"
-eclipseAptPlugin = "3.34.1"
 flatlaf = "2.0"
 mockito = "4.2.0"
 compileJdkVersion = "17"  # JDK version used for compilation
@@ -13,7 +12,6 @@ sourceJavaVersion = "16"
 runtimeJdkVersion = "8"  # JDK version used at runtime, determines available APIs
 
 [libraries]
-build-eclipseAptPlugin = { module = "com.diffplug.gradle:goomph", version.ref = "eclipseAptPlugin" }
 build-errorprone-core = "com.google.errorprone:error_prone_core:2.10.0"
 build-errorprone-javac = "com.google.errorprone:javac:9+181-r4173-1"
 build-errorprone-plugin = { module = "net.ltgt.gradle:gradle-errorprone-plugin", version.ref = "errorpronePlugin" }
@@ -43,8 +41,6 @@ test-mockito-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.r
 [plugins]
 # Bitbucket plugin allows publishing releases to the Bitbucket project's Downloads page
 bitbucket = "name.mlopatkin.bitbucket:0.5-rc4"
-# Eclipse APT plugin configures annotation processors when importing the project into Eclipse
-eclipseApt = { id = "com.diffplug.eclipse.apt", version.ref = "eclipseAptPlugin" }
 # Errorprone plugin allows to configure Errorprone compiler
 errorprone = { id = "net.ltgt.errorprone", version.ref = "errorpronePlugin" }
 # Runtime plugin allows preparing runtime images with JDK included


### PR DESCRIPTION
Importing into Eclipse doesn't work out-of-the-box and the ROI of fixing it is too small. I hereby proclaim an end of the Eclipse era of the project.

Issue: fixes #285