### PR TITLE
Preserve EOLNs when reading logs

### DIFF
--- a/.nolint
+++ b/.nolint
@@ -1,6 +1,7 @@
 # Test resources may have whatever format they want
 test_resources/*
 jmh/resources/*
+base/src/jmh/resources/*
 
 # Binary files
 *.png

--- a/base/build.gradle.kts
+++ b/base/build.gradle.kts
@@ -17,6 +17,8 @@
 plugins {
     id("name.mlopatkin.andlogview.building.java-library-conventions")
 
+    alias(libs.plugins.jmh)
+
     `java-test-fixtures`
 }
 

--- a/base/src/jmh/java/name/mlopatkin/andlogview/base/io/LineReaderPerfTest.java
+++ b/base/src/jmh/java/name/mlopatkin/andlogview/base/io/LineReaderPerfTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.base.io;
+
+import com.google.common.io.CharSource;
+import com.google.common.io.Resources;
+
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.function.Supplier;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@State(Scope.Benchmark)
+@Fork(3)
+public class LineReaderPerfTest {
+    @Param({"lf", "crlf", "random"})
+    private @MonotonicNonNull String eoln;
+
+    private @MonotonicNonNull CharSource input;
+
+    @Setup(Level.Trial)
+    public void setUp() throws Exception {
+        input = CharSource.wrap(loadWithLfConversion(loadResource("test_log_lf.log")));
+    }
+
+    private String loadWithLfConversion(CharSource source) throws IOException {
+        Supplier<String> eolnFactory = switch (eoln) {
+            case "lf" -> () -> "\n";
+            case "cr" -> () -> "\r";
+            case "crlf" -> () -> "\r\n";
+            case "random" -> randomEolnGenerator();
+            default -> throw new IllegalArgumentException("Unknown eoln mode " + eoln);
+        };
+        StringBuilder output = new StringBuilder();
+        try (var reader = source.openBufferedStream()) {
+            int ch = reader.read();
+            while (ch != -1) {
+                if (ch == '\n') {
+                    output.append(eolnFactory.get());
+                } else {
+                    output.append((char) ch);
+                }
+                ch = reader.read();
+            }
+        }
+        return output.toString();
+    }
+
+    private Supplier<String> randomEolnGenerator() {
+        var rnd = new Random(1337L);
+        String[] eolns = {"\n", "\r\n"};
+        return () -> eolns[rnd.nextInt(2)];
+    }
+
+    @Benchmark
+    public void parseWithBufferedReader(Blackhole bh) throws IOException {
+        try (var in = input.openBufferedStream()) {
+            String line = in.readLine();
+            while (line != null) {
+                bh.consume(line);
+                line = in.readLine();
+            }
+        }
+    }
+
+    @Benchmark
+    public void parseWithLineReader(Blackhole bh) throws IOException {
+        try (var in = new LineReader(input, 8192)) {
+            String line = in.readLine();
+            while (line != null) {
+                bh.consume(line);
+                line = in.readLine();
+            }
+        }
+    }
+
+    public static CharSource loadResource(String benchmarkDataFile) {
+        return Resources.asCharSource(Resources.getResource(LineReaderPerfTest.class, benchmarkDataFile),
+                StandardCharsets.UTF_8);
+    }
+}

--- a/base/src/jmh/resources/name/mlopatkin/andlogview/base/io/test_log_lf.log
+++ b/base/src/jmh/resources/name/mlopatkin/andlogview/base/io/test_log_lf.log
@@ -1,0 +1,5000 @@
+01-13 01:49:39.074  2348  2367 E ReloadingLock: Finalizing LOCKED Token[shortcuts 2020-01-13 01:47:46.561]
+01-13 01:49:39.074  2348  2367 E ReloadingLock: Finalizing LOCKED Token[shortcuts 2020-01-13 01:47:46.582]
+01-13 01:49:39.214  2116  2116 I BeaconBle: Scan : No clients left, canceling alarm.
+01-13 01:49:41.911  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 01:49:41.911  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 01:49:41.911  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 01:49:45.716  2348 18518 I EventLogSendingHelper: Sending log events.
+01-13 01:49:48.992  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 01:49:48.992  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 01:49:48.992  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 01:50:00.005  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:50:00.005  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:50:00.020  1442  1465 D hwcomposer: hw_composer sent 24 syncs in 60s
+01-13 01:50:00.024  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:00.581  2155 18524 E Dialer  : SpamAsyncTaskUtil.onError - error while fetching list updates via gRPC
+01-13 01:50:00.582  2155 18524 E Dialer  : SpamAsyncTaskUtil.onError - fdz: UNAVAILABLE
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at fdu.a(PG:53)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at fgp.a(PG:20)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at io.grpc.internal.q.a(PG:172)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at io.grpc.internal.q$a.a(PG:17)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at io.grpc.internal.v.a(PG:11)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at io.grpc.internal.ai.run(PG:5)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at io.grpc.internal.ds.run(PG:19)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at java.lang.Thread.run(Thread.java:764)
+01-13 01:50:00.582  2155 18524 E Dialer  : Caused by: java.net.ConnectException: failed to connect to telephonyspamprotect-pa.googleapis.com/2a00:1450:4010:c06::5f (port 443) from /:: (port 46193): connect failed: ECONNREFUSED (Connection refused)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at libcore.io.IoBridge.connect(IoBridge.java:138)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:129)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:356)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:200)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:182)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:357)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at java.net.Socket.connect(Socket.java:616)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at java.net.Socket.connect(Socket.java:565)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at java.net.Socket.<init>(Socket.java:445)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at java.net.Socket.<init>(Socket.java:248)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at fez.run(PG:45)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at io.grpc.internal.ds.run(PG:19)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at dda.run(Unknown Source:3)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	... 3 more
+01-13 01:50:00.582  2155 18524 E Dialer  : Caused by: android.system.ErrnoException: connect failed: ECONNREFUSED (Connection refused)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at libcore.io.Linux.connect(Native Method)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at libcore.io.BlockGuardOs.connect(BlockGuardOs.java:126)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at libcore.io.IoBridge.connectErrno(IoBridge.java:152)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	at libcore.io.IoBridge.connect(IoBridge.java:130)
+01-13 01:50:00.582  2155 18524 E Dialer  : 	... 15 more
+01-13 01:50:04.188  2348 17010 W GmsLocationProvider: Error removing location updates: 16
+01-13 01:50:06.038  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 01:50:11.020  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:11.022  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 26588403 , only wrote 26588160
+01-13 01:50:11.060  1666  1687 D AutofillManagerService: onBackKeyPressed()
+01-13 01:50:11.063  1666  1691 D AutofillManagerService: Close system dialogs
+01-13 01:50:11.068  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:11.072  1666  7773 I ActivityManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.HOME] flg=0x10200000 cmp=com.google.android.apps.nexuslauncher/.NexusLauncherActivity} from uid 10029
+01-13 01:50:11.089  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:11.110  1441  1502 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:50:11.117  1441  1502 I chatty  : uid=1000(system) HwBinder:1441_2 identical 1 line
+01-13 01:50:11.130  1441  1502 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:50:11.130  2116  2618 W GCoreFlp: No location to return for getLastLocation()
+01-13 01:50:11.147  1451  1451 D SurfaceFlinger: duplicate layer name: changing com.google.android.apps.nexuslauncher/com.google.android.apps.nexuslauncher.NexusLauncherActivity to com.google.android.apps.nexuslauncher/com.google.android.apps.nexuslauncher.NexusLauncherActivity#1
+01-13 01:50:11.151  2348  2728 D EGL_emulation: eglMakeCurrent: 0xe1085f00: ver 2 0 (tinfo 0xe1083ba0)
+01-13 01:50:11.156  1441  1502 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:50:11.164  1812  7320 I zygote  : Explicit concurrent copying GC freed 5670(374KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 4MB/9MB, paused 676us total 62.469ms
+01-13 01:50:11.174  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:50:11.181  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:50:11.205  2374  2504 D EGL_emulation: eglMakeCurrent: 0xce51d940: ver 2 0 (tinfo 0xce534ae0)
+01-13 01:50:11.225  2348  2348 W SessionLifecycleManager: Handover failed. Creating new session controller.
+01-13 01:50:11.230  2348  2348 I OptInState: There is a new client and it does not support opt-in. Dropping request.
+01-13 01:50:11.241  1666  7775 I WifiService: getConnectionInfo uid=10032
+01-13 01:50:11.251  2348 18404 W LocationOracle: No location history returned by ContextManager
+01-13 01:50:11.257  2348  2348 I MicroDetectionWorker: #updateMicroDetector [detectionMode: [mDetectionMode: [1]]]
+01-13 01:50:11.257  2348  2348 I MicroDetectionWorker: #startMicroDetector [speakerMode: 0]
+01-13 01:50:11.258  2348  2348 I AudioController: Using mInputStreamFactoryBuilder
+01-13 01:50:11.261  1666  7772 I WifiService: getConnectionInfo uid=10032
+01-13 01:50:11.263  2348 17656 I MicroRecognitionRunner: Starting detection.
+01-13 01:50:11.272  2348 18402 I MicrophoneInputStream: mic_starting com.google.android.apps.gsa.staticplugins.aa.c@ca6f8f5
+01-13 01:50:11.273  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:11.274  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:50:11.274  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:11.274  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:50:11.275  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:11.275  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:50:11.275  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:11.276  1526  1581 W ServiceManager: Permission failure: android.permission.RECORD_AUDIO from uid=10032 pid=2348
+01-13 01:50:11.276  1526  1581 E         : Request requires android.permission.RECORD_AUDIO
+01-13 01:50:11.276  1526  1581 E         : android.permission.CAPTURE_AUDIO_HOTWORD
+01-13 01:50:11.276  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:50:11.276  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:11.276  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:50:11.276  2348 18402 E AudioRecord: Could not get audio input for session 15905, record source 1999, sample rate 16000, format 0x1, channel mask 0x10, flags 0
+01-13 01:50:11.277  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:11.277  2348 18402 E AudioRecord-JNI: Error creating AudioRecord instance: initialization check failed with status -22.
+01-13 01:50:11.277  2348 18402 E android.media.AudioRecord: Error code -20 when initializing native AudioRecord object.
+01-13 01:50:11.277  2348 18402 I MicrophoneInputStream: mic_started com.google.android.apps.gsa.staticplugins.aa.c@ca6f8f5
+01-13 01:50:11.278  2348 18402 E ActivityThread: Failed to find provider info for com.google.android.apps.gsa.testing.ui.audio.recorded
+01-13 01:50:11.278  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:50:11.284  2348  2348 I MicroDetectionWorker: onReady
+01-13 01:50:11.298  2348  2348 I MicroDetectionWorker: onReady
+01-13 01:50:11.309  2348 18402 I MicrophoneInputStream: mic_close com.google.android.apps.gsa.staticplugins.aa.c@ca6f8f5
+01-13 01:50:11.312  2348 17656 I MicroRecognitionRunner: Detection finished
+01-13 01:50:11.312  2348 17656 W ErrorReporter: reportError [type: 211, code: 524300]: Error reading from input stream
+01-13 01:50:11.313  2348  2813 I MicroRecognitionRunner: Stopping hotword detection.
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: onFatalError, processing error from engine(4)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: com.google.android.apps.gsa.shared.speech.b.g: Error reading from input stream
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at com.google.android.apps.gsa.staticplugins.recognizer.j.a.a(SourceFile:28)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at com.google.android.apps.gsa.staticplugins.recognizer.j.b.run(SourceFile:15)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:457)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:457)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.ag.run(Unknown Source:4)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.bo.run(SourceFile:4)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.bo.run(SourceFile:4)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at java.lang.Thread.run(Thread.java:764)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.ak.run(SourceFile:6)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: Caused by: com.google.android.apps.gsa.shared.exception.GsaIOException: Error code: 393238 | Buffer overflow, no available space.
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.Tee.f(SourceFile:103)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.au.read(SourceFile:2)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at java.io.InputStream.read(InputStream.java:101)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.ao.run(SourceFile:18)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.an.run(SourceFile:2)
+01-13 01:50:11.313  2348 17656 W ErrorProcessor: 	... 11 more
+01-13 01:50:11.313  2348 17656 I AudioController: internalShutdown
+01-13 01:50:11.316  2348  2348 I MicroDetector: Keeping mic open: false
+01-13 01:50:11.317  2348  2348 I MicroDetectionWorker: #onError(false)
+01-13 01:50:11.317  2348 18404 I DeviceStateChecker: DeviceStateChecker cancelled
+01-13 01:50:11.349  1666  7772 I GnssLocationProvider: WakeLock acquired by sendMessage(SET_REQUEST, 0, com.android.server.location.GnssLocationProvider$GpsRequest@6a6e09b)
+01-13 01:50:11.350  2116 17737 I Places  : ?: Couldn't find platform key file.
+01-13 01:50:11.351  1666  1685 I GnssLocationProvider: WakeLock released by handleMessage(SET_REQUEST, 0, com.android.server.location.GnssLocationProvider$GpsRequest@6a6e09b)
+01-13 01:50:11.366  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:11.414  2116  2116 I GeofencerStateMachine: removeGeofences: removeRequest=RemoveGeofencingRequest[REMOVE_BY_PENDING_INTENT pendingIntent=PendingIntent[creatorPackage=com.google.android.gms], packageName=com.google.android.gms]
+01-13 01:50:11.421  2116  2116 I GeofencerStateMachine: removeGeofences: removeRequest=RemoveGeofencingRequest[REMOVE_BY_PENDING_INTENT pendingIntent=PendingIntent[creatorPackage=com.google.android.gms], packageName=com.google.android.gms]
+01-13 01:50:11.430  2116 17737 I Places  : ?: Couldn't find platform key file.
+01-13 01:50:11.431  2116 18527 I PlaceInferenceEngine: [anon] Changed inference mode: 0
+01-13 01:50:11.433  2116 17737 I Places  : ?: Couldn't find platform key file.
+01-13 01:50:11.449  2116 18509 E ctxmgr  : [ProducerStatusImpl]updateStateForNewContextData: inactive, contextName=7 [CONTEXT service_id=47 ]
+01-13 01:50:11.459  2116 18509 I Places  : ?: Couldn't find platform key file.
+01-13 01:50:11.467  2116 17737 I Places  : ?: Couldn't find platform key file.
+01-13 01:50:11.477  2116 18527 I Places  : ?: PlacesBleScanner start() with priority 2
+01-13 01:50:11.478  2116 18527 I PlaceInferenceEngine: [anon] Changed inference mode: 1
+01-13 01:50:11.487  2116  2132 I zygote  : Waiting for a blocking GC ProfileSaver
+01-13 01:50:11.490  2116 18527 I Places  : Converted 0 out of 1 WiFi scans
+01-13 01:50:11.491  1666  7775 I WifiService: getConnectionInfo uid=10013
+01-13 01:50:11.492  2116  2116 E BeaconBle: Missing BluetoothAdapter
+01-13 01:50:11.492  2116  2116 I BeaconBle: BLE 'KK+' software access layer enabled
+01-13 01:50:11.502  2116 18509 I Places  : ?: Couldn't find platform key file.
+01-13 01:50:11.504  2116 18528 I Places  : ?: Couldn't find platform key file.
+01-13 01:50:11.506  2116 18527 I PlaceInferenceEngine: [anon] Changed inference mode: 1
+01-13 01:50:11.507  2116 18509 I Places  : ?: Couldn't find platform key file.
+01-13 01:50:11.521  2116 18509 I Places  : ?: Couldn't find platform key file.
+01-13 01:50:11.528  2116  2116 I BeaconBle: Client requested scan, settings=BleSettings [scanMode=ZERO_POWER, callbackType=ALL_MATCHES, reportDelayMillis=0, 1 filters, 0 clients, callingClientName=Places]
+01-13 01:50:11.529  2116  2116 I BeaconBle: Scan : No clients left, canceling alarm.
+01-13 01:50:11.529  2116  2116 E BeaconBle: Scan couldn't start for Places
+01-13 01:50:11.530  2116  2116 W Places  : BLE failure while scanning - code 5
+01-13 01:50:11.546  2116 18529 I PlaceInferenceEngine: No beacon scan available - ignoring candidates.
+01-13 01:50:11.546  2116 18509 I Places  : ?: Couldn't find platform key file.
+01-13 01:50:11.567  2116 18529 I Places  : ?: Couldn't find platform key file.
+01-13 01:50:11.578  2116  2128 I zygote  : Background concurrent copying GC freed 73274(3MB) AllocSpace objects, 40(2MB) LOS objects, 37% free, 10MB/16MB, paused 912us total 110.876ms
+01-13 01:50:11.579  2116  2132 I zygote  : WaitForGcToComplete blocked ProfileSaver on ProfileSaver for 91.900ms
+01-13 01:50:11.712  2374  2504 W OpenGLRenderer: Incorrectly called buildLayer on View: ShortcutAndWidgetContainer, destroying layer...
+01-13 01:50:12.027  2374  2504 W OpenGLRenderer: Incorrectly called buildLayer on View: Hotseat, destroying layer...
+01-13 01:50:12.028  2374  2504 W OpenGLRenderer: Incorrectly called buildLayer on View: PageIndicatorLineCaret, destroying layer...
+01-13 01:50:12.042  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:13.071  1666  7771 I GnssLocationProvider: WakeLock acquired by sendMessage(SET_REQUEST, 0, com.android.server.location.GnssLocationProvider$GpsRequest@5f17157)
+01-13 01:50:13.072  1666  1685 I GnssLocationProvider: WakeLock released by handleMessage(SET_REQUEST, 0, com.android.server.location.GnssLocationProvider$GpsRequest@5f17157)
+01-13 01:50:14.249  1433  1583 W audio_hw_generic: Not supplying enough data to HAL, expected position 26895992 , only wrote 26742960
+01-13 01:50:16.317  1666  7772 I ActivityManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=name.mlopatkin.shuttle/.NewMainActivity bnds=[426,675][559,838]} from uid 10023
+01-13 01:50:16.320  2348  2348 I MicroDetectionWorker: #updateMicroDetector [detectionMode: [mDetectionMode: [1]]]
+01-13 01:50:16.320  2348  2348 I MicroDetectionWorker: #startMicroDetector [speakerMode: 0]
+01-13 01:50:16.320  2348  2348 I AudioController: Using mInputStreamFactoryBuilder
+01-13 01:50:16.321  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 26743158 , only wrote 26742960
+01-13 01:50:16.327  2348  2348 I MicroDetectionWorker: onReady
+01-13 01:50:16.327  2348 18321 I MicroRecognitionRunner: Starting detection.
+01-13 01:50:16.328  2348 18402 I MicrophoneInputStream: mic_starting com.google.android.apps.gsa.staticplugins.aa.c@47b1e45
+01-13 01:50:16.330  1526  1581 W ServiceManager: Permission failure: android.permission.RECORD_AUDIO from uid=10032 pid=2348
+01-13 01:50:16.331  1526  1581 E         : Request requires android.permission.RECORD_AUDIO
+01-13 01:50:16.331  1526  1581 E         : android.permission.CAPTURE_AUDIO_HOTWORD
+01-13 01:50:16.331  2348 18402 E AudioRecord: Could not get audio input for session 15913, record source 1999, sample rate 16000, format 0x1, channel mask 0x10, flags 0
+01-13 01:50:16.334  2348 18402 E AudioRecord-JNI: Error creating AudioRecord instance: initialization check failed with status -22.
+01-13 01:50:16.334  2348 18402 E android.media.AudioRecord: Error code -20 when initializing native AudioRecord object.
+01-13 01:50:16.335  2348 18402 I MicrophoneInputStream: mic_started com.google.android.apps.gsa.staticplugins.aa.c@47b1e45
+01-13 01:50:16.339  2116  2618 W GCoreFlp: No location to return for getLastLocation()
+01-13 01:50:16.344  1666  7772 I ActivityManager: Start proc 18535:name.mlopatkin.shuttle/u0a85 for activity name.mlopatkin.shuttle/.NewMainActivity
+01-13 01:50:16.345 18535 18535 I zygote  : Not late-enabling -Xcheck:jni (already on)
+01-13 01:50:16.371  2348 18402 E ActivityThread: Failed to find provider info for com.google.android.apps.gsa.testing.ui.audio.recorded
+01-13 01:50:16.373 18535 18535 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+01-13 01:50:16.377  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3411968
+01-13 01:50:16.380  2348  2348 I MicroDetectionWorker: onReady
+01-13 01:50:16.384  1666  1740 D         : HostConnection::get() New Host Connection established 0xde47cac0, tid 1740
+01-13 01:50:16.395 18535 18542 E zygote  : Failed sending reply to debugger: Broken pipe
+01-13 01:50:16.396 18535 18542 I zygote  : Debugger is no longer active
+01-13 01:50:16.396  2348 18402 I MicrophoneInputStream: mic_close com.google.android.apps.gsa.staticplugins.aa.c@47b1e45
+01-13 01:50:16.397  2348 18321 I MicroRecognitionRunner: Detection finished
+01-13 01:50:16.397  2348 18321 W ErrorReporter: reportError [type: 211, code: 524300]: Error reading from input stream
+01-13 01:50:16.397  2348  2367 E ReloadingLock: Finalizing LOCKED Token[shortcuts 2020-01-13 01:50:11.294]
+01-13 01:50:16.397  2348  2813 I MicroRecognitionRunner: Stopping hotword detection.
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: onFatalError, processing error from engine(4)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: com.google.android.apps.gsa.shared.speech.b.g: Error reading from input stream
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.staticplugins.recognizer.j.a.a(SourceFile:28)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.staticplugins.recognizer.j.b.run(SourceFile:15)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:457)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:457)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.ag.run(Unknown Source:4)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.bo.run(SourceFile:4)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.bo.run(SourceFile:4)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at java.lang.Thread.run(Thread.java:764)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.ak.run(SourceFile:6)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: Caused by: com.google.android.apps.gsa.shared.exception.GsaIOException: Error code: 393238 | Buffer overflow, no available space.
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.Tee.f(SourceFile:103)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.au.read(SourceFile:2)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at java.io.InputStream.read(InputStream.java:101)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.ao.run(SourceFile:18)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.an.run(SourceFile:2)
+01-13 01:50:16.398  2348 18321 W ErrorProcessor: 	... 11 more
+01-13 01:50:16.398  2348 18321 I AudioController: internalShutdown
+01-13 01:50:16.413  2348  2348 I MicroDetector: Keeping mic open: false
+01-13 01:50:16.413  2348  2348 I MicroDetectionWorker: #onError(false)
+01-13 01:50:16.413  2348 18404 I DeviceStateChecker: DeviceStateChecker cancelled
+01-13 01:50:16.461 18535 18535 D ShuttleDatabase: Loading database...
+01-13 01:50:16.462 18535 18555 D ShuttleDatabase: Start loading
+01-13 01:50:16.482  2348  2728 D EGL_emulation: eglMakeCurrent: 0xe1085f00: ver 2 0 (tinfo 0xe1083ba0)
+01-13 01:50:16.486  1451  1628 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:16.486  1451  1628 D         : HostConnection::get() New Host Connection established 0xf1cf2fc0, tid 1628
+01-13 01:50:16.488  1451  1628 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:16.488  1451  1628 D         : HostConnection::get() New Host Connection established 0xf1cf2fc0, tid 1628
+01-13 01:50:16.489  1451  1628 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:16.489  1451  1628 D         : HostConnection::get() New Host Connection established 0xf1cf2fc0, tid 1628
+01-13 01:50:16.492  2374  2504 D EGL_emulation: eglMakeCurrent: 0xce51d940: ver 2 0 (tinfo 0xce534ae0)
+01-13 01:50:16.494  1451  1628 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:16.508  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:16.510  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:16.510  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:50:16.510  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:16.511  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:16.512  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:50:16.513  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:16.513  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:50:16.513  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:16.513  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:50:16.513  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:16.514  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:50:16.514  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:16.514  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:50:16.514  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:16.521  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:16.525  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:50:16.527  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:16.539 18535 18555 D ShuttleDatabase: Loading done 77
+01-13 01:50:16.540 18535 18557 D DownloadTask: Downloading the schedule
+01-13 01:50:16.542  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:16.547  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:16.549 18535 18557 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+01-13 01:50:16.551  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:16.568  1812  2065 I chatty  : uid=10029(com.android.systemui) RenderThread identical 2 lines
+01-13 01:50:16.579  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:16.580 18535 18535 I zygote  : Rejecting re-init on previously-failed class java.lang.Class<androidx.core.view.ViewCompat$2>: java.lang.NoClassDefFoundError: Failed resolution of: Landroid/view/View$OnUnhandledKeyEventListener;
+01-13 01:50:16.580 18535 18535 I zygote  :   at void androidx.core.view.ViewCompat.setOnApplyWindowInsetsListener(android.view.View, androidx.core.view.OnApplyWindowInsetsListener) (ViewCompat.java:2421)
+01-13 01:50:16.580 18535 18535 I zygote  :   at android.view.ViewGroup androidx.appcompat.app.AppCompatDelegateImpl.createSubDecor() (AppCompatDelegateImpl.java:779)
+01-13 01:50:16.580 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatDelegateImpl.ensureSubDecor() (AppCompatDelegateImpl.java:659)
+01-13 01:50:16.580 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatDelegateImpl.setContentView(int) (AppCompatDelegateImpl.java:552)
+01-13 01:50:16.580 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatActivity.setContentView(int) (AppCompatActivity.java:161)
+01-13 01:50:16.580 18535 18535 I zygote  :   at void name.mlopatkin.shuttle.NewMainActivity.onCreate(android.os.Bundle) (NewMainActivity.kt:54)
+01-13 01:50:16.580 18535 18535 I zygote  :   at void android.app.Activity.performCreate(android.os.Bundle, android.os.PersistableBundle) (Activity.java:7009)
+01-13 01:50:16.580 18535 18535 I zygote  :   at void android.app.Activity.performCreate(android.os.Bundle) (Activity.java:7000)
+01-13 01:50:16.580 18535 18535 I zygote  :   at void android.app.Instrumentation.callActivityOnCreate(android.app.Activity, android.os.Bundle) (Instrumentation.java:1214)
+01-13 01:50:16.580 18535 18535 I zygote  :   at android.app.Activity android.app.ActivityThread.performLaunchActivity(android.app.ActivityThread$ActivityClientRecord, android.content.Intent) (ActivityThread.java:2731)
+01-13 01:50:16.580 18535 18535 I zygote  :   at void android.app.ActivityThread.handleLaunchActivity(android.app.ActivityThread$ActivityClientRecord, android.content.Intent, java.lang.String) (ActivityThread.java:2856)
+01-13 01:50:16.580 18535 18535 I zygote  :   at void android.app.ActivityThread.-wrap11(android.app.ActivityThread, android.app.ActivityThread$ActivityClientRecord, android.content.Intent, java.lang.String) (ActivityThread.java:-1)
+01-13 01:50:16.580 18535 18535 I zygote  :   at void android.app.ActivityThread$H.handleMessage(android.os.Message) (ActivityThread.java:1589)
+01-13 01:50:16.580 18535 18535 I zygote  :   at void android.os.Handler.dispatchMessage(android.os.Message) (Handler.java:106)
+01-13 01:50:16.580 18535 18535 I zygote  :   at void android.os.Looper.loop() (Looper.java:164)
+01-13 01:50:16.580 18535 18535 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+01-13 01:50:16.580 18535 18535 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+01-13 01:50:16.580 18535 18535 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+01-13 01:50:16.580 18535 18535 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+01-13 01:50:16.580 18535 18535 I zygote  : Caused by: java.lang.ClassNotFoundException: Didn't find class "android.view.View$OnUnhandledKeyEventListener" on path: DexPathList[[zip file "/data/app/name.mlopatkin.shuttle-6LB2lDENE5ElB3XVTldtIQ==/base.apk"],nativeLibraryDirectories=[/data/app/name.mlopatkin.shuttle-6LB2lDENE5ElB3XVTldtIQ==/lib/x86, /system/lib, /vendor/lib]]
+01-13 01:50:16.580 18535 18535 I zygote  :   at java.lang.Class dalvik.system.BaseDexClassLoader.findClass(java.lang.String) (BaseDexClassLoader.java:125)
+01-13 01:50:16.580 18535 18535 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String, boolean) (ClassLoader.java:379)
+01-13 01:50:16.581 18535 18535 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String) (ClassLoader.java:312)
+01-13 01:50:16.581 18535 18535 I zygote  :   at void androidx.core.view.ViewCompat.setOnApplyWindowInsetsListener(android.view.View, androidx.core.view.OnApplyWindowInsetsListener) (ViewCompat.java:2421)
+01-13 01:50:16.581 18535 18535 I zygote  :   at android.view.ViewGroup androidx.appcompat.app.AppCompatDelegateImpl.createSubDecor() (AppCompatDelegateImpl.java:779)
+01-13 01:50:16.581 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatDelegateImpl.ensureSubDecor() (AppCompatDelegateImpl.java:659)
+01-13 01:50:16.581 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatDelegateImpl.setContentView(int) (AppCompatDelegateImpl.java:552)
+01-13 01:50:16.581 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatActivity.setContentView(int) (AppCompatActivity.java:161)
+01-13 01:50:16.581 18535 18535 I zygote  :   at void name.mlopatkin.shuttle.NewMainActivity.onCreate(android.os.Bundle) (NewMainActivity.kt:54)
+01-13 01:50:16.581 18535 18535 I zygote  :   at void android.app.Activity.performCreate(android.os.Bundle, android.os.PersistableBundle) (Activity.java:7009)
+01-13 01:50:16.581 18535 18535 I zygote  :   at void android.app.Activity.performCreate(android.os.Bundle) (Activity.java:7000)
+01-13 01:50:16.581 18535 18535 I zygote  :   at void android.app.Instrumentation.callActivityOnCreate(android.app.Activity, android.os.Bundle) (Instrumentation.java:1214)
+01-13 01:50:16.581 18535 18535 I zygote  :   at android.app.Activity android.app.ActivityThread.performLaunchActivity(android.app.ActivityThread$ActivityClientRecord, android.content.Intent) (ActivityThread.java:2731)
+01-13 01:50:16.581 18535 18535 I zygote  :   at void android.app.ActivityThread.handleLaunchActivity(android.app.ActivityThread$ActivityClientRecord, android.content.Intent, java.lang.String) (ActivityThread.java:2856)
+01-13 01:50:16.581 18535 18535 I zygote  :   at void android.app.ActivityThread.-wrap11(android.app.ActivityThread, android.app.ActivityThread$ActivityClientRecord, android.content.Intent, java.lang.String) (ActivityThread.java:-1)
+01-13 01:50:16.581 18535 18535 I zygote  :   at void android.app.ActivityThread$H.handleMessage(android.os.Message) (ActivityThread.java:1589)
+01-13 01:50:16.581 18535 18535 I zygote  :   at void android.os.Handler.dispatchMessage(android.os.Message) (Handler.java:106)
+01-13 01:50:16.581 18535 18535 I zygote  :   at void android.os.Looper.loop() (Looper.java:164)
+01-13 01:50:16.581 18535 18535 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+01-13 01:50:16.581 18535 18535 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+01-13 01:50:16.581 18535 18535 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+01-13 01:50:16.581 18535 18535 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+01-13 01:50:16.581 18535 18535 I zygote  : 
+01-13 01:50:16.582 18535 18535 I zygote  : Rejecting re-init on previously-failed class java.lang.Class<androidx.core.view.ViewCompat$2>: java.lang.NoClassDefFoundError: Failed resolution of: Landroid/view/View$OnUnhandledKeyEventListener;
+01-13 01:50:16.582 18535 18535 I zygote  :   at void androidx.core.view.ViewCompat.setOnApplyWindowInsetsListener(android.view.View, androidx.core.view.OnApplyWindowInsetsListener) (ViewCompat.java:2421)
+01-13 01:50:16.582 18535 18535 I zygote  :   at android.view.ViewGroup androidx.appcompat.app.AppCompatDelegateImpl.createSubDecor() (AppCompatDelegateImpl.java:779)
+01-13 01:50:16.582 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatDelegateImpl.ensureSubDecor() (AppCompatDelegateImpl.java:659)
+01-13 01:50:16.582 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatDelegateImpl.setContentView(int) (AppCompatDelegateImpl.java:552)
+01-13 01:50:16.582 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatActivity.setContentView(int) (AppCompatActivity.java:161)
+01-13 01:50:16.582 18535 18535 I zygote  :   at void name.mlopatkin.shuttle.NewMainActivity.onCreate(android.os.Bundle) (NewMainActivity.kt:54)
+01-13 01:50:16.582 18535 18535 I zygote  :   at void android.app.Activity.performCreate(android.os.Bundle, android.os.PersistableBundle) (Activity.java:7009)
+01-13 01:50:16.582 18535 18535 I zygote  :   at void android.app.Activity.performCreate(android.os.Bundle) (Activity.java:7000)
+01-13 01:50:16.582 18535 18535 I zygote  :   at void android.app.Instrumentation.callActivityOnCreate(android.app.Activity, android.os.Bundle) (Instrumentation.java:1214)
+01-13 01:50:16.582 18535 18535 I zygote  :   at android.app.Activity android.app.ActivityThread.performLaunchActivity(android.app.ActivityThread$ActivityClientRecord, android.content.Intent) (ActivityThread.java:2731)
+01-13 01:50:16.582 18535 18535 I zygote  :   at void android.app.ActivityThread.handleLaunchActivity(android.app.ActivityThread$ActivityClientRecord, android.content.Intent, java.lang.String) (ActivityThread.java:2856)
+01-13 01:50:16.583 18535 18535 I zygote  :   at void android.app.ActivityThread.-wrap11(android.app.ActivityThread, android.app.ActivityThread$ActivityClientRecord, android.content.Intent, java.lang.String) (ActivityThread.java:-1)
+01-13 01:50:16.583 18535 18535 I zygote  :   at void android.app.ActivityThread$H.handleMessage(android.os.Message) (ActivityThread.java:1589)
+01-13 01:50:16.583 18535 18535 I zygote  :   at void android.os.Handler.dispatchMessage(android.os.Message) (Handler.java:106)
+01-13 01:50:16.583 18535 18535 I zygote  :   at void android.os.Looper.loop() (Looper.java:164)
+01-13 01:50:16.583 18535 18535 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+01-13 01:50:16.583 18535 18535 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+01-13 01:50:16.583 18535 18535 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+01-13 01:50:16.583 18535 18535 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+01-13 01:50:16.583 18535 18535 I zygote  : Caused by: java.lang.ClassNotFoundException: Didn't find class "android.view.View$OnUnhandledKeyEventListener" on path: DexPathList[[zip file "/data/app/name.mlopatkin.shuttle-6LB2lDENE5ElB3XVTldtIQ==/base.apk"],nativeLibraryDirectories=[/data/app/name.mlopatkin.shuttle-6LB2lDENE5ElB3XVTldtIQ==/lib/x86, /system/lib, /vendor/lib]]
+01-13 01:50:16.583 18535 18535 I zygote  :   at java.lang.Class dalvik.system.BaseDexClassLoader.findClass(java.lang.String) (BaseDexClassLoader.java:125)
+01-13 01:50:16.583 18535 18535 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String, boolean) (ClassLoader.java:379)
+01-13 01:50:16.584  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:16.583 18535 18535 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String) (ClassLoader.java:312)
+01-13 01:50:16.584 18535 18535 I zygote  :   at void androidx.core.view.ViewCompat.setOnApplyWindowInsetsListener(android.view.View, androidx.core.view.OnApplyWindowInsetsListener) (ViewCompat.java:2421)
+01-13 01:50:16.584 18535 18535 I zygote  :   at android.view.ViewGroup androidx.appcompat.app.AppCompatDelegateImpl.createSubDecor() (AppCompatDelegateImpl.java:779)
+01-13 01:50:16.584 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatDelegateImpl.ensureSubDecor() (AppCompatDelegateImpl.java:659)
+01-13 01:50:16.584 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatDelegateImpl.setContentView(int) (AppCompatDelegateImpl.java:552)
+01-13 01:50:16.584 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatActivity.setContentView(int) (AppCompatActivity.java:161)
+01-13 01:50:16.584 18535 18535 I zygote  :   at void name.mlopatkin.shuttle.NewMainActivity.onCreate(android.os.Bundle) (NewMainActivity.kt:54)
+01-13 01:50:16.584 18535 18535 I zygote  :   at void android.app.Activity.performCreate(android.os.Bundle, android.os.PersistableBundle) (Activity.java:7009)
+01-13 01:50:16.584 18535 18535 I zygote  :   at void android.app.Activity.performCreate(android.os.Bundle) (Activity.java:7000)
+01-13 01:50:16.584 18535 18535 I zygote  :   at void android.app.Instrumentation.callActivityOnCreate(android.app.Activity, android.os.Bundle) (Instrumentation.java:1214)
+01-13 01:50:16.584 18535 18535 I zygote  :   at android.app.Activity android.app.ActivityThread.performLaunchActivity(android.app.ActivityThread$ActivityClientRecord, android.content.Intent) (ActivityThread.java:2731)
+01-13 01:50:16.584 18535 18535 I zygote  :   at void android.app.ActivityThread.handleLaunchActivity(android.app.ActivityThread$ActivityClientRecord, android.content.Intent, java.lang.String) (ActivityThread.java:2856)
+01-13 01:50:16.585 18535 18535 I zygote  :   at void android.app.ActivityThread.-wrap11(android.app.ActivityThread, android.app.ActivityThread$ActivityClientRecord, android.content.Intent, java.lang.String) (ActivityThread.java:-1)
+01-13 01:50:16.585 18535 18535 I zygote  :   at void android.app.ActivityThread$H.handleMessage(android.os.Message) (ActivityThread.java:1589)
+01-13 01:50:16.585 18535 18535 I zygote  :   at void android.os.Handler.dispatchMessage(android.os.Message) (Handler.java:106)
+01-13 01:50:16.585 18535 18535 I zygote  :   at void android.os.Looper.loop() (Looper.java:164)
+01-13 01:50:16.585 18535 18535 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+01-13 01:50:16.585 18535 18535 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+01-13 01:50:16.585 18535 18535 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+01-13 01:50:16.585 18535 18535 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+01-13 01:50:16.585 18535 18535 I zygote  : 
+01-13 01:50:16.585 18535 18535 I zygote  : Rejecting re-init on previously-failed class java.lang.Class<androidx.core.view.ViewCompat$2>: java.lang.NoClassDefFoundError: Failed resolution of: Landroid/view/View$OnUnhandledKeyEventListener;
+01-13 01:50:16.586 18535 18535 I zygote  :   at void androidx.core.view.ViewCompat.setOnApplyWindowInsetsListener(android.view.View, androidx.core.view.OnApplyWindowInsetsListener) (ViewCompat.java:2421)
+01-13 01:50:16.586 18535 18535 I zygote  :   at android.view.ViewGroup androidx.appcompat.app.AppCompatDelegateImpl.createSubDecor() (AppCompatDelegateImpl.java:779)
+01-13 01:50:16.586 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatDelegateImpl.ensureSubDecor() (AppCompatDelegateImpl.java:659)
+01-13 01:50:16.586 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatDelegateImpl.setContentView(int) (AppCompatDelegateImpl.java:552)
+01-13 01:50:16.586 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatActivity.setContentView(int) (AppCompatActivity.java:161)
+01-13 01:50:16.586 18535 18535 I zygote  :   at void name.mlopatkin.shuttle.NewMainActivity.onCreate(android.os.Bundle) (NewMainActivity.kt:54)
+01-13 01:50:16.586 18535 18535 I zygote  :   at void android.app.Activity.performCreate(android.os.Bundle, android.os.PersistableBundle) (Activity.java:7009)
+01-13 01:50:16.586 18535 18535 I zygote  :   at void android.app.Activity.performCreate(android.os.Bundle) (Activity.java:7000)
+01-13 01:50:16.586 18535 18535 I zygote  :   at void android.app.Instrumentation.callActivityOnCreate(android.app.Activity, android.os.Bundle) (Instrumentation.java:1214)
+01-13 01:50:16.586 18535 18535 I zygote  :   at android.app.Activity android.app.ActivityThread.performLaunchActivity(android.app.ActivityThread$ActivityClientRecord, android.content.Intent) (ActivityThread.java:2731)
+01-13 01:50:16.586 18535 18535 I zygote  :   at void android.app.ActivityThread.handleLaunchActivity(android.app.ActivityThread$ActivityClientRecord, android.content.Intent, java.lang.String) (ActivityThread.java:2856)
+01-13 01:50:16.586 18535 18535 I zygote  :   at void android.app.ActivityThread.-wrap11(android.app.ActivityThread, android.app.ActivityThread$ActivityClientRecord, android.content.Intent, java.lang.String) (ActivityThread.java:-1)
+01-13 01:50:16.587 18535 18535 I zygote  :   at void android.app.ActivityThread$H.handleMessage(android.os.Message) (ActivityThread.java:1589)
+01-13 01:50:16.587 18535 18535 I zygote  :   at void android.os.Handler.dispatchMessage(android.os.Message) (Handler.java:106)
+01-13 01:50:16.587 18535 18535 I zygote  :   at void android.os.Looper.loop() (Looper.java:164)
+01-13 01:50:16.587 18535 18535 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+01-13 01:50:16.587 18535 18535 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+01-13 01:50:16.587 18535 18535 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+01-13 01:50:16.587 18535 18535 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+01-13 01:50:16.587 18535 18535 I zygote  : Caused by: java.lang.ClassNotFoundException: Didn't find class "android.view.View$OnUnhandledKeyEventListener" on path: DexPathList[[zip file "/data/app/name.mlopatkin.shuttle-6LB2lDENE5ElB3XVTldtIQ==/base.apk"],nativeLibraryDirectories=[/data/app/name.mlopatkin.shuttle-6LB2lDENE5ElB3XVTldtIQ==/lib/x86, /system/lib, /vendor/lib]]
+01-13 01:50:16.587 18535 18535 I zygote  :   at java.lang.Class dalvik.system.BaseDexClassLoader.findClass(java.lang.String) (BaseDexClassLoader.java:125)
+01-13 01:50:16.587 18535 18535 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String, boolean) (ClassLoader.java:379)
+01-13 01:50:16.587 18535 18535 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String) (ClassLoader.java:312)
+01-13 01:50:16.587 18535 18535 I zygote  :   at void androidx.core.view.ViewCompat.setOnApplyWindowInsetsListener(android.view.View, androidx.core.view.OnApplyWindowInsetsListener) (ViewCompat.java:2421)
+01-13 01:50:16.588 18535 18535 I zygote  :   at android.view.ViewGroup androidx.appcompat.app.AppCompatDelegateImpl.createSubDecor() (AppCompatDelegateImpl.java:779)
+01-13 01:50:16.588 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatDelegateImpl.ensureSubDecor() (AppCompatDelegateImpl.java:659)
+01-13 01:50:16.588 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatDelegateImpl.setContentView(int) (AppCompatDelegateImpl.java:552)
+01-13 01:50:16.588 18535 18535 I zygote  :   at void androidx.appcompat.app.AppCompatActivity.setContentView(int) (AppCompatActivity.java:161)
+01-13 01:50:16.588 18535 18535 I zygote  :   at void name.mlopatkin.shuttle.NewMainActivity.onCreate(android.os.Bundle) (NewMainActivity.kt:54)
+01-13 01:50:16.588 18535 18535 I zygote  :   at void android.app.Activity.performCreate(android.os.Bundle, android.os.PersistableBundle) (Activity.java:7009)
+01-13 01:50:16.588 18535 18535 I zygote  :   at void android.app.Activity.performCreate(android.os.Bundle) (Activity.java:7000)
+01-13 01:50:16.588 18535 18535 I zygote  :   at void android.app.Instrumentation.callActivityOnCreate(android.app.Activity, android.os.Bundle) (Instrumentation.java:1214)
+01-13 01:50:16.588 18535 18535 I zygote  :   at android.app.Activity android.app.ActivityThread.performLaunchActivity(android.app.ActivityThread$ActivityClientRecord, android.content.Intent) (ActivityThread.java:2731)
+01-13 01:50:16.588 18535 18535 I zygote  :   at void android.app.ActivityThread.handleLaunchActivity(android.app.ActivityThread$ActivityClientRecord, android.content.Intent, java.lang.String) (ActivityThread.java:2856)
+01-13 01:50:16.588 18535 18535 I zygote  :   at void android.app.ActivityThread.-wrap11(android.app.ActivityThread, android.app.ActivityThread$ActivityClientRecord, android.content.Intent, java.lang.String) (ActivityThread.java:-1)
+01-13 01:50:16.589 18535 18535 I zygote  :   at void android.app.ActivityThread$H.handleMessage(android.os.Message) (ActivityThread.java:1589)
+01-13 01:50:16.589 18535 18535 I zygote  :   at void android.os.Handler.dispatchMessage(android.os.Message) (Handler.java:106)
+01-13 01:50:16.591 18535 18535 I zygote  :   at void android.os.Looper.loop() (Looper.java:164)
+01-13 01:50:16.591 18535 18535 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+01-13 01:50:16.591 18535 18535 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+01-13 01:50:16.591 18535 18535 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+01-13 01:50:16.591 18535 18535 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+01-13 01:50:16.591 18535 18535 I zygote  : 
+01-13 01:50:16.596  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:16.704  1812  2065 I chatty  : uid=10029(com.android.systemui) RenderThread identical 12 lines
+01-13 01:50:16.714  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:16.893 18535 18557 E DownloadTask: Failure during loading a schedule from net
+01-13 01:50:16.893 18535 18557 E DownloadTask: javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.org.conscrypt.ConscryptFileDescriptorSocket.startHandshake(ConscryptFileDescriptorSocket.java:219)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.okhttp.internal.io.RealConnection.connectTls(RealConnection.java:192)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.okhttp.internal.io.RealConnection.connectSocket(RealConnection.java:149)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.okhttp.internal.io.RealConnection.connect(RealConnection.java:112)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.okhttp.internal.http.StreamAllocation.findConnection(StreamAllocation.java:184)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.okhttp.internal.http.StreamAllocation.findHealthyConnection(StreamAllocation.java:126)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.okhttp.internal.http.StreamAllocation.newStream(StreamAllocation.java:95)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:281)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:224)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:461)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:407)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getInputStream(HttpURLConnectionImpl.java:244)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getInputStream(DelegatingHttpsURLConnection.java:210)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getInputStream(Unknown Source:0)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at name.mlopatkin.shuttle.net.DownloadTask.doInBackground(DownloadTask.java:60)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at name.mlopatkin.shuttle.net.DownloadTask.doInBackground(DownloadTask.java:36)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at android.os.AsyncTask$2.call(AsyncTask.java:333)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at java.lang.Thread.run(Thread.java:764)
+01-13 01:50:16.893 18535 18557 E DownloadTask: Caused by: java.security.cert.CertificateException: Chain validation failed
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:707)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:539)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:560)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:605)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:495)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:418)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.org.conscrypt.TrustManagerImpl.getTrustedChainForServer(TrustManagerImpl.java:339)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at android.security.net.config.NetworkSecurityTrustManager.checkServerTrusted(NetworkSecurityTrustManager.java:94)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at android.security.net.config.RootTrustManager.checkServerTrusted(RootTrustManager.java:88)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.org.conscrypt.Platform.checkServerTrusted(Platform.java:197)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.org.conscrypt.ConscryptFileDescriptorSocket.verifyCertificateChain(ConscryptFileDescriptorSocket.java:399)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.org.conscrypt.SslWrapper.doHandshake(SslWrapper.java:374)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at com.android.org.conscrypt.ConscryptFileDescriptorSocket.startHandshake(ConscryptFileDescriptorSocket.java:217)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	... 20 more
+01-13 01:50:16.893 18535 18557 E DownloadTask: Caused by: java.security.cert.CertPathValidatorException: Response is unreliable: its validity interval is out-of-date
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:133)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:222)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:140)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at sun.security.provider.certpath.PKIXCertPathValidator.engineValidate(PKIXCertPathValidator.java:79)
+01-13 01:50:16.893 18535 18557 E DownloadTask: 	at java.security.cert.CertPathValidator.validate(CertPathValidator.java:301)
+01-13 01:50:16.895 18535 18557 E DownloadTask: 	at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:703)
+01-13 01:50:16.895 18535 18557 E DownloadTask: 	... 33 more
+01-13 01:50:16.895 18535 18557 E DownloadTask: Caused by: java.security.cert.CertPathValidatorException: Response is unreliable: its validity interval is out-of-date
+01-13 01:50:16.895 18535 18557 E DownloadTask: 	at sun.security.provider.certpath.OCSPResponse.verify(OCSPResponse.java:619)
+01-13 01:50:16.895 18535 18557 E DownloadTask: 	at sun.security.provider.certpath.RevocationChecker.checkOCSP(RevocationChecker.java:709)
+01-13 01:50:16.895 18535 18557 E DownloadTask: 	at sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:363)
+01-13 01:50:16.895 18535 18557 E DownloadTask: 	at sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:337)
+01-13 01:50:16.895 18535 18557 E DownloadTask: 	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:125)
+01-13 01:50:16.895 18535 18557 E DownloadTask: 	... 38 more
+01-13 01:50:16.895 18535 18557 E DownloadTask: 	Suppressed: java.security.cert.CertPathValidatorException: Could not determine revocation status
+01-13 01:50:16.895 18535 18557 E DownloadTask: 		at sun.security.provider.certpath.RevocationChecker.buildToNewKey(RevocationChecker.java:1092)
+01-13 01:50:16.895 18535 18557 E DownloadTask: 		at sun.security.provider.certpath.RevocationChecker.verifyWithSeparateSigningKey(RevocationChecker.java:910)
+01-13 01:50:16.895 18535 18557 E DownloadTask: 		at sun.security.provider.certpath.RevocationChecker.checkCRLs(RevocationChecker.java:577)
+01-13 01:50:16.895 18535 18557 E DownloadTask: 		at sun.security.provider.certpath.RevocationChecker.checkCRLs(RevocationChecker.java:465)
+01-13 01:50:16.895 18535 18557 E DownloadTask: 		at sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:394)
+01-13 01:50:16.895 18535 18557 E DownloadTask: 		... 40 more
+01-13 01:50:16.926 18554 18554 D AndroidRuntime: >>>>>> START com.android.internal.os.RuntimeInit uid 2000 <<<<<<
+01-13 01:50:17.022 18554 18554 W app_process: Unexpected CPU variant for X86 using defaults: x86
+01-13 01:50:17.023 18554 18554 I app_process: The ClassLoaderContext is a special shared library.
+01-13 01:50:17.066 18554 18554 D AndroidRuntime: Calling main entry com.android.commands.pm.Pm
+01-13 01:50:17.079 18554 18567 W MessageQueue: Handler (android.os.Handler) {d9047ff} sending message to a Handler on a dead thread
+01-13 01:50:17.079 18554 18567 W MessageQueue: java.lang.IllegalStateException: Handler (android.os.Handler) {d9047ff} sending message to a Handler on a dead thread
+01-13 01:50:17.079 18554 18567 W MessageQueue: 	at android.os.MessageQueue.enqueueMessage(MessageQueue.java:545)
+01-13 01:50:17.079 18554 18567 W MessageQueue: 	at android.os.Handler.enqueueMessage(Handler.java:662)
+01-13 01:50:17.079 18554 18567 W MessageQueue: 	at android.os.Handler.sendMessageAtTime(Handler.java:631)
+01-13 01:50:17.079 18554 18567 W MessageQueue: 	at android.os.Handler.sendMessageDelayed(Handler.java:601)
+01-13 01:50:17.079 18554 18567 W MessageQueue: 	at android.os.Handler.post(Handler.java:357)
+01-13 01:50:17.079 18554 18567 W MessageQueue: 	at android.os.ResultReceiver$MyResultReceiver.send(ResultReceiver.java:57)
+01-13 01:50:17.079 18554 18567 W MessageQueue: 	at com.android.internal.os.IResultReceiver$Stub.onTransact(IResultReceiver.java:58)
+01-13 01:50:17.079 18554 18567 W MessageQueue: 	at android.os.Binder.execTransact(Binder.java:697)
+01-13 01:50:17.080 18554 18554 I app_process: System.exit called, status: 0
+01-13 01:50:17.080 18554 18554 I AndroidRuntime: VM exiting with result code 0.
+01-13 01:50:17.566 18570 18570 D AndroidRuntime: >>>>>> START com.android.internal.os.RuntimeInit uid 2000 <<<<<<
+01-13 01:50:17.667 18570 18570 W app_process: Unexpected CPU variant for X86 using defaults: x86
+01-13 01:50:17.670 18570 18570 I app_process: The ClassLoaderContext is a special shared library.
+01-13 01:50:17.713 18570 18570 D AndroidRuntime: Calling main entry com.android.commands.pm.Pm
+01-13 01:50:17.720 18570 18578 W MessageQueue: Handler (android.os.Handler) {32e268} sending message to a Handler on a dead thread
+01-13 01:50:17.720 18570 18578 W MessageQueue: java.lang.IllegalStateException: Handler (android.os.Handler) {32e268} sending message to a Handler on a dead thread
+01-13 01:50:17.720 18570 18578 W MessageQueue: 	at android.os.MessageQueue.enqueueMessage(MessageQueue.java:545)
+01-13 01:50:17.720 18570 18578 W MessageQueue: 	at android.os.Handler.enqueueMessage(Handler.java:662)
+01-13 01:50:17.720 18570 18578 W MessageQueue: 	at android.os.Handler.sendMessageAtTime(Handler.java:631)
+01-13 01:50:17.720 18570 18578 W MessageQueue: 	at android.os.Handler.sendMessageDelayed(Handler.java:601)
+01-13 01:50:17.720 18570 18578 W MessageQueue: 	at android.os.Handler.post(Handler.java:357)
+01-13 01:50:17.720 18570 18578 W MessageQueue: 	at android.os.ResultReceiver$MyResultReceiver.send(ResultReceiver.java:57)
+01-13 01:50:17.720 18570 18578 W MessageQueue: 	at com.android.internal.os.IResultReceiver$Stub.onTransact(IResultReceiver.java:58)
+01-13 01:50:17.720 18570 18578 W MessageQueue: 	at android.os.Binder.execTransact(Binder.java:697)
+01-13 01:50:17.720 18570 18570 I app_process: System.exit called, status: 0
+01-13 01:50:17.720 18570 18570 I AndroidRuntime: VM exiting with result code 0.
+01-13 01:50:19.532  1433  1583 W audio_hw_generic: Not supplying enough data to HAL, expected position 27049233 , only wrote 26897040
+01-13 01:50:21.088  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:50:21.089  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:50:24.696  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 01:50:25.486  1449  1449 I boot-pipe: done populating /dev/random
+01-13 01:50:26.325  1666  1686 W ActivityManager: Launch timeout has expired, giving up wake lock!
+01-13 01:50:26.412  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:50:26.412  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:50:35.138  1666  1674 D         : HostConnection::get() New Host Connection established 0xde47c040, tid 1674
+01-13 01:50:35.138  1666  1674 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:35.139  1666  1674 D         : HostConnection::get() New Host Connection established 0xde47c040, tid 1674
+01-13 01:50:35.139  1666  1674 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:35.140  1666  1674 D         : HostConnection::get() New Host Connection established 0xde47c040, tid 1674
+01-13 01:50:35.141  1666  1674 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:35.141  1666  1674 D         : HostConnection::get() New Host Connection established 0xde47c040, tid 1674
+01-13 01:50:35.141  1666  1674 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:35.142  1666  1674 D         : HostConnection::get() New Host Connection established 0xde47c9c0, tid 1674
+01-13 01:50:35.142  1666  1674 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:35.143  1666  1674 D         : HostConnection::get() New Host Connection established 0xde47c9c0, tid 1674
+01-13 01:50:35.143  1666  1674 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:50:36.924  2116 13352 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 01:50:36.924  2116 13352 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 01:50:36.926  1666  1775 D ConnectivityService: reportNetworkConnectivity(101, false) by 10013
+01-13 01:50:36.926  1666  2854 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: Forcing reevaluation for UID 10013
+01-13 01:50:36.982  1666 18585 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS connectivitycheck.gstatic.com 54ms OK 64.233.163.94,2a00:1450:4010:c08::5e
+01-13 01:50:36.986  1666 18584 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS www.google.com 57ms OK 64.233.164.103,2a00:1450:4010:c09::69
+01-13 01:50:37.027  1666 18585 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=45ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:12:01 GMT], X-Android-Received-Millis=[1578869437027], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869437005]}
+01-13 01:50:37.062  1666 18584 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:50:37.115  1666  2854 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_FALLBACK http://www.google.com/gen_204 time=49ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Content-Type=[text/html; charset=UTF-8], Date=[Fri, 28 Feb 2020 19:12:01 GMT], Server=[gws], Set-Cookie=[1P_JAR=2020-02-28-19; expires=Sun, 29-Mar-2020 19:12:01 GMT; path=/; domain=.google.com; Secure], X-Android-Received-Millis=[1578869437115], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869437089], X-Frame-Options=[SAMEORIGIN], X-XSS-Protection=[0]}
+01-13 01:50:37.116  1666  1775 D ConnectivityService: NetworkAgentInfo [WIFI () - 101] validation failed
+01-13 01:50:37.118  1666  1775 D ConnectivityService: Switching to new default network: NetworkAgentInfo{ ni{[type: MOBILE[LTE], state: CONNECTED/CONNECTED, reason: connected, extra: epc.tmobile.com, failover: false, available: true, roaming: false]}  network{100}  nethandle{429513165534}  lp{{InterfaceName: radio0 LinkAddresses: [192.168.200.2/24,]  Routes: [0.0.0.0/0 -> 192.168.200.1 radio0,192.168.200.0/24 -> 0.0.0.0 radio0,] DnsAddresses: [10.0.2.3,] Domains: null MTU: 1500 TcpBufferSizes: 524288,1048576,2097152,262144,524288,1048576}}  nc{[ Transports: CELLULAR Capabilities: MMS&SUPL&DUN&FOTA&IMS&CBS&IA&INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN&VALIDATED LinkUpBandwidth>=51200Kbps LinkDnBandwidth>=102400Kbps Specifier: <1>]}  Score{50}  everValidated{true}  lastValidated{true}  created{true} lingering{false} explicitlySelected{false} acceptUnvalidated{false} everCaptivePortalDetected{false} lastCaptivePortalDetected{false} clat{null} }
+01-13 01:50:37.127  1666  1873 D NetworkTimeUpdateService: New default network 100; checking time.
+01-13 01:50:37.128  1666  1775 D ConnectivityService: Sending DISCONNECTED broadcast for type 1 NetworkAgentInfo [WIFI () - 101] isDefaultNetwork=true
+01-13 01:50:37.133  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:50:37.133  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:50:37.144  1812  2022 I zygote  : Deoptimizing void com.android.systemui.statusbar.policy.SignalController.notifyListenersIfNecessary() due to JIT inline cache
+01-13 01:50:37.144  1666  1775 D ConnectivityService: Sending CONNECTED broadcast for type 0 NetworkAgentInfo [MOBILE (LTE) - 100] isDefaultNetwork=true
+01-13 01:50:37.150  1666  1771 D WifiStateMachine: NETWORK_STATUS_UNWANTED_VALIDATION_FAILED
+01-13 01:50:37.151  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:50:37.151  1666  1775 D ConnectivityService: handleNetworkUnvalidated NetworkAgentInfo [WIFI () - 101] cap=[ Transports: WIFI Capabilities: NOT_METERED&INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN&FOREGROUND LinkUpBandwidth>=1048576Kbps LinkDnBandwidth>=1048576Kbps SignalStrength: -50]
+01-13 01:50:37.164  1666  1768 I WifiService: getConnectionInfo uid=1000
+01-13 01:50:37.168  1666  1768 D RecurrenceRule: Resolving using anchor 2020-01-13T01:50:37.168+03:00[Europe/Moscow]
+01-13 01:50:37.171  1666  1768 D RecurrenceRule: Resolving using anchor 2020-01-13T01:50:37.170+03:00[Europe/Moscow]
+01-13 01:50:37.172  1666  1768 D RecurrenceRule: Cycle 12 from 2020-01-13T00:00+03:00[Europe/Moscow] to 2020-02-13T00:00+03:00[Europe/Moscow]
+01-13 01:50:37.173  1666  1768 D NetworkStats: Resolving plan for NetworkTemplate: matchRule=MOBILE_ALL, subscriberId=310260..., matchSubscriberIds=[310260...]
+01-13 01:50:37.178  1666  1768 D NetworkStats: Found active matching subId 1
+01-13 01:50:37.188  1666  1768 D NetworkStats: Resolved to plan null
+01-13 01:50:37.193  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:50:37.193  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:50:37.204  1666  1768 I WifiService: getConnectionInfo uid=1000
+01-13 01:50:37.208  1666  1768 D RecurrenceRule: Resolving using anchor 2020-01-13T01:50:37.208+03:00[Europe/Moscow]
+01-13 01:50:37.210  1666  1768 D RecurrenceRule: Resolving using anchor 2020-01-13T01:50:37.210+03:00[Europe/Moscow]
+01-13 01:50:37.212  1666  1768 D RecurrenceRule: Cycle 12 from 2020-01-13T00:00+03:00[Europe/Moscow] to 2020-02-13T00:00+03:00[Europe/Moscow]
+01-13 01:50:37.212  1666  1768 D NetworkStats: Resolving plan for NetworkTemplate: matchRule=MOBILE_ALL, subscriberId=310260..., matchSubscriberIds=[310260...]
+01-13 01:50:37.216  1666  1768 D NetworkStats: Found active matching subId 1
+01-13 01:50:37.225  1666  1768 D NetworkStats: Resolved to plan null
+01-13 01:50:37.239  2116  2116 D Backup  : [BackupScheduler] Setting backup scheduler enabled=true due to desired state 1
+01-13 01:50:37.239  2116  2116 V Backup  : [BackupTransportCS] no backup now
+01-13 01:50:37.245  2116  2116 D Backup  : [BackupScheduler] Setting backup scheduler enabled=true due to desired state 1
+01-13 01:50:37.245  2116  2116 V Backup  : [BackupTransportCS] no backup now
+01-13 01:50:38.014  1812  2022 I zygote  : Deoptimizing void com.android.systemui.statusbar.policy.SignalController.saveLastState() due to JIT inline cache
+01-13 01:50:38.120  1666 18593 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS www.google.com 0ms OK 64.233.164.103,2a00:1450:4010:c09::69
+01-13 01:50:38.121  1666 18594 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS connectivitycheck.gstatic.com 1ms OK 64.233.163.94,2a00:1450:4010:c08::5e
+01-13 01:50:38.145  1666 18594 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=22ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:12:02 GMT], X-Android-Received-Millis=[1578869438144], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869438122]}
+01-13 01:50:38.185  1666 18593 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:50:38.213  1666  2854 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_FALLBACK http://www.google.com/gen_204 time=27ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Content-Type=[text/html; charset=UTF-8], Date=[Fri, 28 Feb 2020 19:12:02 GMT], Server=[gws], Set-Cookie=[1P_JAR=2020-02-28-19; expires=Sun, 29-Mar-2020 19:12:02 GMT; path=/; domain=.google.com; Secure], X-Android-Received-Millis=[1578869438213], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869438186], X-Frame-Options=[SAMEORIGIN], X-XSS-Protection=[0]}
+01-13 01:50:38.214  1666  1775 D ConnectivityService: NetworkAgentInfo [WIFI () - 101] validation failed
+01-13 01:50:38.214  1666  1771 D WifiStateMachine: NETWORK_STATUS_UNWANTED_VALIDATION_FAILED
+01-13 01:50:40.220  1666 18596 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS connectivitycheck.gstatic.com 2ms OK 64.233.163.94,2a00:1450:4010:c08::5e
+01-13 01:50:40.223  1666 18595 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS www.google.com 4ms OK 64.233.164.104,2a00:1450:4010:c09::69
+01-13 01:50:40.244  1666 18596 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=23ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:12:04 GMT], X-Android-Received-Millis=[1578869440244], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869440222]}
+01-13 01:50:43.250  1666  2854 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_FALLBACK http://www.google.com/gen_204 time=29ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Content-Type=[text/html; charset=UTF-8], Date=[Fri, 28 Feb 2020 19:12:07 GMT], Server=[gws], Set-Cookie=[1P_JAR=2020-02-28-19; expires=Sun, 29-Mar-2020 19:12:07 GMT; path=/; domain=.google.com; Secure], X-Android-Received-Millis=[1578869443250], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869443221], X-Frame-Options=[SAMEORIGIN], X-XSS-Protection=[0]}
+01-13 01:50:48.712  1666  7773 D WificondControl: Scan result ready event
+01-13 01:50:50.302  1666 18595 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:50:50.304  1666  1771 D WifiStateMachine: NETWORK_STATUS_UNWANTED_VALIDATION_FAILED
+01-13 01:50:54.311  1666 18600 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS connectivitycheck.gstatic.com 1ms OK 64.233.163.94,2a00:1450:4010:c08::5e
+01-13 01:50:54.313  1666 18599 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS www.google.com 2ms OK 64.233.164.103,2a00:1450:4010:c09::69
+01-13 01:50:54.336  1666 18600 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=23ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:12:18 GMT], X-Android-Received-Millis=[1578869454336], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869454313]}
+01-13 01:50:54.386  1666 18599 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:50:54.490  1666  2854 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_FALLBACK http://play.googleapis.com/generate_204 time=103ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:12:18 GMT], X-Android-Received-Millis=[1578869454490], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869454466]}
+01-13 01:50:54.491  1666  1771 D WifiStateMachine: NETWORK_STATUS_UNWANTED_VALIDATION_FAILED
+01-13 01:50:57.082  2116 18583 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 01:50:57.082  2116 18583 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 01:50:57.336  2116 18590 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 01:50:57.336  2116 18590 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 01:50:50.304  1666  1775 I chatty  : uid=1000(system) ConnectivitySer identical 1 line
+01-13 01:50:54.491  1666  1775 D ConnectivityService: NetworkAgentInfo [WIFI () - 101] validation failed
+01-13 01:50:57.337  1666  1775 D ConnectivityService: reportNetworkConnectivity(100, false) by 10013
+01-13 01:50:57.337  1666  2183 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: Forcing reevaluation for UID 10013
+01-13 01:50:57.345  1666 18605 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS connectivitycheck.gstatic.com 6ms OK 64.233.163.94,2a00:1450:4010:c08::5e
+01-13 01:50:57.371  1666 18604 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS www.google.com 33ms OK 64.233.164.106,2a00:1450:4010:c09::69
+01-13 01:50:57.399  1666 18605 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=53ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:12:21 GMT], X-Android-Received-Millis=[1578869457399], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869457372]}
+01-13 01:50:57.434  1666 18604 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:50:57.489  1666  2183 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_FALLBACK http://www.google.com/gen_204 time=54ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Content-Type=[text/html; charset=UTF-8], Date=[Fri, 28 Feb 2020 19:12:21 GMT], Server=[gws], Set-Cookie=[1P_JAR=2020-02-28-19; expires=Sun, 29-Mar-2020 19:12:21 GMT; path=/; domain=.google.com; Secure], X-Android-Received-Millis=[1578869457489], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869457460], X-Frame-Options=[SAMEORIGIN], X-XSS-Protection=[0]}
+01-13 01:50:57.490  1666  1775 D ConnectivityService: NetworkAgentInfo [MOBILE (LTE) - 100] validation failed
+01-13 01:50:57.495  1666  1775 D ConnectivityService: Switching to new default network: NetworkAgentInfo{ ni{[type: WIFI[], state: CONNECTED/CONNECTED, reason: (unspecified), extra: "AndroidWifi", failover: false, available: true, roaming: false]}  network{101}  nethandle{433808132830}  lp{{InterfaceName: wlan0 LinkAddresses: [fe80::ff:fe44:5566/64,192.168.232.2/21,fec0::ff:fe44:5566/64,fec0::d34:4dd5:a8e1:12ec/64,]  Routes: [fe80::/64 -> :: wlan0,::/0 -> fe80::ff:fe00:100 wlan0,fec0::/64 -> :: wlan0,192.168.232.0/21 -> 0.0.0.0 wlan0,0.0.0.0/0 -> 192.168.232.1 wlan0,] DnsAddresses: [10.0.2.3,] Domains: null MTU: 0 TcpBufferSizes: 524288,1048576,2097152,262144,524288,1048576}}  nc{[ Transports: WIFI Capabilities: NOT_METERED&INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN&FOREGROUND LinkUpBandwidth>=1048576Kbps LinkDnBandwidth>=1048576Kbps SignalStrength: -50]}  Score{20}  everValidated{true}  lastValidated{false}  created{true} lingering{false} explicitlySelected{false} acceptUnvalidated{false} everCaptivePortalDetected{false} lastCaptivePortalDetected{false} clat{null} }
+01-13 01:50:57.500  1666  1873 D NetworkTimeUpdateService: New default network 101; checking time.
+01-13 01:50:57.501  1666  1775 D ConnectivityService: Sending DISCONNECTED broadcast for type 0 NetworkAgentInfo [MOBILE (LTE) - 100] isDefaultNetwork=true
+01-13 01:50:57.508  1666  1775 D ConnectivityService: Sending CONNECTED broadcast for type 1 NetworkAgentInfo [WIFI () - 101] isDefaultNetwork=true
+01-13 01:50:57.517  1666  1775 D ConnectivityService: handleNetworkUnvalidated NetworkAgentInfo [MOBILE (LTE) - 100] cap=[ Transports: CELLULAR Capabilities: MMS&SUPL&DUN&FOTA&IMS&CBS&IA&INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN&FOREGROUND LinkUpBandwidth>=51200Kbps LinkDnBandwidth>=102400Kbps Specifier: <1>]
+01-13 01:50:57.517  1666  1768 I WifiService: getConnectionInfo uid=1000
+01-13 01:50:57.520  1666  1768 D RecurrenceRule: Resolving using anchor 2020-01-13T01:50:57.520+03:00[Europe/Moscow]
+01-13 01:50:57.522  1666  1768 D RecurrenceRule: Resolving using anchor 2020-01-13T01:50:57.522+03:00[Europe/Moscow]
+01-13 01:50:57.523  1666  1768 D RecurrenceRule: Cycle 12 from 2020-01-13T00:00+03:00[Europe/Moscow] to 2020-02-13T00:00+03:00[Europe/Moscow]
+01-13 01:50:57.524  1666  1768 D NetworkStats: Resolving plan for NetworkTemplate: matchRule=MOBILE_ALL, subscriberId=310260..., matchSubscriberIds=[310260...]
+01-13 01:50:57.526  1666  1768 D NetworkStats: Found active matching subId 1
+01-13 01:50:57.533  1666  1768 D NetworkStats: Resolved to plan null
+01-13 01:50:57.542  1666  1768 I WifiService: getConnectionInfo uid=1000
+01-13 01:50:57.545  1666  1768 D RecurrenceRule: Resolving using anchor 2020-01-13T01:50:57.545+03:00[Europe/Moscow]
+01-13 01:50:57.546  1666  1768 D RecurrenceRule: Resolving using anchor 2020-01-13T01:50:57.546+03:00[Europe/Moscow]
+01-13 01:50:57.547  1666  1768 D RecurrenceRule: Cycle 12 from 2020-01-13T00:00+03:00[Europe/Moscow] to 2020-02-13T00:00+03:00[Europe/Moscow]
+01-13 01:50:57.548  1666  1768 D NetworkStats: Resolving plan for NetworkTemplate: matchRule=MOBILE_ALL, subscriberId=310260..., matchSubscriberIds=[310260...]
+01-13 01:50:57.550  1666  1768 D NetworkStats: Found active matching subId 1
+01-13 01:50:57.558  1666  1768 D NetworkStats: Resolved to plan null
+01-13 01:50:57.559  2116  2116 D Backup  : [BackupScheduler] Setting backup scheduler enabled=true due to desired state 1
+01-13 01:50:57.559  2116  2116 V Backup  : [BackupTransportCS] no backup now
+01-13 01:50:57.559  1666  7772 I WifiService: getConnectionInfo uid=10013
+01-13 01:50:57.561  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:50:57.562  1666  7772 I WifiService: getConnectionInfo uid=10013
+01-13 01:50:57.565  2116  2116 D Backup  : [BackupScheduler] Setting backup scheduler enabled=true due to desired state 1
+01-13 01:50:57.565  2116  2116 V Backup  : [BackupTransportCS] no backup now
+01-13 01:50:57.567  1666  7775 I WifiService: getConnectionInfo uid=10013
+01-13 01:50:57.571  1666  7771 I WifiService: getConnectionInfo uid=10013
+01-13 01:50:58.496  1666 18611 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS www.google.com 1ms OK 64.233.162.147,2a00:1450:4010:c09::69
+01-13 01:50:58.496  1666 18612 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS connectivitycheck.gstatic.com 1ms OK 64.233.163.94,2a00:1450:4010:c08::5e
+01-13 01:50:58.523  1666 18612 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=26ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:12:22 GMT], X-Android-Received-Millis=[1578869458523], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869458498]}
+01-13 01:50:58.558  1666 18611 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:50:58.611  1666  2183 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_FALLBACK http://play.googleapis.com/generate_204 time=52ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:12:22 GMT], X-Android-Received-Millis=[1578869458611], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869458587]}
+01-13 01:50:58.612  1666  1775 D ConnectivityService: NetworkAgentInfo [MOBILE (LTE) - 100] validation failed
+01-13 01:51:00.012  1442  1465 D hwcomposer: hw_composer sent 288 syncs in 60s
+01-13 01:51:00.619  1666 18615 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS connectivitycheck.gstatic.com 2ms OK 64.233.163.94,2a00:1450:4010:c08::5e
+01-13 01:51:00.622  1666 18614 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS www.google.com 5ms OK 64.233.162.147,2a00:1450:4010:c09::69
+01-13 01:51:00.645  1666 18615 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=25ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:12:24 GMT], X-Android-Received-Millis=[1578869460645], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869460620]}
+01-13 01:51:00.681  1666 18614 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:51:00.710  1666  2183 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_FALLBACK http://www.google.com/gen_204 time=28ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Content-Type=[text/html; charset=UTF-8], Date=[Fri, 28 Feb 2020 19:12:24 GMT], Server=[gws], Set-Cookie=[1P_JAR=2020-02-28-19; expires=Sun, 29-Mar-2020 19:12:24 GMT; path=/; domain=.google.com; Secure], X-Android-Received-Millis=[1578869460710], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869460682], X-Frame-Options=[SAMEORIGIN], X-XSS-Protection=[0]}
+01-13 01:51:02.502  1666 18619 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS connectivitycheck.gstatic.com 1ms OK 64.233.163.94,2a00:1450:4010:c08::5e
+01-13 01:51:02.507  1666 18618 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS www.google.com 5ms OK 64.233.162.104,2a00:1450:4010:c09::69
+01-13 01:51:02.526  1666 18619 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=23ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:12:26 GMT], X-Android-Received-Millis=[1578869462526], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869462503]}
+01-13 01:51:02.565  1666 18618 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:51:02.591  1666  2854 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_FALLBACK http://play.googleapis.com/generate_204 time=24ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:12:26 GMT], X-Android-Received-Millis=[1578869462591], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869462567]}
+01-13 01:51:00.711  1666  1775 D ConnectivityService: NetworkAgentInfo [MOBILE (LTE) - 100] validation failed
+01-13 01:51:02.592  1666  1775 D ConnectivityService: NetworkAgentInfo [WIFI () - 101] validation failed
+01-13 01:51:02.592  1666  1771 D WifiStateMachine: NETWORK_STATUS_UNWANTED_VALIDATION_FAILED
+01-13 01:51:04.721  1666 18622 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS www.google.com 3ms OK 64.233.162.99,2a00:1450:4010:c09::69
+01-13 01:51:04.722  1666 18623 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS connectivitycheck.gstatic.com 4ms OK 64.233.163.94,2a00:1450:4010:c08::5e
+01-13 01:51:04.747  1666 18623 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=24ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:12:29 GMT], X-Android-Received-Millis=[1578869464747], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869464723]}
+01-13 01:51:07.748  1666  2183 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_FALLBACK http://www.google.com/gen_204 time=29ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Content-Type=[text/html; charset=UTF-8], Date=[Fri, 28 Feb 2020 19:12:32 GMT], Server=[gws], Set-Cookie=[1P_JAR=2020-02-28-19; expires=Sun, 29-Mar-2020 19:12:32 GMT; path=/; domain=.google.com; Secure], X-Android-Received-Millis=[1578869467748], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869467719], X-Frame-Options=[SAMEORIGIN], X-XSS-Protection=[0]}
+01-13 01:51:14.798  1666 18622 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:51:14.801  1666  1775 D ConnectivityService: NetworkAgentInfo [MOBILE (LTE) - 100] validation failed
+01-13 01:51:17.658  2116 18609 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 01:51:17.658  2116 18609 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 01:51:18.611  1666 18631 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS connectivitycheck.gstatic.com 1ms OK 64.233.163.94,2a00:1450:4010:c08::5e
+01-13 01:51:18.612  1666 18630 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS www.google.com 3ms OK 64.233.162.106,2a00:1450:4010:c09::69
+01-13 01:51:18.635  1666 18631 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=23ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:12:42 GMT], X-Android-Received-Millis=[1578869478635], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869478612]}
+01-13 01:51:18.675  1666 18630 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:51:18.700  1666  2854 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_FALLBACK http://play.googleapis.com/generate_204 time=24ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:12:42 GMT], X-Android-Received-Millis=[1578869478700], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869478676]}
+01-13 01:51:18.701  1666  1775 D ConnectivityService: NetworkAgentInfo [WIFI () - 101] validation failed
+01-13 01:51:18.701  1666  1771 D WifiStateMachine: NETWORK_STATUS_UNWANTED_VALIDATION_FAILED
+01-13 01:51:22.172  1666  1759 I InputDispatcher: Dropping event because there is no touchable window at (442, 624).
+01-13 01:51:22.812  1666 18635 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS connectivitycheck.gstatic.com 2ms OK 64.233.163.94,2a00:1450:4010:c08::5e
+01-13 01:51:22.812  1666 18634 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS www.google.com 3ms OK 64.233.162.105,2a00:1450:4010:c09::69
+01-13 01:51:22.837  1666 18635 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=24ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:12:47 GMT], X-Android-Received-Millis=[1578869482837], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869482813]}
+01-13 01:51:22.875  1666 18634 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:51:22.905  1666  2183 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_FALLBACK http://www.google.com/gen_204 time=28ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Content-Type=[text/html; charset=UTF-8], Date=[Fri, 28 Feb 2020 19:12:47 GMT], Server=[gws], Set-Cookie=[1P_JAR=2020-02-28-19; expires=Sun, 29-Mar-2020 19:12:47 GMT; path=/; domain=.google.com; Secure], X-Android-Received-Millis=[1578869482905], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869482877], X-Frame-Options=[SAMEORIGIN], X-XSS-Protection=[0]}
+01-13 01:51:22.906  1666  1775 D ConnectivityService: NetworkAgentInfo [MOBILE (LTE) - 100] validation failed
+01-13 01:51:23.741  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:23.742  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 26897401 , only wrote 26897040
+01-13 01:51:23.820  1666  1691 D AutofillManagerService: Close system dialogs
+01-13 01:51:23.822  1666  1759 I ActivityManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.HOME] flg=0x10200000 cmp=com.google.android.apps.nexuslauncher/.NexusLauncherActivity (has extras)} from uid 1000
+01-13 01:51:23.828  1666  1740 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:23.829  1666  1740 D         : HostConnection::get() New Host Connection established 0xde47cac0, tid 1740
+01-13 01:51:23.829  1666  1740 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:23.831  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:23.831  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:23.832  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:23.856  2116  2618 W GCoreFlp: No location to return for getLastLocation()
+01-13 01:51:23.870  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:23.877  2116  2618 W GCoreFlp: No location to return for getLastLocation()
+01-13 01:51:23.879  1666  7773 D WindowManager: relayoutVisibleWindow: Window{9203362 u0 com.google.android.apps.nexuslauncher/com.google.android.apps.nexuslauncher.NexusLauncherActivity EXITING} mAnimatingExit=true, mRemoveOnExit=false, mDestroying=false
+01-13 01:51:23.882  1666  7778 D WindowManager: relayoutVisibleWindow: Window{4fdf975 u0 com.google.android.apps.nexuslauncher/com.google.android.apps.nexuslauncher.NexusLauncherActivity EXITING} mAnimatingExit=true, mRemoveOnExit=false, mDestroying=false
+01-13 01:51:23.883  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:23.887  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:23.890  1441  1502 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:23.902  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:23.902  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:23.948  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:23.948  1441  1502 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:23.994  1451  2135 E IPCThreadState: binder thread pool (4 threads) starved for 102 ms
+01-13 01:51:24.003  2348  2728 D EGL_emulation: eglMakeCurrent: 0xe1085f00: ver 2 0 (tinfo 0xe1083ba0)
+01-13 01:51:24.005  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:24.019  2374  2504 D EGL_emulation: eglMakeCurrent: 0xce51d940: ver 2 0 (tinfo 0xce534ae0)
+01-13 01:51:24.036  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:24.043  2348  2348 I MicroDetectionWorker: #updateMicroDetector [detectionMode: [mDetectionMode: [1]]]
+01-13 01:51:24.044  2348  2348 I MicroDetectionWorker: #startMicroDetector [speakerMode: 0]
+01-13 01:51:24.044  2348  2348 I AudioController: Using mInputStreamFactoryBuilder
+01-13 01:51:24.046  2348  2348 I MicroDetectionWorker: onReady
+01-13 01:51:24.047  2348 18321 I MicroRecognitionRunner: Starting detection.
+01-13 01:51:24.047  2348 18318 I MicrophoneInputStream: mic_starting com.google.android.apps.gsa.staticplugins.aa.c@e77ac4d
+01-13 01:51:24.048  1526  1581 W ServiceManager: Permission failure: android.permission.RECORD_AUDIO from uid=10032 pid=2348
+01-13 01:51:24.048  1526  1581 E         : Request requires android.permission.RECORD_AUDIO
+01-13 01:51:24.048  1526  1581 E         : android.permission.CAPTURE_AUDIO_HOTWORD
+01-13 01:51:24.048  2348 18318 E AudioRecord: Could not get audio input for session 15921, record source 1999, sample rate 16000, format 0x1, channel mask 0x10, flags 0
+01-13 01:51:24.049  2348 18318 E AudioRecord-JNI: Error creating AudioRecord instance: initialization check failed with status -22.
+01-13 01:51:24.049  2348 18318 E android.media.AudioRecord: Error code -20 when initializing native AudioRecord object.
+01-13 01:51:24.049  2348 18318 I MicrophoneInputStream: mic_started com.google.android.apps.gsa.staticplugins.aa.c@e77ac4d
+01-13 01:51:24.049  2348 18318 E ActivityThread: Failed to find provider info for com.google.android.apps.gsa.testing.ui.audio.recorded
+01-13 01:51:24.050  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:24.050  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:24.050  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:24.051  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:24.056  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:24.057  2348  2348 I MicroDetectionWorker: onReady
+01-13 01:51:24.060  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:24.064  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:24.069  2348 18318 I MicrophoneInputStream: mic_close com.google.android.apps.gsa.staticplugins.aa.c@e77ac4d
+01-13 01:51:24.070  2348 18321 I MicroRecognitionRunner: Detection finished
+01-13 01:51:24.070  2348 18321 W ErrorReporter: reportError [type: 211, code: 524300]: Error reading from input stream
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: onFatalError, processing error from engine(4)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: com.google.android.apps.gsa.shared.speech.b.g: Error reading from input stream
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.staticplugins.recognizer.j.a.a(SourceFile:28)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.staticplugins.recognizer.j.b.run(SourceFile:15)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:457)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:457)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.ag.run(Unknown Source:4)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.bo.run(SourceFile:4)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.bo.run(SourceFile:4)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at java.lang.Thread.run(Thread.java:764)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.ak.run(SourceFile:6)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: Caused by: com.google.android.apps.gsa.shared.exception.GsaIOException: Error code: 393238 | Buffer overflow, no available space.
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.Tee.f(SourceFile:103)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.au.read(SourceFile:2)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at java.io.InputStream.read(InputStream.java:101)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.ao.run(SourceFile:18)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.an.run(SourceFile:2)
+01-13 01:51:24.072  2348 18321 W ErrorProcessor: 	... 11 more
+01-13 01:51:24.073  2348  2813 I MicroRecognitionRunner: Stopping hotword detection.
+01-13 01:51:24.073  2348 18321 I AudioController: internalShutdown
+01-13 01:51:24.075  2348  2348 I MicroDetector: Keeping mic open: false
+01-13 01:51:24.075  2348 17010 I DeviceStateChecker: DeviceStateChecker cancelled
+01-13 01:51:24.075  2348  2348 I MicroDetectionWorker: #onError(false)
+01-13 01:51:24.076  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:24.335  1666  1686 W ActivityManager: Activity pause timeout for ActivityRecord{91fe92d u0 name.mlopatkin.shuttle/.NewMainActivity t336}
+01-13 01:51:24.125  1812  2065 I chatty  : uid=10029(com.android.systemui) RenderThread identical 6 lines
+01-13 01:51:24.132  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:24.522  2374  2504 W OpenGLRenderer: Incorrectly called buildLayer on View: ShortcutAndWidgetContainer, destroying layer...
+01-13 01:51:25.140  2374  2504 W OpenGLRenderer: Incorrectly called buildLayer on View: Hotseat, destroying layer...
+01-13 01:51:25.140  2374  2504 W OpenGLRenderer: Incorrectly called buildLayer on View: PageIndicatorLineCaret, destroying layer...
+01-13 01:51:25.143  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:25.151  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:25.486  1449  1449 I boot-pipe: done populating /dev/random
+01-13 01:51:25.918  1666  7771 I ActivityManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=name.mlopatkin.shuttle/.NewMainActivity bnds=[426,675][559,838]} from uid 10023
+01-13 01:51:25.931  2116  2618 W GCoreFlp: No location to return for getLastLocation()
+01-13 01:51:26.054  1666  1676 I zygote  : Background concurrent copying GC freed 139288(5MB) AllocSpace objects, 0(0B) LOS objects, 35% free, 10MB/16MB, paused 6.907ms total 108.462ms
+01-13 01:51:27.342  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:51:27.342  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:51:27.491  1666  1775 D ConnectivityService: handleLingerComplete for NetworkAgentInfo [MOBILE (LTE) - 100]
+01-13 01:51:29.098  1433  1583 W audio_hw_generic: Not supplying enough data to HAL, expected position 27409218 , only wrote 27154080
+01-13 01:51:30.958  2348  2728 D EGL_emulation: eglMakeCurrent: 0xe1085f00: ver 2 0 (tinfo 0xe1083ba0)
+01-13 01:51:30.959  2374  2504 D EGL_emulation: eglMakeCurrent: 0xce51d940: ver 2 0 (tinfo 0xce534ae0)
+01-13 01:51:30.963  1451  2135 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:30.964  1451  2135 D         : HostConnection::get() New Host Connection established 0xf1cf2b80, tid 2135
+01-13 01:51:30.964  1451  2135 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:30.965  1451  2135 D         : HostConnection::get() New Host Connection established 0xf1cf2b80, tid 2135
+01-13 01:51:30.966  1451  2135 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:30.966  1451  2135 D         : HostConnection::get() New Host Connection established 0xf1cf2b80, tid 2135
+01-13 01:51:30.966  1451  2135 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:30.968  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:30.968  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:30.968  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:30.969  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:30.969  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:30.970  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:30.970  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:30.970  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:30.971  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:30.971  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:30.971  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:30.971  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:30.971  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:30.972  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:30.972  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:30.978  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:30.980  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:34.341  1666  1686 W ActivityManager: Activity stop timeout for ActivityRecord{91fe92d u0 name.mlopatkin.shuttle/.NewMainActivity t336}
+01-13 01:51:34.342  1666  1686 I ActivityManager: Activity reported stop, but no longer stopping: ActivityRecord{91fe92d u0 name.mlopatkin.shuttle/.NewMainActivity t336}
+01-13 01:51:35.546  1666  1759 I InputDispatcher: Dropping event because there is no touchable window at (495, 426).
+01-13 01:51:35.923  1666  1686 W ActivityManager: Launch timeout has expired, giving up wake lock!
+01-13 01:51:35.941  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:51:35.941  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:51:37.381  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:51:37.381  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:51:37.698  1666  1687 D AutofillManagerService: onBackKeyPressed()
+01-13 01:51:37.738  2116 18628 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 01:51:37.738  2116 18628 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 01:51:37.744  2116 18628 W WakeLock: GCM_CONN_ALARM counter does not exist
+01-13 01:51:38.928  1666 18641 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS www.google.com 2ms OK 64.233.162.99,2a00:1450:4010:c09::69
+01-13 01:51:38.954  1666 18642 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS connectivitycheck.gstatic.com 28ms OK 64.233.165.94,2a00:1450:4010:c08::5e
+01-13 01:51:38.979  1666 18642 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=24ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:13:03 GMT], X-Android-Received-Millis=[1578869498979], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869498955]}
+01-13 01:51:38.987  1666 18641 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:51:39.016  1666  2183 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_FALLBACK http://www.google.com/gen_204 time=27ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Content-Type=[text/html; charset=UTF-8], Date=[Fri, 28 Feb 2020 19:13:03 GMT], Server=[gws], Set-Cookie=[1P_JAR=2020-02-28-19; expires=Sun, 29-Mar-2020 19:13:03 GMT; path=/; domain=.google.com; Secure], X-Android-Received-Millis=[1578869499015], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869498988], X-Frame-Options=[SAMEORIGIN], X-XSS-Protection=[0]}
+01-13 01:51:39.016  1666  1775 D ConnectivityService: NetworkAgentInfo [MOBILE (LTE) - 100] validation failed
+01-13 01:51:42.478  1666  1759 I InputDispatcher: Application is not responding: AppWindowToken{7a345c8 token=Token{1702e62 ActivityRecord{91fe92d u0 name.mlopatkin.shuttle/.NewMainActivity t336}}}.  It has been 5008.8ms since event, 5006.8ms since wait started.  Reason: Waiting because no window has focus but there is a focused application that may eventually add a window when it finishes starting up.
+01-13 01:51:42.480  1666  1759 I WindowManager: Input event dispatching timed out sending to application AppWindowToken{7a345c8 token=Token{1702e62 ActivityRecord{91fe92d u0 name.mlopatkin.shuttle/.NewMainActivity t336}}}.  Reason: Waiting because no window has focus but there is a focused application that may eventually add a window when it finishes starting up.
+01-13 01:51:42.825  1666  1686 I zygote  : libdebuggerd_client: started dumping process 18535
+01-13 01:51:42.825  1542  1542 I /system/bin/tombstoned: registered intercept for pid 18535 and type kDebuggerdJavaBacktrace
+01-13 01:51:42.826 18535 18541 I zygote  : Thread[3,tid=18541,WaitingInMainSignalCatcherLoop,Thread*=0xe8dd9c00,peer=0x145c3fd8,"Signal Catcher"]: reacting to signal 3
+01-13 01:51:42.826 18535 18541 I zygote  : 
+01-13 01:51:42.863  1542  1542 I /system/bin/tombstoned: received crash request for pid 18535
+01-13 01:51:42.863  1542  1542 I /system/bin/tombstoned: found intercept fd 512 for pid 18535 and type kDebuggerdJavaBacktrace
+01-13 01:51:42.864 18535 18541 I zygote  : Wrote stack traces to '[tombstoned]'
+01-13 01:51:42.866  1666  1686 I zygote  : libdebuggerd_client: done dumping process 18535
+01-13 01:51:42.866  1666  1686 I zygote  : libdebuggerd_client: started dumping process 1666
+01-13 01:51:42.867  1542  1542 I /system/bin/tombstoned: registered intercept for pid 1666 and type kDebuggerdJavaBacktrace
+01-13 01:51:42.868  1666  1671 I zygote  : Thread[2,tid=1671,WaitingInMainSignalCatcherLoop,Thread*=0xe1095600,peer=0x12c001b8,"Signal Catcher"]: reacting to signal 3
+01-13 01:51:42.868  1666  1671 I zygote  : 
+01-13 01:51:43.145  1542  1542 I /system/bin/tombstoned: received crash request for pid 1666
+01-13 01:51:43.145  1542  1542 I /system/bin/tombstoned: found intercept fd 512 for pid 1666 and type kDebuggerdJavaBacktrace
+01-13 01:51:43.146  1666  1671 I zygote  : Wrote stack traces to '[tombstoned]'
+01-13 01:51:43.162  1666  1686 I zygote  : libdebuggerd_client: done dumping process 1666
+01-13 01:51:43.162  1666  1686 I zygote  : libdebuggerd_client: started dumping process 1879
+01-13 01:51:43.163  1542  1542 I /system/bin/tombstoned: registered intercept for pid 1879 and type kDebuggerdJavaBacktrace
+01-13 01:51:43.163  1879  1887 I zygote  : Thread[3,tid=1887,WaitingInMainSignalCatcherLoop,Thread*=0xe8dd9c00,peer=0x138c0000,"Signal Catcher"]: reacting to signal 3
+01-13 01:51:43.163  1879  1887 I zygote  : 
+01-13 01:51:43.232  1542  1542 I /system/bin/tombstoned: received crash request for pid 1879
+01-13 01:51:43.232  1542  1542 I /system/bin/tombstoned: found intercept fd 512 for pid 1879 and type kDebuggerdJavaBacktrace
+01-13 01:51:43.232  1879  1887 I zygote  : Wrote stack traces to '[tombstoned]'
+01-13 01:51:43.237  1666  1686 I zygote  : libdebuggerd_client: done dumping process 1879
+01-13 01:51:43.237  1666  1686 I zygote  : libdebuggerd_client: started dumping process 1812
+01-13 01:51:43.237  1542  1542 I /system/bin/tombstoned: registered intercept for pid 1812 and type kDebuggerdJavaBacktrace
+01-13 01:51:43.237  1812  1816 I zygote  : Thread[3,tid=1816,WaitingInMainSignalCatcherLoop,Thread*=0xe8dd9c00,peer=0x12f80898,"Signal Catcher"]: reacting to signal 3
+01-13 01:51:43.237  1812  1816 I zygote  : 
+01-13 01:51:43.321  1542  1542 I /system/bin/tombstoned: received crash request for pid 1812
+01-13 01:51:43.321  1542  1542 I /system/bin/tombstoned: found intercept fd 512 for pid 1812 and type kDebuggerdJavaBacktrace
+01-13 01:51:43.326  1666  1686 I zygote  : libdebuggerd_client: done dumping process 1812
+01-13 01:51:43.326  1666  1686 I zygote  : libdebuggerd_client: started dumping process 1451
+01-13 01:51:43.327  1542  1542 I /system/bin/tombstoned: registered intercept for pid 1451 and type kDebuggerdNativeBacktrace
+01-13 01:51:43.327  1812  1816 I zygote  : Wrote stack traces to '[tombstoned]'
+01-13 01:51:43.328  1451  1451 I libc    : Requested dump for tid 1451 (surfaceflinger)
+01-13 01:51:43.347 18647 18647 I crash_dump32: obtaining output fd from tombstoned, type: kDebuggerdNativeBacktrace
+01-13 01:51:43.348  1542  1542 I /system/bin/tombstoned: received crash request for pid 1451
+01-13 01:51:43.348  1542  1542 I /system/bin/tombstoned: found intercept fd 512 for pid 1451 and type kDebuggerdNativeBacktrace
+01-13 01:51:43.348 18647 18647 I crash_dump32: performing dump of process 1451 (target tid = 1451)
+01-13 01:51:43.395  1666  1686 I zygote  : libdebuggerd_client: done dumping process 1451
+01-13 01:51:43.395  1666  1686 I zygote  : libdebuggerd_client: started dumping process 1526
+01-13 01:51:43.395  1542  1542 I /system/bin/tombstoned: registered intercept for pid 1526 and type kDebuggerdNativeBacktrace
+01-13 01:51:43.396  1526  1526 I libc    : Requested dump for tid 1526 (audioserver)
+01-13 01:51:43.413 18650 18650 I crash_dump32: obtaining output fd from tombstoned, type: kDebuggerdNativeBacktrace
+01-13 01:51:43.414  1542  1542 I /system/bin/tombstoned: received crash request for pid 1526
+01-13 01:51:43.414  1542  1542 I /system/bin/tombstoned: found intercept fd 512 for pid 1526 and type kDebuggerdNativeBacktrace
+01-13 01:51:43.414 18650 18650 I crash_dump32: performing dump of process 1526 (target tid = 1526)
+01-13 01:51:43.449  1666  1686 I zygote  : libdebuggerd_client: done dumping process 1526
+01-13 01:51:43.449  1666  1686 I zygote  : libdebuggerd_client: started dumping process 1527
+01-13 01:51:43.449  1542  1542 I /system/bin/tombstoned: registered intercept for pid 1527 and type kDebuggerdNativeBacktrace
+01-13 01:51:43.449  1527  1527 I libc    : Requested dump for tid 1527 (cameraserver)
+01-13 01:51:43.464 18654 18654 I crash_dump32: obtaining output fd from tombstoned, type: kDebuggerdNativeBacktrace
+01-13 01:51:43.464  1542  1542 I /system/bin/tombstoned: received crash request for pid 1527
+01-13 01:51:43.464  1542  1542 I /system/bin/tombstoned: found intercept fd 512 for pid 1527 and type kDebuggerdNativeBacktrace
+01-13 01:51:43.465 18654 18654 I crash_dump32: performing dump of process 1527 (target tid = 1527)
+01-13 01:51:43.484  1666  1686 I zygote  : libdebuggerd_client: done dumping process 1527
+01-13 01:51:43.484  1666  1686 I zygote  : libdebuggerd_client: started dumping process 1528
+01-13 01:51:43.485  1542  1542 I /system/bin/tombstoned: registered intercept for pid 1528 and type kDebuggerdNativeBacktrace
+01-13 01:51:43.485  1528  1528 I libc    : Requested dump for tid 1528 (drmserver)
+01-13 01:51:43.499 18657 18657 I crash_dump32: obtaining output fd from tombstoned, type: kDebuggerdNativeBacktrace
+01-13 01:51:43.500  1542  1542 I /system/bin/tombstoned: received crash request for pid 1528
+01-13 01:51:43.500  1542  1542 I /system/bin/tombstoned: found intercept fd 512 for pid 1528 and type kDebuggerdNativeBacktrace
+01-13 01:51:43.500 18657 18657 I crash_dump32: performing dump of process 1528 (target tid = 1528)
+01-13 01:51:43.515  1666  1686 I zygote  : libdebuggerd_client: done dumping process 1528
+01-13 01:51:43.515  1666  1686 I zygote  : libdebuggerd_client: started dumping process 1531
+01-13 01:51:43.516  1542  1542 I /system/bin/tombstoned: registered intercept for pid 1531 and type kDebuggerdNativeBacktrace
+01-13 01:51:43.516  1531  1531 I libc    : Requested dump for tid 1531 (mediadrmserver)
+01-13 01:51:43.529 18660 18660 I crash_dump32: obtaining output fd from tombstoned, type: kDebuggerdNativeBacktrace
+01-13 01:51:43.529  1542  1542 I /system/bin/tombstoned: received crash request for pid 1531
+01-13 01:51:43.530  1542  1542 I /system/bin/tombstoned: found intercept fd 512 for pid 1531 and type kDebuggerdNativeBacktrace
+01-13 01:51:43.530 18660 18660 I crash_dump32: performing dump of process 1531 (target tid = 1531)
+01-13 01:51:43.542  1666  1686 I zygote  : libdebuggerd_client: done dumping process 1531
+01-13 01:51:43.542  1666  1686 I zygote  : libdebuggerd_client: started dumping process 1534
+01-13 01:51:43.543  1542  1542 I /system/bin/tombstoned: registered intercept for pid 1534 and type kDebuggerdNativeBacktrace
+01-13 01:51:43.544  1534  1534 I libc    : Requested dump for tid 1534 (mediaserver)
+01-13 01:51:43.559 18664 18664 I crash_dump32: obtaining output fd from tombstoned, type: kDebuggerdNativeBacktrace
+01-13 01:51:43.559  1542  1542 I /system/bin/tombstoned: received crash request for pid 1534
+01-13 01:51:43.559  1542  1542 I /system/bin/tombstoned: found intercept fd 512 for pid 1534 and type kDebuggerdNativeBacktrace
+01-13 01:51:43.560 18664 18664 I crash_dump32: performing dump of process 1534 (target tid = 1534)
+01-13 01:51:43.579  1666  1686 I zygote  : libdebuggerd_client: done dumping process 1534
+01-13 01:51:43.579  1666  1686 I zygote  : libdebuggerd_client: started dumping process 18301
+01-13 01:51:43.580  1542  1542 I /system/bin/tombstoned: registered intercept for pid 18301 and type kDebuggerdNativeBacktrace
+01-13 01:51:43.583  1542  1542 I /system/bin/tombstoned: received crash request for pid 18301
+01-13 01:51:43.583  1542  1542 I /system/bin/tombstoned: found intercept fd 512 for pid 18301 and type kDebuggerdNativeBacktrace
+01-13 01:51:43.587  1542  1542 W /system/bin/tombstoned: crash socket received short read of length 0 (expected 12)
+01-13 01:51:43.588  1380  1380 I ServiceManager: service 'media.extractor' died
+01-13 01:51:43.590  1666  1686 I zygote  : libdebuggerd_client: done dumping process 18301
+01-13 01:51:43.590  1666  1686 I zygote  : libdebuggerd_client: started dumping process 18302
+01-13 01:51:43.593  1542  1542 I /system/bin/tombstoned: registered intercept for pid 18302 and type kDebuggerdNativeBacktrace
+01-13 01:51:43.595  1542  1542 I /system/bin/tombstoned: received crash request for pid 18302
+01-13 01:51:43.595  1542  1542 I /system/bin/tombstoned: found intercept fd 512 for pid 18302 and type kDebuggerdNativeBacktrace
+01-13 01:51:43.600  1666  1686 I zygote  : libdebuggerd_client: done dumping process 18302
+01-13 01:51:43.600  1666  1686 I zygote  : libdebuggerd_client: started dumping process 2249
+01-13 01:51:43.600  1542  1542 W /system/bin/tombstoned: crash socket received short read of length 0 (expected 12)
+01-13 01:51:43.600  1542  1542 I /system/bin/tombstoned: registered intercept for pid 2249 and type kDebuggerdJavaBacktrace
+01-13 01:51:43.601  1381  1381 E hw-IPCThreadState: attemptIncStrongHandle(24): Not supported
+01-13 01:51:43.601  1381  1381 I chatty  : uid=1000(system) hwservicemanage identical 7 lines
+01-13 01:51:43.601  1381  1381 E hw-IPCThreadState: attemptIncStrongHandle(24): Not supported
+01-13 01:51:43.601  2249  2258 I zygote  : Thread[3,tid=2258,WaitingInMainSignalCatcherLoop,Thread*=0xe8dd9c00,peer=0x12c80218,"Signal Catcher"]: reacting to signal 3
+01-13 01:51:43.601  2249  2258 I zygote  : 
+01-13 01:51:43.688  1542  1542 I /system/bin/tombstoned: received crash request for pid 2249
+01-13 01:51:43.688  1542  1542 I /system/bin/tombstoned: found intercept fd 512 for pid 2249 and type kDebuggerdJavaBacktrace
+01-13 01:51:43.688 18666 18666 I /vendor/bin/hw/android.hardware.media.omx@1.0-service: mediacodecservice starting
+01-13 01:51:43.688  2249  2258 I zygote  : Wrote stack traces to '[tombstoned]'
+01-13 01:51:43.688 18666 18666 W /vendor/bin/hw/android.hardware.media.omx@1.0-service: Could not read additional policy file '/vendor/etc/seccomp_policy/mediacodec.policy'
+01-13 01:51:43.688 18666 18666 W /vendor/bin/hw/android.hardware.media.omx@1.0-service: libminijail[18666]: allowing syscall: socketcall
+01-13 01:51:43.689 18666 18666 W /vendor/bin/hw/android.hardware.media.omx@1.0-service: libminijail[18666]: allowing syscall: writev
+01-13 01:51:43.689 18666 18666 W /vendor/bin/hw/android.hardware.media.omx@1.0-service: libminijail[18666]: allowing syscall: fcntl64
+01-13 01:51:43.689 18666 18666 W /vendor/bin/hw/android.hardware.media.omx@1.0-service: libminijail[18666]: allowing syscall: clock_gettime
+01-13 01:51:43.689 18666 18666 W /vendor/bin/hw/android.hardware.media.omx@1.0-service: libminijail[18666]: logging seccomp filter failures
+01-13 01:51:43.691 18666 18666 W MediaCodecsXmlParser: unable to open media codecs configuration xml file: /data/misc/media/media_codecs_profiling_results.xml
+01-13 01:51:43.691 18666 18666 W MediaCodecsXmlParser: parseTopLevelXMLFile(/data/misc/media/media_codecs_profiling_results.xml) failed
+01-13 01:51:43.692 18666 18666 I ServiceManagement: Removing namespace from process name android.hardware.media.omx@1.0-service to omx@1.0-service.
+01-13 01:51:43.692  1666  1686 I zygote  : libdebuggerd_client: done dumping process 2249
+01-13 01:51:43.694  1666  1686 E ActivityManager: ANR in name.mlopatkin.shuttle (name.mlopatkin.shuttle/.NewMainActivity)
+01-13 01:51:43.694  1666  1686 E ActivityManager: PID: 18535
+01-13 01:51:43.694  1666  1686 E ActivityManager: Reason: Input dispatching timed out (Waiting because no window has focus but there is a focused application that may eventually add a window when it finishes starting up.)
+01-13 01:51:43.694  1666  1686 E ActivityManager: Load: 0.86 / 0.95 / 0.78
+01-13 01:51:43.694  1666  1686 E ActivityManager: CPU usage from 137510ms to 0ms ago (2020-01-13 01:49:24.976 to 2020-01-13 01:51:42.486):
+01-13 01:51:43.694  1666  1686 E ActivityManager:   2.6% 1666/system_server: 1.4% user + 1.1% kernel / faults: 5362 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   1.1% 1451/surfaceflinger: 0.3% user + 0.7% kernel / faults: 33 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0.9% 2116/com.google.android.gms.persistent: 0.6% user + 0.2% kernel / faults: 4562 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0.8% 1442/android.hardware.graphics.composer@2.1-service: 0% user + 0.7% kernel / faults: 44 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0.6% 1444/android.hardware.sensors@1.0-service: 0% user + 0.6% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0.4% 1812/com.android.systemui: 0.2% user + 0.2% kernel / faults: 1914 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0.3% 1433/android.hardware.audio@2.0-service: 0% user + 0.3% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0.3% 2374/com.google.android.apps.nexuslauncher: 0.2% user + 0.1% kernel / faults: 3431 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0.3% 2348/com.google.android.googlequicksearchbox:search: 0.2% user + 0.1% kernel / faults: 2616 minor 1 major
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0.3% 1526/audioserver: 0.2% user + 0.1% kernel / faults: 1 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0.1% 1459/adbd: 0% user + 0.1% kernel / faults: 1183 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0.1% 1879/com.android.phone: 0% user + 0% kernel / faults: 229 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0.1% 1379/logd: 0% user + 0% kernel / faults: 6 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 2155/com.google.android.dialer: 0% user + 0% kernel / faults: 353 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1535/netd: 0% user + 0% kernel / faults: 542 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 18251/kworker/u8:2: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 7/rcu_preempt: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1440/android.hardware.gnss@1.0-service: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1463/logcat: 0% user + 0% kernel / faults: 1 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 18500/kworker/u8:1: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 3/ksoftirqd/0: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1443/android.hardware.power@1.0-service: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 2187/com.google.android.gms: 0% user + 0% kernel / faults: 69 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 17/ksoftirqd/2: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1441/android.hardware.graphics.allocator@2.0-service: 0% user + 0% kernel / faults: 22 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1494/dmcrypt_write: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1518/jbd2/dm-0-8: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1634/dhcpclient: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 2249/com.google.process.gservices: 0% user + 0% kernel / faults: 175 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 17658/kworker/u9:2: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 17661/kworker/u9:3: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 18340/kworker/u9:0: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1//init: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 16/migration/2: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 703/hwrng: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1445/android.hardware.wifi@1.0-service: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1511/kworker/0:1H: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1525/zygote: 0% user + 0% kernel / faults: 135 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1537/wificond: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1539/rild: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1557/iptables-restore: 0% user + 0% kernel / faults: 1 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1558/ip6tables-restore: 0% user + 0% kernel / faults: 25 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1649/ipv6proxy: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 1797/com.google.android.inputmethod.latin: 0% user + 0% kernel / faults: 5 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 14841/kworker/1:0: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 17832/kworker/3:1: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 18053/kworker/0:0: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 18322/kworker/2:0: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   0% 18417/kworker/u9:4: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:  +0% 18515/logcat: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:  +0% 18535/name.mlopatkin.shuttle: 0% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager: 19% TOTAL: 18% user + 1% kernel + 0% iowait + 0% softirq
+01-13 01:51:43.694  1666  1686 E ActivityManager: CPU usage from 14ms to 321ms later (2020-01-13 01:51:42.500 to 2020-01-13 01:51:42.807):
+01-13 01:51:43.694  1666  1686 E ActivityManager:   96% 18535/name.mlopatkin.shuttle: 96% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:     100% 18535/opatkin.shuttle: 100% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   29% 1666/system_server: 29% user + 0% kernel / faults: 204 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:     25% 1686/ActivityManager: 22% user + 3.6% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager:   4.1% 2249/com.google.process.gservices: 4.1% user + 0% kernel / faults: 82 minor
+01-13 01:51:43.694  1666  1686 E ActivityManager:     4.1% 2263/HeapTaskDaemon: 4.1% user + 0% kernel
+01-13 01:51:43.694  1666  1686 E ActivityManager: 35% TOTAL: 34% user + 0.8% kernel
+01-13 01:51:43.699 18666 18666 W MediaCodecsXmlParser: unable to open media codecs configuration xml file: /data/misc/media/media_codecs_profiling_results.xml
+01-13 01:51:43.699 18666 18666 W MediaCodecsXmlParser: parseTopLevelXMLFile(/data/misc/media/media_codecs_profiling_results.xml) failed
+01-13 01:51:43.699 18666 18666 I ServiceManagement: Removing namespace from process name android.hardware.media.omx@1.0-service to omx@1.0-service.
+01-13 01:51:43.701 18666 18666 I /vendor/bin/hw/android.hardware.media.omx@1.0-service: Treble OMX service created.
+01-13 01:51:43.717  1666  1687 W ViewRootImpl[shuttle]: Cancelling event due to no window focus: KeyEvent { action=ACTION_UP, keyCode=KEYCODE_BACK, scanCode=158, metaState=0, flags=0x28, repeatCount=0, eventTime=29852698, downTime=29852470, deviceId=0, source=0x101 }
+01-13 01:51:43.717  1666  1687 I chatty  : uid=1000(system) android.ui identical 4 lines
+01-13 01:51:43.717  1666  1687 W ViewRootImpl[shuttle]: Cancelling event due to no window focus: KeyEvent { action=ACTION_UP, keyCode=KEYCODE_BACK, scanCode=158, metaState=0, flags=0x28, repeatCount=0, eventTime=29852698, downTime=29852470, deviceId=0, source=0x101 }
+01-13 01:51:43.748  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.stats.service.DropBoxEntryAddedReceiver
+01-13 01:51:43.749  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+01-13 01:51:43.758  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 1810432
+01-13 01:51:43.774  1441  1501 I chatty  : uid=1000(system) HwBinder:1441_1 identical 1 line
+01-13 01:51:43.783  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 1810432
+01-13 01:51:43.818  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:43.821  1666  5180 I zygote  : android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 0
+01-13 01:51:43.821  1666  5180 I OpenGLRenderer: Initialized EGL, version 1.4
+01-13 01:51:43.821  1666  5180 D OpenGLRenderer: Swap behavior 1
+01-13 01:51:43.822  1666  5180 W OpenGLRenderer: Failed to choose config with EGL_SWAP_BEHAVIOR_PRESERVED, retrying without...
+01-13 01:51:43.822  1666  5180 D OpenGLRenderer: Swap behavior 0
+01-13 01:51:43.826  1666  5180 D EGL_emulation: eglCreateContext: 0xc9dc2ae0: maj 2 min 0 rcv 2
+01-13 01:51:43.832  1666  5180 D EGL_emulation: eglMakeCurrent: 0xc9dc2ae0: ver 2 0 (tinfo 0xcef36390)
+01-13 01:51:43.835 18665 18665 V MediaUtils: physMem: 1567338496
+01-13 01:51:43.835 18665 18665 V MediaUtils: requested limit: 313467680
+01-13 01:51:43.835 18665 18665 V MediaUtils: cfi shadow size: 32768
+01-13 01:51:43.835 18665 18665 V MediaUtils: actual limit: 313500448
+01-13 01:51:43.835 18665 18665 V MediaUtils: original limits: 4294967295/4294967295
+01-13 01:51:43.835 18665 18665 V MediaUtils: new limits: 313500448/4294967295
+01-13 01:51:43.843 18665 18665 W /system/bin/mediaextractor: Could not read additional policy file '/vendor/etc/seccomp_policy/mediaextractor.policy'
+01-13 01:51:43.843 18665 18665 W /system/bin/mediaextractor: libminijail[18665]: allowing syscall: socketcall
+01-13 01:51:43.843 18665 18665 W /system/bin/mediaextractor: libminijail[18665]: allowing syscall: writev
+01-13 01:51:43.843 18665 18665 W /system/bin/mediaextractor: libminijail[18665]: allowing syscall: fcntl64
+01-13 01:51:43.843 18665 18665 W /system/bin/mediaextractor: libminijail[18665]: allowing syscall: clock_gettime
+01-13 01:51:43.844 18665 18665 W /system/bin/mediaextractor: libminijail[18665]: logging seccomp filter failures
+01-13 01:51:43.850  1666  1676 I zygote  : Background concurrent copying GC freed 57192(2MB) AllocSpace objects, 21(2MB) LOS objects, 33% free, 11MB/17MB, paused 516us total 135.294ms
+01-13 01:51:43.856  1666  5180 D EGL_emulation: eglMakeCurrent: 0xc9dc2ae0: ver 2 0 (tinfo 0xcef36390)
+01-13 01:51:43.969  1666  1687 W Looper  : Dispatch took 176ms on android.ui, h=Handler (android.view.Choreographer$FrameHandler) {3789ba8} cb=android.view.Choreographer$FrameDisplayEventReceiver@5b7a6c1 msg=0
+01-13 01:51:45.323  1666  1687 W ActivityManager:   Force finishing activity name.mlopatkin.shuttle/.NewMainActivity
+01-13 01:51:45.335  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 27154462 , only wrote 27154080
+01-13 01:51:45.344  1666  1687 I ActivityManager: Killing 18535:name.mlopatkin.shuttle/u0a85 (adj 0): user request after error
+01-13 01:51:45.346  1666  1688 W zygote  : kill(-18535, 9) failed: No such process
+01-13 01:51:45.348  1666  5180 D EGL_emulation: eglMakeCurrent: 0xc9dc2ae0: ver 2 0 (tinfo 0xcef36390)
+01-13 01:51:45.352  1451  1477 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:45.353  1451  1477 D         : HostConnection::get() New Host Connection established 0xf1cf2e40, tid 1477
+01-13 01:51:45.353  1451  1477 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:45.379  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:45.380  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:45.380  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:45.380  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:45.381  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:45.381  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:45.381  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:45.382  1666  1740 W AppOps  : Finishing op nesting under-run: uid 1000 pkg android code 24 time=0 duration=0 nesting=0
+01-13 01:51:45.386  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:45.390  1666  1688 W zygote  : kill(-18535, 9) failed: No such process
+01-13 01:51:45.421  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:45.425  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:45.430  1441  1502 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:45.433  1451  2135 D         : HostConnection::get() New Host Connection established 0xebe53300, tid 2135
+01-13 01:51:45.431  1666  1688 W zygote  : kill(-18535, 9) failed: No such process
+01-13 01:51:45.433  1666  1688 I zygote  : Successfully killed process cgroup uid 10085 pid 18535 in 87ms
+01-13 01:51:45.438  1451  1752 D         : HostConnection::get() New Host Connection established 0xf1cf2c00, tid 1752
+01-13 01:51:45.439  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:45.439  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:45.452  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:45.452  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:45.472  2348  2728 D EGL_emulation: eglMakeCurrent: 0xe1085f00: ver 2 0 (tinfo 0xe1083ba0)
+01-13 01:51:45.481  2348  2348 I MicroDetectionWorker: #updateMicroDetector [detectionMode: [mDetectionMode: [1]]]
+01-13 01:51:45.481  2348  2348 I MicroDetectionWorker: #startMicroDetector [speakerMode: 0]
+01-13 01:51:45.481  2348  2348 I AudioController: Using mInputStreamFactoryBuilder
+01-13 01:51:45.482  2348  2348 I MicroDetectionWorker: onReady
+01-13 01:51:45.482  2348 17010 I MicroRecognitionRunner: Starting detection.
+01-13 01:51:45.483  2374  2504 D EGL_emulation: eglMakeCurrent: 0xce51d940: ver 2 0 (tinfo 0xce534ae0)
+01-13 01:51:45.485  2348 18318 I MicrophoneInputStream: mic_starting com.google.android.apps.gsa.staticplugins.aa.c@a92f012
+01-13 01:51:45.486  2116  2618 W GCoreFlp: No location to return for getLastLocation()
+01-13 01:51:45.487  1526 15574 W ServiceManager: Permission failure: android.permission.RECORD_AUDIO from uid=10032 pid=2348
+01-13 01:51:45.487  1526 15574 E         : Request requires android.permission.RECORD_AUDIO
+01-13 01:51:45.487  1526 15574 E         : android.permission.CAPTURE_AUDIO_HOTWORD
+01-13 01:51:45.488  2348 18318 E AudioRecord: Could not get audio input for session 15929, record source 1999, sample rate 16000, format 0x1, channel mask 0x10, flags 0
+01-13 01:51:45.491  2348 18318 E AudioRecord-JNI: Error creating AudioRecord instance: initialization check failed with status -22.
+01-13 01:51:45.491  2348 18318 E android.media.AudioRecord: Error code -20 when initializing native AudioRecord object.
+01-13 01:51:45.491  2348 18318 I MicrophoneInputStream: mic_started com.google.android.apps.gsa.staticplugins.aa.c@a92f012
+01-13 01:51:45.492  2348 18318 E ActivityThread: Failed to find provider info for com.google.android.apps.gsa.testing.ui.audio.recorded
+01-13 01:51:45.500  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:45.509  2348  2348 I MicroDetectionWorker: onReady
+01-13 01:51:45.510  2348 18318 I MicrophoneInputStream: mic_close com.google.android.apps.gsa.staticplugins.aa.c@a92f012
+01-13 01:51:45.511  2348 17010 I MicroRecognitionRunner: Detection finished
+01-13 01:51:45.511  2348 17010 W ErrorReporter: reportError [type: 211, code: 524300]: Error reading from input stream
+01-13 01:51:45.512  2348  2813 I MicroRecognitionRunner: Stopping hotword detection.
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: onFatalError, processing error from engine(4)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: com.google.android.apps.gsa.shared.speech.b.g: Error reading from input stream
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at com.google.android.apps.gsa.staticplugins.recognizer.j.a.a(SourceFile:28)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at com.google.android.apps.gsa.staticplugins.recognizer.j.b.run(SourceFile:15)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:457)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:457)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.ag.run(Unknown Source:4)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.bo.run(SourceFile:4)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.bo.run(SourceFile:4)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at java.lang.Thread.run(Thread.java:764)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.ak.run(SourceFile:6)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: Caused by: com.google.android.apps.gsa.shared.exception.GsaIOException: Error code: 393238 | Buffer overflow, no available space.
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.Tee.f(SourceFile:103)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.au.read(SourceFile:2)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at java.io.InputStream.read(InputStream.java:101)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.ao.run(SourceFile:18)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.an.run(SourceFile:2)
+01-13 01:51:45.512  2348 17010 W ErrorProcessor: 	... 11 more
+01-13 01:51:45.513  2348 17010 I AudioController: internalShutdown
+01-13 01:51:45.516  2348  2348 I MicroDetector: Keeping mic open: false
+01-13 01:51:45.516  2348 18321 I DeviceStateChecker: DeviceStateChecker cancelled
+01-13 01:51:45.516  2348  2348 I MicroDetectionWorker: #onError(false)
+01-13 01:51:45.992  2374  2504 W OpenGLRenderer: Incorrectly called buildLayer on View: ShortcutAndWidgetContainer, destroying layer...
+01-13 01:51:46.010  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:46.011  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:46.011  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:46.016  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:47.215  1666  7770 I ActivityManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=name.mlopatkin.shuttle/.MainActivity bnds=[559,152][693,315]} from uid 10023
+01-13 01:51:47.238 18683 18683 I zygote  : Not late-enabling -Xcheck:jni (already on)
+01-13 01:51:47.240  1666  7770 I ActivityManager: Start proc 18683:name.mlopatkin.shuttle/u0a85 for activity name.mlopatkin.shuttle/.MainActivity
+01-13 01:51:47.245  2116  2618 W GCoreFlp: No location to return for getLastLocation()
+01-13 01:51:47.260 18683 18683 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+01-13 01:51:47.265  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3411968
+01-13 01:51:47.273  1666  1740 D         : HostConnection::get() New Host Connection established 0xcfe66980, tid 1740
+01-13 01:51:47.320 18683 18683 D ShuttleDatabase: Loading database...
+01-13 01:51:47.321 18683 18703 D ShuttleDatabase: Start loading
+01-13 01:51:47.401 18683 18703 D ShuttleDatabase: Loading done 80
+01-13 01:51:47.403 18683 18706 D DownloadTask: Downloading the schedule
+01-13 01:51:47.427  2348  2728 D EGL_emulation: eglMakeCurrent: 0xe1085f00: ver 2 0 (tinfo 0xe1083ba0)
+01-13 01:51:47.432  1451  2135 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:47.432  1451  2135 D         : HostConnection::get() New Host Connection established 0xebe53300, tid 2135
+01-13 01:51:47.434  1451  2135 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:47.434  1451  2135 D         : HostConnection::get() New Host Connection established 0xebe53300, tid 2135
+01-13 01:51:47.435  1451  2135 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:47.435  1451  2135 D         : HostConnection::get() New Host Connection established 0xebe53300, tid 2135
+01-13 01:51:47.435  1451  2135 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:47.435  2374  2504 D EGL_emulation: eglMakeCurrent: 0xce51d940: ver 2 0 (tinfo 0xce534ae0)
+01-13 01:51:47.436 18683 18706 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+01-13 01:51:47.447  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:47.464  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:47.473  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:47.473  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:47.474  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:47.475  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:47.475  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:47.475  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:47.475  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:47.475  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:47.476  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:47.476  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:47.476  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:47.477  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:47.478  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:47.478  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:47.478  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:47.478  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:47.487  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:47.491  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:47.502  1812  2065 I chatty  : uid=10029(com.android.systemui) RenderThread identical 1 line
+01-13 01:51:47.513  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:47.519  1451  1477 E SurfaceFlinger: ro.sf.lcd_density must be defined as a build property
+01-13 01:51:47.519 18683 18708 D OpenGLRenderer: HWUI GL Pipeline
+01-13 01:51:47.520  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:47.526  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:47.530 18683 18683 D AndroidPositionProvider: Started with position estimate loc=null
+01-13 01:51:47.531 18683 18683 D AndroidPositionProvider: Starting requesting position updates
+01-13 01:51:47.543  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:47.549  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:47.553 18683 18683 D Heartbeat: Enable heartbeat
+01-13 01:51:47.567  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:47.577 18683 18683 D ShuttleDatabase: Database is ready
+01-13 01:51:47.582  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:47.615  1812  2065 I chatty  : uid=10029(com.android.systemui) RenderThread identical 3 lines
+01-13 01:51:47.621  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:47.630  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3411968
+01-13 01:51:47.632 18683 18708 D         : HostConnection::get() New Host Connection established 0xde429300, tid 18708
+01-13 01:51:47.637 18683 18708 I zygote  : android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 0
+01-13 01:51:47.637  1451  1477 D         : HostConnection::get() New Host Connection established 0xf1cf2e40, tid 1477
+01-13 01:51:47.637 18683 18708 I OpenGLRenderer: Initialized EGL, version 1.4
+01-13 01:51:47.637 18683 18708 D OpenGLRenderer: Swap behavior 1
+01-13 01:51:47.637 18683 18708 W OpenGLRenderer: Failed to choose config with EGL_SWAP_BEHAVIOR_PRESERVED, retrying without...
+01-13 01:51:47.637 18683 18708 D OpenGLRenderer: Swap behavior 0
+01-13 01:51:47.638  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3411968
+01-13 01:51:47.638  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:47.652 18683 18708 D EGL_emulation: eglCreateContext: 0xe10852a0: maj 2 min 0 rcv 2
+01-13 01:51:47.652  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3411968
+01-13 01:51:47.697 18683 18708 D EGL_emulation: eglMakeCurrent: 0xe10852a0: ver 2 0 (tinfo 0xe1083350)
+01-13 01:51:47.700  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:47.702  1451  1752 E SurfaceFlinger: ro.sf.lcd_density must be defined as a build property
+01-13 01:51:47.708  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:47.916 18702 18702 D AndroidRuntime: >>>>>> START com.android.internal.os.RuntimeInit uid 2000 <<<<<<
+01-13 01:51:47.972 18683 18706 E DownloadTask: Failure during loading a schedule from net
+01-13 01:51:47.972 18683 18706 E DownloadTask: javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.org.conscrypt.ConscryptFileDescriptorSocket.startHandshake(ConscryptFileDescriptorSocket.java:219)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.okhttp.internal.io.RealConnection.connectTls(RealConnection.java:192)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.okhttp.internal.io.RealConnection.connectSocket(RealConnection.java:149)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.okhttp.internal.io.RealConnection.connect(RealConnection.java:112)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.okhttp.internal.http.StreamAllocation.findConnection(StreamAllocation.java:184)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.okhttp.internal.http.StreamAllocation.findHealthyConnection(StreamAllocation.java:126)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.okhttp.internal.http.StreamAllocation.newStream(StreamAllocation.java:95)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:281)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:224)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:461)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:407)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getInputStream(HttpURLConnectionImpl.java:244)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getInputStream(DelegatingHttpsURLConnection.java:210)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getInputStream(Unknown Source:0)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at name.mlopatkin.shuttle.net.DownloadTask.doInBackground(DownloadTask.java:60)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at name.mlopatkin.shuttle.net.DownloadTask.doInBackground(DownloadTask.java:36)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at android.os.AsyncTask$2.call(AsyncTask.java:333)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at java.lang.Thread.run(Thread.java:764)
+01-13 01:51:47.972 18683 18706 E DownloadTask: Caused by: java.security.cert.CertificateException: Chain validation failed
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:707)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:539)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:560)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:605)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:495)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:418)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.org.conscrypt.TrustManagerImpl.getTrustedChainForServer(TrustManagerImpl.java:339)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at android.security.net.config.NetworkSecurityTrustManager.checkServerTrusted(NetworkSecurityTrustManager.java:94)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at android.security.net.config.RootTrustManager.checkServerTrusted(RootTrustManager.java:88)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.org.conscrypt.Platform.checkServerTrusted(Platform.java:197)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.org.conscrypt.ConscryptFileDescriptorSocket.verifyCertificateChain(ConscryptFileDescriptorSocket.java:399)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.org.conscrypt.SslWrapper.doHandshake(SslWrapper.java:374)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at com.android.org.conscrypt.ConscryptFileDescriptorSocket.startHandshake(ConscryptFileDescriptorSocket.java:217)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	... 20 more
+01-13 01:51:47.972 18683 18706 E DownloadTask: Caused by: java.security.cert.CertPathValidatorException: Response is unreliable: its validity interval is out-of-date
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:133)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:222)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:140)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at sun.security.provider.certpath.PKIXCertPathValidator.engineValidate(PKIXCertPathValidator.java:79)
+01-13 01:51:47.972 18683 18706 E DownloadTask: 	at java.security.cert.CertPathValidator.validate(CertPathValidator.java:301)
+01-13 01:51:47.975 18683 18706 E DownloadTask: 	at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:703)
+01-13 01:51:47.975 18683 18706 E DownloadTask: 	... 33 more
+01-13 01:51:47.975 18683 18706 E DownloadTask: Caused by: java.security.cert.CertPathValidatorException: Response is unreliable: its validity interval is out-of-date
+01-13 01:51:47.975 18683 18706 E DownloadTask: 	at sun.security.provider.certpath.OCSPResponse.verify(OCSPResponse.java:619)
+01-13 01:51:47.975 18683 18706 E DownloadTask: 	at sun.security.provider.certpath.RevocationChecker.checkOCSP(RevocationChecker.java:709)
+01-13 01:51:47.975 18683 18706 E DownloadTask: 	at sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:363)
+01-13 01:51:47.975 18683 18706 E DownloadTask: 	at sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:337)
+01-13 01:51:47.975 18683 18706 E DownloadTask: 	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:125)
+01-13 01:51:47.975 18683 18706 E DownloadTask: 	... 38 more
+01-13 01:51:47.975 18683 18706 E DownloadTask: 	Suppressed: java.security.cert.CertPathValidatorException: Could not determine revocation status
+01-13 01:51:47.975 18683 18706 E DownloadTask: 		at sun.security.provider.certpath.RevocationChecker.buildToNewKey(RevocationChecker.java:1092)
+01-13 01:51:47.975 18683 18706 E DownloadTask: 		at sun.security.provider.certpath.RevocationChecker.verifyWithSeparateSigningKey(RevocationChecker.java:910)
+01-13 01:51:47.975 18683 18706 E DownloadTask: 		at sun.security.provider.certpath.RevocationChecker.checkCRLs(RevocationChecker.java:577)
+01-13 01:51:47.975 18683 18706 E DownloadTask: 		at sun.security.provider.certpath.RevocationChecker.checkCRLs(RevocationChecker.java:465)
+01-13 01:51:47.975 18683 18706 E DownloadTask: 		at sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:394)
+01-13 01:51:47.975 18683 18706 E DownloadTask: 		... 40 more
+01-13 01:51:48.010 18683 18688 I zygote  : Do partial code cache collection, code=28KB, data=30KB
+01-13 01:51:48.011 18683 18688 I zygote  : After code cache collection, code=26KB, data=30KB
+01-13 01:51:48.011 18683 18688 I zygote  : Increasing code cache capacity to 128KB
+01-13 01:51:48.015 18702 18702 W app_process: Unexpected CPU variant for X86 using defaults: x86
+01-13 01:51:48.017 18702 18702 I app_process: The ClassLoaderContext is a special shared library.
+01-13 01:51:48.064 18702 18702 D AndroidRuntime: Calling main entry com.android.commands.pm.Pm
+01-13 01:51:48.075 18702 18719 W MessageQueue: Handler (android.os.Handler) {d5d2b52} sending message to a Handler on a dead thread
+01-13 01:51:48.075 18702 18719 W MessageQueue: java.lang.IllegalStateException: Handler (android.os.Handler) {d5d2b52} sending message to a Handler on a dead thread
+01-13 01:51:48.075 18702 18719 W MessageQueue: 	at android.os.MessageQueue.enqueueMessage(MessageQueue.java:545)
+01-13 01:51:48.075 18702 18719 W MessageQueue: 	at android.os.Handler.enqueueMessage(Handler.java:662)
+01-13 01:51:48.075 18702 18719 W MessageQueue: 	at android.os.Handler.sendMessageAtTime(Handler.java:631)
+01-13 01:51:48.075 18702 18719 W MessageQueue: 	at android.os.Handler.sendMessageDelayed(Handler.java:601)
+01-13 01:51:48.075 18702 18719 W MessageQueue: 	at android.os.Handler.post(Handler.java:357)
+01-13 01:51:48.075 18702 18719 W MessageQueue: 	at android.os.ResultReceiver$MyResultReceiver.send(ResultReceiver.java:57)
+01-13 01:51:48.075 18702 18719 W MessageQueue: 	at com.android.internal.os.IResultReceiver$Stub.onTransact(IResultReceiver.java:58)
+01-13 01:51:48.075 18702 18719 W MessageQueue: 	at android.os.Binder.execTransact(Binder.java:697)
+01-13 01:51:48.075 18702 18702 I app_process: System.exit called, status: 0
+01-13 01:51:48.075 18702 18702 I AndroidRuntime: VM exiting with result code 0.
+01-13 01:51:48.198 18683 18688 I zygote  : Do partial code cache collection, code=60KB, data=43KB
+01-13 01:51:48.200 18683 18688 I zygote  : After code cache collection, code=52KB, data=41KB
+01-13 01:51:48.200 18683 18688 I zygote  : Increasing code cache capacity to 256KB
+01-13 01:51:48.371 18683 18683 D AndroidPositionProvider: onProviderDisabled network
+01-13 01:51:48.407 18683 18683 I Choreographer: Skipped 49 frames!  The application may be doing too much work on its main thread.
+01-13 01:51:48.436 18683 18708 D EGL_emulation: eglMakeCurrent: 0xe10852a0: ver 2 0 (tinfo 0xe1083350)
+01-13 01:51:48.475 18683 18688 I zygote  : Do full code cache collection, code=79KB, data=79KB
+01-13 01:51:48.476 18683 18688 I zygote  : After code cache collection, code=60KB, data=53KB
+01-13 01:51:48.513  1666  1693 I ActivityManager: Displayed name.mlopatkin.shuttle/.MainActivity: +1s278ms (total +3m59s754ms)
+01-13 01:51:48.568  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:48.568  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:48.569  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:48.570  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+01-13 01:51:48.570  1666  1740 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:48.571  1666  1740 D         : HostConnection::get() New Host Connection established 0xcfe66980, tid 1740
+01-13 01:51:48.572  1666  1740 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:48.592 18722 18722 D AndroidRuntime: >>>>>> START com.android.internal.os.RuntimeInit uid 2000 <<<<<<
+01-13 01:51:48.629  1451  1451 W SurfaceFlinger: couldn't log to binary event log: overflow.
+01-13 01:51:48.630  1451  1451 W SurfaceFlinger: couldn't log to binary event log: overflow.
+01-13 01:51:48.687 18722 18722 W app_process: Unexpected CPU variant for X86 using defaults: x86
+01-13 01:51:48.690 18722 18722 I app_process: The ClassLoaderContext is a special shared library.
+01-13 01:51:48.704  2348  2348 W SearchService: Abort, client detached.
+01-13 01:51:48.743 18722 18722 D AndroidRuntime: Calling main entry com.android.commands.pm.Pm
+01-13 01:51:48.749 18722 18722 I app_process: System.exit called, status: 0
+01-13 01:51:48.749 18722 18722 I AndroidRuntime: VM exiting with result code 0.
+01-13 01:51:48.763  2116 18528 I Places  : ?: Couldn't find platform key file.
+01-13 01:51:48.768  2116 18529 I Places  : ?: Couldn't find platform key file.
+01-13 01:51:48.780  2116 18527 I Places  : ?: PlacesBleScanner stop()
+01-13 01:51:48.781  2116  2116 I BeaconBle: Scan : No clients left, canceling alarm.
+01-13 01:51:48.781  2116  2116 I BeaconBle: Scan canceled successfully.
+01-13 01:51:48.787  2116 18527 I PlaceInferenceEngine: [anon] Changed inference mode: 0
+01-13 01:51:48.800  2116 18509 I Places  : ?: Couldn't find platform key file.
+01-13 01:51:48.801  2116 18734 I Places  : ?: Couldn't find platform key file.
+01-13 01:51:48.809  2116  2116 I GeofencerStateMachine: removeGeofences: removeRequest=RemoveGeofencingRequest[REMOVE_BY_PENDING_INTENT pendingIntent=PendingIntent[creatorPackage=com.google.android.gms], packageName=com.google.android.gms]
+01-13 01:51:50.406  1433  1583 W audio_hw_generic: Not supplying enough data to HAL, expected position 27639007 , only wrote 27397440
+01-13 01:51:50.712  1666 18735 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS www.google.com 3ms OK 64.233.162.103,2a00:1450:4010:c09::69
+01-13 01:51:50.713  1666 18736 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS connectivitycheck.gstatic.com 3ms OK 64.233.165.94,2a00:1450:4010:c08::5e
+01-13 01:51:50.736  1666 18736 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=22ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:13:15 GMT], X-Android-Received-Millis=[1578869510736], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869510714]}
+01-13 01:51:50.773  1666 18735 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:51:50.798  1666  2854 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_FALLBACK http://play.googleapis.com/generate_204 time=24ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:13:15 GMT], X-Android-Received-Millis=[1578869510798], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869510774]}
+01-13 01:51:50.799  1666  1775 D ConnectivityService: NetworkAgentInfo [WIFI () - 101] validation failed
+01-13 01:51:50.799  1666  1771 D WifiStateMachine: NETWORK_STATUS_UNWANTED_VALIDATION_FAILED
+01-13 01:51:51.255 18683 18683 I zygote  : Rejecting re-init on previously-failed class java.lang.Class<androidx.core.view.ViewCompat$2>: java.lang.NoClassDefFoundError: Failed resolution of: Landroid/view/View$OnUnhandledKeyEventListener;
+01-13 01:51:51.256 18683 18683 I zygote  :   at boolean androidx.core.view.ViewCompat.dispatchUnhandledKeyEventBeforeHierarchy(android.view.View, android.view.KeyEvent) (ViewCompat.java:3750)
+01-13 01:51:51.256 18683 18683 I zygote  :   at boolean androidx.core.view.KeyEventDispatcher.dispatchBeforeHierarchy(android.view.View, android.view.KeyEvent) (KeyEventDispatcher.java:63)
+01-13 01:51:51.256 18683 18683 I zygote  :   at boolean androidx.core.app.ComponentActivity.dispatchKeyEvent(android.view.KeyEvent) (ComponentActivity.java:130)
+01-13 01:51:51.256 18683 18683 I zygote  :   at boolean com.android.internal.policy.DecorView.dispatchKeyEvent(android.view.KeyEvent) (DecorView.java:354)
+01-13 01:51:51.256 18683 18683 I zygote  :   at int android.view.ViewRootImpl$ViewPostImeInputStage.processKeyEvent(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4733)
+01-13 01:51:51.256 18683 18683 I zygote  :   at int android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4605)
+01-13 01:51:51.256 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.256 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.256 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.256 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4293)
+01-13 01:51:51.256 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4174)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4350)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4174)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4326)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.view.ViewRootImpl$ImeInputStage.onFinishedInputEvent(java.lang.Object, boolean) (ViewRootImpl.java:4487)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager$PendingEvent.run() (InputMethodManager.java:2435)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager.invokeFinishedInputEventCallback(android.view.inputmethod.InputMethodManager$PendingEvent, boolean) (InputMethodManager.java:1998)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager.finishedInputEvent(int, boolean, boolean) (InputMethodManager.java:1989)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager$ImeInputEventSender.onInputEventFinished(int, boolean) (InputMethodManager.java:2412)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.view.InputEventSender.dispatchInputEventFinished(int, boolean) (InputEventSender.java:141)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.os.MessageQueue.nativePollOnce(long, int) (MessageQueue.java:-2)
+01-13 01:51:51.257 18683 18683 I zygote  :   at android.os.Message android.os.MessageQueue.next() (MessageQueue.java:325)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.os.Looper.loop() (Looper.java:142)
+01-13 01:51:51.257 18683 18683 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+01-13 01:51:51.258 18683 18683 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+01-13 01:51:51.258 18683 18683 I zygote  : Caused by: java.lang.ClassNotFoundException: Didn't find class "android.view.View$OnUnhandledKeyEventListener" on path: DexPathList[[zip file "/data/app/name.mlopatkin.shuttle-6LB2lDENE5ElB3XVTldtIQ==/base.apk"],nativeLibraryDirectories=[/data/app/name.mlopatkin.shuttle-6LB2lDENE5ElB3XVTldtIQ==/lib/x86, /system/lib, /vendor/lib]]
+01-13 01:51:51.258 18683 18683 I zygote  :   at java.lang.Class dalvik.system.BaseDexClassLoader.findClass(java.lang.String) (BaseDexClassLoader.java:125)
+01-13 01:51:51.258 18683 18683 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String, boolean) (ClassLoader.java:379)
+01-13 01:51:51.258 18683 18683 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String) (ClassLoader.java:312)
+01-13 01:51:51.258 18683 18683 I zygote  :   at boolean androidx.core.view.ViewCompat.dispatchUnhandledKeyEventBeforeHierarchy(android.view.View, android.view.KeyEvent) (ViewCompat.java:3750)
+01-13 01:51:51.258 18683 18683 I zygote  :   at boolean androidx.core.view.KeyEventDispatcher.dispatchBeforeHierarchy(android.view.View, android.view.KeyEvent) (KeyEventDispatcher.java:63)
+01-13 01:51:51.258 18683 18683 I zygote  :   at boolean androidx.core.app.ComponentActivity.dispatchKeyEvent(android.view.KeyEvent) (ComponentActivity.java:130)
+01-13 01:51:51.258 18683 18683 I zygote  :   at boolean com.android.internal.policy.DecorView.dispatchKeyEvent(android.view.KeyEvent) (DecorView.java:354)
+01-13 01:51:51.258 18683 18683 I zygote  :   at int android.view.ViewRootImpl$ViewPostImeInputStage.processKeyEvent(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4733)
+01-13 01:51:51.258 18683 18683 I zygote  :   at int android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4605)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4293)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4174)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4350)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4174)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4326)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.ViewRootImpl$ImeInputStage.onFinishedInputEvent(java.lang.Object, boolean) (ViewRootImpl.java:4487)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager$PendingEvent.run() (InputMethodManager.java:2435)
+01-13 01:51:51.258 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager.invokeFinishedInputEventCallback(android.view.inputmethod.InputMethodManager$PendingEvent, boolean) (InputMethodManager.java:1998)
+01-13 01:51:51.259 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager.finishedInputEvent(int, boolean, boolean) (InputMethodManager.java:1989)
+01-13 01:51:51.259 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager$ImeInputEventSender.onInputEventFinished(int, boolean) (InputMethodManager.java:2412)
+01-13 01:51:51.259 18683 18683 I zygote  :   at void android.view.InputEventSender.dispatchInputEventFinished(int, boolean) (InputEventSender.java:141)
+01-13 01:51:51.259 18683 18683 I zygote  :   at void android.os.MessageQueue.nativePollOnce(long, int) (MessageQueue.java:-2)
+01-13 01:51:51.259 18683 18683 I zygote  :   at android.os.Message android.os.MessageQueue.next() (MessageQueue.java:325)
+01-13 01:51:51.259 18683 18683 I zygote  :   at void android.os.Looper.loop() (Looper.java:142)
+01-13 01:51:51.259 18683 18683 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+01-13 01:51:51.259 18683 18683 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+01-13 01:51:51.259 18683 18683 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+01-13 01:51:51.259  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 27397681 , only wrote 27397440
+01-13 01:51:51.259 18683 18683 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+01-13 01:51:51.259 18683 18683 I zygote  : 
+01-13 01:51:51.260 18683 18683 I zygote  : Rejecting re-init on previously-failed class java.lang.Class<androidx.core.view.ViewCompat$2>: java.lang.NoClassDefFoundError: Failed resolution of: Landroid/view/View$OnUnhandledKeyEventListener;
+01-13 01:51:51.260 18683 18683 I zygote  :   at boolean androidx.core.view.ViewCompat.dispatchUnhandledKeyEventBeforeHierarchy(android.view.View, android.view.KeyEvent) (ViewCompat.java:3750)
+01-13 01:51:51.260 18683 18683 I zygote  :   at boolean androidx.core.view.KeyEventDispatcher.dispatchBeforeHierarchy(android.view.View, android.view.KeyEvent) (KeyEventDispatcher.java:63)
+01-13 01:51:51.260 18683 18683 I zygote  :   at boolean androidx.core.app.ComponentActivity.dispatchKeyEvent(android.view.KeyEvent) (ComponentActivity.java:130)
+01-13 01:51:51.260 18683 18683 I zygote  :   at boolean com.android.internal.policy.DecorView.dispatchKeyEvent(android.view.KeyEvent) (DecorView.java:354)
+01-13 01:51:51.261  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.260 18683 18683 I zygote  :   at int android.view.ViewRootImpl$ViewPostImeInputStage.processKeyEvent(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4733)
+01-13 01:51:51.261 18683 18683 I zygote  :   at int android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4605)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4293)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4174)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4350)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4174)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4326)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.ViewRootImpl$ImeInputStage.onFinishedInputEvent(java.lang.Object, boolean) (ViewRootImpl.java:4487)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager$PendingEvent.run() (InputMethodManager.java:2435)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager.invokeFinishedInputEventCallback(android.view.inputmethod.InputMethodManager$PendingEvent, boolean) (InputMethodManager.java:1998)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager.finishedInputEvent(int, boolean, boolean) (InputMethodManager.java:1989)
+01-13 01:51:51.261 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager$ImeInputEventSender.onInputEventFinished(int, boolean) (InputMethodManager.java:2412)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.InputEventSender.dispatchInputEventFinished(int, boolean) (InputEventSender.java:141)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.os.MessageQueue.nativePollOnce(long, int) (MessageQueue.java:-2)
+01-13 01:51:51.262 18683 18683 I zygote  :   at android.os.Message android.os.MessageQueue.next() (MessageQueue.java:325)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.os.Looper.loop() (Looper.java:142)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+01-13 01:51:51.262 18683 18683 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+01-13 01:51:51.262 18683 18683 I zygote  : Caused by: java.lang.ClassNotFoundException: Didn't find class "android.view.View$OnUnhandledKeyEventListener" on path: DexPathList[[zip file "/data/app/name.mlopatkin.shuttle-6LB2lDENE5ElB3XVTldtIQ==/base.apk"],nativeLibraryDirectories=[/data/app/name.mlopatkin.shuttle-6LB2lDENE5ElB3XVTldtIQ==/lib/x86, /system/lib, /vendor/lib]]
+01-13 01:51:51.262 18683 18683 I zygote  :   at java.lang.Class dalvik.system.BaseDexClassLoader.findClass(java.lang.String) (BaseDexClassLoader.java:125)
+01-13 01:51:51.262 18683 18683 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String, boolean) (ClassLoader.java:379)
+01-13 01:51:51.262 18683 18683 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String) (ClassLoader.java:312)
+01-13 01:51:51.262 18683 18683 I zygote  :   at boolean androidx.core.view.ViewCompat.dispatchUnhandledKeyEventBeforeHierarchy(android.view.View, android.view.KeyEvent) (ViewCompat.java:3750)
+01-13 01:51:51.262 18683 18683 I zygote  :   at boolean androidx.core.view.KeyEventDispatcher.dispatchBeforeHierarchy(android.view.View, android.view.KeyEvent) (KeyEventDispatcher.java:63)
+01-13 01:51:51.262 18683 18683 I zygote  :   at boolean androidx.core.app.ComponentActivity.dispatchKeyEvent(android.view.KeyEvent) (ComponentActivity.java:130)
+01-13 01:51:51.262 18683 18683 I zygote  :   at boolean com.android.internal.policy.DecorView.dispatchKeyEvent(android.view.KeyEvent) (DecorView.java:354)
+01-13 01:51:51.262 18683 18683 I zygote  :   at int android.view.ViewRootImpl$ViewPostImeInputStage.processKeyEvent(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4733)
+01-13 01:51:51.262 18683 18683 I zygote  :   at int android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4605)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4293)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4174)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4350)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4174)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4326)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.ViewRootImpl$ImeInputStage.onFinishedInputEvent(java.lang.Object, boolean) (ViewRootImpl.java:4487)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager$PendingEvent.run() (InputMethodManager.java:2435)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager.invokeFinishedInputEventCallback(android.view.inputmethod.InputMethodManager$PendingEvent, boolean) (InputMethodManager.java:1998)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager.finishedInputEvent(int, boolean, boolean) (InputMethodManager.java:1989)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager$ImeInputEventSender.onInputEventFinished(int, boolean) (InputMethodManager.java:2412)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.view.InputEventSender.dispatchInputEventFinished(int, boolean) (InputEventSender.java:141)
+01-13 01:51:51.262 18683 18683 I zygote  :   at void android.os.MessageQueue.nativePollOnce(long, int) (MessageQueue.java:-2)
+01-13 01:51:51.262 18683 18683 I zygote  :   at android.os.Message android.os.MessageQueue.next() (MessageQueue.java:325)
+01-13 01:51:51.263 18683 18683 I zygote  :   at void android.os.Looper.loop() (Looper.java:142)
+01-13 01:51:51.263 18683 18683 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+01-13 01:51:51.263 18683 18683 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+01-13 01:51:51.263 18683 18683 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+01-13 01:51:51.263 18683 18683 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+01-13 01:51:51.263 18683 18683 I zygote  : 
+01-13 01:51:51.263 18683 18683 I zygote  : Rejecting re-init on previously-failed class java.lang.Class<androidx.core.view.ViewCompat$2>: java.lang.NoClassDefFoundError: Failed resolution of: Landroid/view/View$OnUnhandledKeyEventListener;
+01-13 01:51:51.263 18683 18683 I zygote  :   at boolean androidx.core.view.ViewCompat.dispatchUnhandledKeyEventBeforeHierarchy(android.view.View, android.view.KeyEvent) (ViewCompat.java:3750)
+01-13 01:51:51.263 18683 18683 I zygote  :   at boolean androidx.core.view.KeyEventDispatcher.dispatchBeforeHierarchy(android.view.View, android.view.KeyEvent) (KeyEventDispatcher.java:63)
+01-13 01:51:51.263 18683 18683 I zygote  :   at boolean androidx.core.app.ComponentActivity.dispatchKeyEvent(android.view.KeyEvent) (ComponentActivity.java:130)
+01-13 01:51:51.263 18683 18683 I zygote  :   at boolean com.android.internal.policy.DecorView.dispatchKeyEvent(android.view.KeyEvent) (DecorView.java:354)
+01-13 01:51:51.263 18683 18683 I zygote  :   at int android.view.ViewRootImpl$ViewPostImeInputStage.processKeyEvent(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4733)
+01-13 01:51:51.263 18683 18683 I zygote  :   at int android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4605)
+01-13 01:51:51.263 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.263 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.263 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.263 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4293)
+01-13 01:51:51.263 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4174)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4350)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4174)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4326)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.ViewRootImpl$ImeInputStage.onFinishedInputEvent(java.lang.Object, boolean) (ViewRootImpl.java:4487)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager$PendingEvent.run() (InputMethodManager.java:2435)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager.invokeFinishedInputEventCallback(android.view.inputmethod.InputMethodManager$PendingEvent, boolean) (InputMethodManager.java:1998)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager.finishedInputEvent(int, boolean, boolean) (InputMethodManager.java:1989)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager$ImeInputEventSender.onInputEventFinished(int, boolean) (InputMethodManager.java:2412)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.InputEventSender.dispatchInputEventFinished(int, boolean) (InputEventSender.java:141)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.os.MessageQueue.nativePollOnce(long, int) (MessageQueue.java:-2)
+01-13 01:51:51.264 18683 18683 I zygote  :   at android.os.Message android.os.MessageQueue.next() (MessageQueue.java:325)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.os.Looper.loop() (Looper.java:142)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+01-13 01:51:51.264 18683 18683 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+01-13 01:51:51.264 18683 18683 I zygote  : Caused by: java.lang.ClassNotFoundException: Didn't find class "android.view.View$OnUnhandledKeyEventListener" on path: DexPathList[[zip file "/data/app/name.mlopatkin.shuttle-6LB2lDENE5ElB3XVTldtIQ==/base.apk"],nativeLibraryDirectories=[/data/app/name.mlopatkin.shuttle-6LB2lDENE5ElB3XVTldtIQ==/lib/x86, /system/lib, /vendor/lib]]
+01-13 01:51:51.264 18683 18683 I zygote  :   at java.lang.Class dalvik.system.BaseDexClassLoader.findClass(java.lang.String) (BaseDexClassLoader.java:125)
+01-13 01:51:51.264 18683 18683 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String, boolean) (ClassLoader.java:379)
+01-13 01:51:51.264 18683 18683 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String) (ClassLoader.java:312)
+01-13 01:51:51.264 18683 18683 I zygote  :   at boolean androidx.core.view.ViewCompat.dispatchUnhandledKeyEventBeforeHierarchy(android.view.View, android.view.KeyEvent) (ViewCompat.java:3750)
+01-13 01:51:51.264 18683 18683 I zygote  :   at boolean androidx.core.view.KeyEventDispatcher.dispatchBeforeHierarchy(android.view.View, android.view.KeyEvent) (KeyEventDispatcher.java:63)
+01-13 01:51:51.264 18683 18683 I zygote  :   at boolean androidx.core.app.ComponentActivity.dispatchKeyEvent(android.view.KeyEvent) (ComponentActivity.java:130)
+01-13 01:51:51.264 18683 18683 I zygote  :   at boolean com.android.internal.policy.DecorView.dispatchKeyEvent(android.view.KeyEvent) (DecorView.java:354)
+01-13 01:51:51.264 18683 18683 I zygote  :   at int android.view.ViewRootImpl$ViewPostImeInputStage.processKeyEvent(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4733)
+01-13 01:51:51.264 18683 18683 I zygote  :   at int android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4605)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4293)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4174)
+01-13 01:51:51.264 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4350)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.apply(android.view.ViewRootImpl$QueuedInputEvent, int) (ViewRootImpl.java:4174)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.deliver(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4147)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.onDeliverToNext(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4200)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.view.ViewRootImpl$InputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4166)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.view.ViewRootImpl$AsyncInputStage.forward(android.view.ViewRootImpl$QueuedInputEvent) (ViewRootImpl.java:4326)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.view.ViewRootImpl$ImeInputStage.onFinishedInputEvent(java.lang.Object, boolean) (ViewRootImpl.java:4487)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager$PendingEvent.run() (InputMethodManager.java:2435)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager.invokeFinishedInputEventCallback(android.view.inputmethod.InputMethodManager$PendingEvent, boolean) (InputMethodManager.java:1998)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager.finishedInputEvent(int, boolean, boolean) (InputMethodManager.java:1989)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.view.inputmethod.InputMethodManager$ImeInputEventSender.onInputEventFinished(int, boolean) (InputMethodManager.java:2412)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.view.InputEventSender.dispatchInputEventFinished(int, boolean) (InputEventSender.java:141)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.os.MessageQueue.nativePollOnce(long, int) (MessageQueue.java:-2)
+01-13 01:51:51.265 18683 18683 I zygote  :   at android.os.Message android.os.MessageQueue.next() (MessageQueue.java:325)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.os.Looper.loop() (Looper.java:142)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+01-13 01:51:51.265 18683 18683 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+01-13 01:51:51.265 18683 18683 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+01-13 01:51:51.265 18683 18683 I zygote  : 
+01-13 01:51:51.323  1666  1687 D AutofillManagerService: onBackKeyPressed()
+01-13 01:51:51.333 18683 18683 D AndroidPositionProvider: Stopped requesting position updates
+01-13 01:51:51.363  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:51.370  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:51.377  2116  2618 W GCoreFlp: No location to return for getLastLocation()
+01-13 01:51:51.381  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:51.388  1451  1451 D SurfaceFlinger: duplicate layer name: changing com.google.android.apps.nexuslauncher/com.google.android.apps.nexuslauncher.NexusLauncherActivity to com.google.android.apps.nexuslauncher/com.google.android.apps.nexuslauncher.NexusLauncherActivity#1
+01-13 01:51:51.394  2348  2728 D EGL_emulation: eglMakeCurrent: 0xe1085f00: ver 2 0 (tinfo 0xe1083ba0)
+01-13 01:51:51.400  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:51.412  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:51.418  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:51.435  2374  2504 D EGL_emulation: eglMakeCurrent: 0xce51d940: ver 2 0 (tinfo 0xce534ae0)
+01-13 01:51:51.448  2348  2348 W SessionLifecycleManager: Handover failed. Creating new session controller.
+01-13 01:51:51.454  2348  2348 I OptInState: There is a new client and it does not support opt-in. Dropping request.
+01-13 01:51:51.463  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.463  1666  7777 I WifiService: getConnectionInfo uid=10032
+01-13 01:51:51.465  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:51.470  2348 18403 W LocationOracle: No location history returned by ContextManager
+01-13 01:51:51.471 18683 18708 D EGL_emulation: eglMakeCurrent: 0xe10852a0: ver 2 0 (tinfo 0xe1083350)
+01-13 01:51:51.472  1666  1740 D         : HostConnection::get() New Host Connection established 0xcfe66c00, tid 1740
+01-13 01:51:51.475  2348  2348 I MicroDetectionWorker: #updateMicroDetector [detectionMode: [mDetectionMode: [1]]]
+01-13 01:51:51.475  2348  2348 I MicroDetectionWorker: #startMicroDetector [speakerMode: 0]
+01-13 01:51:51.476  2348  2348 I AudioController: Using mInputStreamFactoryBuilder
+01-13 01:51:51.478  2348 18404 I MicroRecognitionRunner: Starting detection.
+01-13 01:51:51.479  2348 18402 I MicrophoneInputStream: mic_starting com.google.android.apps.gsa.staticplugins.aa.c@a9c89bd
+01-13 01:51:51.482  1666  7778 I WifiService: getConnectionInfo uid=10032
+01-13 01:51:51.485  1451  1451 E EGL_emulation: tid 1451: eglCreateSyncKHR(2017): error 0x3004 (EGL_BAD_ATTRIBUTE)
+01-13 01:51:51.487  1526 15574 W ServiceManager: Permission failure: android.permission.RECORD_AUDIO from uid=10032 pid=2348
+01-13 01:51:51.487  1526 15574 E         : Request requires android.permission.RECORD_AUDIO
+01-13 01:51:51.487  1526 15574 E         : android.permission.CAPTURE_AUDIO_HOTWORD
+01-13 01:51:51.488  2348 18402 E AudioRecord: Could not get audio input for session 15937, record source 1999, sample rate 16000, format 0x1, channel mask 0x10, flags 0
+01-13 01:51:51.488  2348 18402 E AudioRecord-JNI: Error creating AudioRecord instance: initialization check failed with status -22.
+01-13 01:51:51.489  2348 18402 E android.media.AudioRecord: Error code -20 when initializing native AudioRecord object.
+01-13 01:51:51.489  2348 18402 I MicrophoneInputStream: mic_started com.google.android.apps.gsa.staticplugins.aa.c@a9c89bd
+01-13 01:51:51.490  2348 18402 E ActivityThread: Failed to find provider info for com.google.android.apps.gsa.testing.ui.audio.recorded
+01-13 01:51:51.490  1451  1478 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:51.491  1451  1478 D         : HostConnection::get() New Host Connection established 0xebe535c0, tid 1478
+01-13 01:51:51.492  1451  1478 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:51.497  2348  2348 I MicroDetectionWorker: onReady
+01-13 01:51:51.508  2348  2348 I MicroDetectionWorker: onReady
+01-13 01:51:51.518  2348 18402 I MicrophoneInputStream: mic_close com.google.android.apps.gsa.staticplugins.aa.c@a9c89bd
+01-13 01:51:51.518  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:51.519  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:51.519  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:51.519  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:51.519  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:51.519  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:51.519  2348 18404 I MicroRecognitionRunner: Detection finished
+01-13 01:51:51.520  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:51.520  2348 18404 W ErrorReporter: reportError [type: 211, code: 524300]: Error reading from input stream
+01-13 01:51:51.520  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:51.521  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:51.522  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:51.522  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:51.524  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:51.542  2348  2813 I MicroRecognitionRunner: Stopping hotword detection.
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: onFatalError, processing error from engine(4)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: com.google.android.apps.gsa.shared.speech.b.g: Error reading from input stream
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at com.google.android.apps.gsa.staticplugins.recognizer.j.a.a(SourceFile:28)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at com.google.android.apps.gsa.staticplugins.recognizer.j.b.run(SourceFile:15)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:457)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:457)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.ag.run(Unknown Source:4)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.bo.run(SourceFile:4)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.bo.run(SourceFile:4)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at java.lang.Thread.run(Thread.java:764)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.ak.run(SourceFile:6)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: Caused by: com.google.android.apps.gsa.shared.exception.GsaIOException: Error code: 393238 | Buffer overflow, no available space.
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.Tee.f(SourceFile:103)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.au.read(SourceFile:2)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at java.io.InputStream.read(InputStream.java:101)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.ao.run(SourceFile:18)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.an.run(SourceFile:2)
+01-13 01:51:51.542  2348 18404 W ErrorProcessor: 	... 11 more
+01-13 01:51:51.542  2348 18404 I AudioController: internalShutdown
+01-13 01:51:51.547  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.552  2348 18403 I DeviceStateChecker: DeviceStateChecker cancelled
+01-13 01:51:51.552  2348  2348 I MicroDetector: Keeping mic open: false
+01-13 01:51:51.552  2348  2348 I MicroDetectionWorker: #onError(false)
+01-13 01:51:51.559  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.567 18683 18683 D Heartbeat: Disable heartbeat
+01-13 01:51:51.569  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.570  1666  5180 I zygote  : android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 0
+01-13 01:51:51.574  1666  5180 I OpenGLRenderer: Initialized EGL, version 1.4
+01-13 01:51:51.574  1666  5180 D OpenGLRenderer: Swap behavior 1
+01-13 01:51:51.578  1666  5180 W OpenGLRenderer: Failed to choose config with EGL_SWAP_BEHAVIOR_PRESERVED, retrying without...
+01-13 01:51:51.578  1666  5180 D OpenGLRenderer: Swap behavior 0
+01-13 01:51:51.580  1666  5180 D EGL_emulation: eglCreateContext: 0xc9dc2ae0: maj 2 min 0 rcv 2
+01-13 01:51:51.584  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.585  1666  5180 D EGL_emulation: eglMakeCurrent: 0xc9dc2ae0: ver 2 0 (tinfo 0xcef36390)
+01-13 01:51:51.594  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.600  2116 18528 I Places  : ?: Couldn't find platform key file.
+01-13 01:51:51.604  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.609  1812  1822 I zygote  : NativeAlloc concurrent copying GC freed 11639(565KB) AllocSpace objects, 0(0B) LOS objects, 50% free, 4MB/9MB, paused 1.251ms total 101.056ms
+01-13 01:51:51.610  1812  1819 D         : HostConnection::get() New Host Connection established 0xcce16dc0, tid 1819
+01-13 01:51:51.612  1812  1819 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:51.612  1812  1819 D         : HostConnection::get() New Host Connection established 0xcce16dc0, tid 1819
+01-13 01:51:51.614  1812  1819 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:51.620  1812  1819 D         : HostConnection::get() New Host Connection established 0xcc45d5c0, tid 1819
+01-13 01:51:51.620  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.621  1812  1819 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:51.621  1812  1819 D         : HostConnection::get() New Host Connection established 0xcc45d5c0, tid 1819
+01-13 01:51:51.623  1812  1819 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:51.632  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.642  2116  2116 I GeofencerStateMachine: removeGeofences: removeRequest=RemoveGeofencingRequest[REMOVE_BY_PENDING_INTENT pendingIntent=PendingIntent[creatorPackage=com.google.android.gms], packageName=com.google.android.gms]
+01-13 01:51:51.646  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.649  2116  2116 I GeofencerStateMachine: removeGeofences: removeRequest=RemoveGeofencingRequest[REMOVE_BY_PENDING_INTENT pendingIntent=PendingIntent[creatorPackage=com.google.android.gms], packageName=com.google.android.gms]
+01-13 01:51:51.655  2116 18740 I PlaceInferenceEngine: [anon] Changed inference mode: 0
+01-13 01:51:51.655  2116 18509 I Places  : ?: Couldn't find platform key file.
+01-13 01:51:51.656  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.660  2116 18529 I Places  : ?: Couldn't find platform key file.
+01-13 01:51:51.669  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.677  1812  2065 I chatty  : uid=10029(com.android.systemui) RenderThread identical 1 line
+01-13 01:51:51.690  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.702  2116 18741 I Places  : ?: Couldn't find platform key file.
+01-13 01:51:51.702  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.705  2116 18734 E ctxmgr  : [ProducerStatusImpl]updateStateForNewContextData: inactive, contextName=7 [CONTEXT service_id=47 ]
+01-13 01:51:51.713  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.716  2116 18741 I Places  : ?: Couldn't find platform key file.
+01-13 01:51:51.727  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.741  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:51.753  2116 18740 I Places  : ?: PlacesBleScanner start() with priority 2
+01-13 01:51:51.753  2116 18740 I PlaceInferenceEngine: [anon] Changed inference mode: 1
+01-13 01:51:51.761  2116 18741 I Places  : ?: Couldn't find platform key file.
+01-13 01:51:51.768  2116 18740 I Places  : Converted 0 out of 1 WiFi scans
+01-13 01:51:51.770  1666  7772 I WifiService: getConnectionInfo uid=10013
+01-13 01:51:51.778  2116  2116 I BeaconBle: Client requested scan, settings=BleSettings [scanMode=ZERO_POWER, callbackType=ALL_MATCHES, reportDelayMillis=0, 1 filters, 0 clients, callingClientName=Places]
+01-13 01:51:51.779  2116  2116 I BeaconBle: Scan : No clients left, canceling alarm.
+01-13 01:51:51.781  2116  2116 E BeaconBle: Scan couldn't start for Places
+01-13 01:51:51.781  2116  2116 W Places  : BLE failure while scanning - code 5
+01-13 01:51:51.782  2116 18740 I PlaceInferenceEngine: [anon] Changed inference mode: 1
+01-13 01:51:51.783  1666  1676 I zygote  : NativeAlloc concurrent copying GC freed 34831(2MB) AllocSpace objects, 8(944KB) LOS objects, 35% free, 10MB/16MB, paused 955us total 122.558ms
+01-13 01:51:51.783  2116 18734 I Places  : ?: Couldn't find platform key file.
+01-13 01:51:51.784  2116 17737 I Places  : ?: Couldn't find platform key file.
+01-13 01:51:51.791  2116 18741 I Places  : ?: Couldn't find platform key file.
+01-13 01:51:51.800  2116 18529 I PlaceInferenceEngine: No beacon scan available - ignoring candidates.
+01-13 01:51:51.800  2116 18734 I Places  : ?: Couldn't find platform key file.
+01-13 01:51:51.819  2116  2128 I zygote  : Background concurrent copying GC freed 100061(4MB) AllocSpace objects, 40(2MB) LOS objects, 38% free, 9MB/15MB, paused 848us total 100.237ms
+01-13 01:51:51.821  2116 18529 I Places  : ?: Couldn't find platform key file.
+01-13 01:51:51.938  2374  2504 W OpenGLRenderer: Incorrectly called buildLayer on View: ShortcutAndWidgetContainer, destroying layer...
+01-13 01:51:53.018  1666  7772 I ActivityManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=name.mlopatkin.shuttle/.MainActivity bnds=[27,1001][160,1164]} from uid 10023
+01-13 01:51:53.045  2116  2618 W GCoreFlp: No location to return for getLastLocation()
+01-13 01:51:53.067  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3411968
+01-13 01:51:53.148 18683 18683 D Heartbeat: Enable heartbeat
+01-13 01:51:53.166 18683 18683 D AndroidPositionProvider: Starting requesting position updates
+01-13 01:51:53.187 18683 18683 D AndroidPositionProvider: onProviderDisabled network
+01-13 01:51:53.200  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:53.201  2348  2728 D EGL_emulation: eglMakeCurrent: 0xe1085f00: ver 2 0 (tinfo 0xe1083ba0)
+01-13 01:51:53.206  2374  2504 D EGL_emulation: eglMakeCurrent: 0xce51d940: ver 2 0 (tinfo 0xce534ae0)
+01-13 01:51:53.207  1451  1752 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:53.208  1451  1752 D         : HostConnection::get() New Host Connection established 0xf1cf2c00, tid 1752
+01-13 01:51:53.209  1451  1752 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:53.209  1451  1752 D         : HostConnection::get() New Host Connection established 0xf1cf2c00, tid 1752
+01-13 01:51:53.210  1451  1752 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:53.210  1451  1752 D         : HostConnection::get() New Host Connection established 0xf1cf2c00, tid 1752
+01-13 01:51:53.211  1451  1752 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:53.214  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:53.214  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:53.215  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:53.215  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:53.216  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:53.216  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:53.216  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:53.216  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:53.216  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:53.217  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:53.217  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:53.217  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:53.217  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:53.217  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:53.217  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:53.219  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:53.220  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3411968
+01-13 01:51:53.228  1451  1752 D         : HostConnection::get() New Host Connection established 0xf1cf2380, tid 1752
+01-13 01:51:53.228  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3411968
+01-13 01:51:53.234  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:53.234  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:53.234  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3411968
+01-13 01:51:53.247  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:53.350  1812  2065 I chatty  : uid=10029(com.android.systemui) RenderThread identical 12 lines
+01-13 01:51:53.362  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:53.362 18683 18708 D EGL_emulation: eglMakeCurrent: 0xe10852a0: ver 2 0 (tinfo 0xe1083350)
+01-13 01:51:53.370  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:53.382 18683 18688 I zygote  : Do partial code cache collection, code=93KB, data=100KB
+01-13 01:51:53.382 18683 18688 I zygote  : After code cache collection, code=93KB, data=100KB
+01-13 01:51:53.383 18683 18688 I zygote  : Increasing code cache capacity to 512KB
+01-13 01:51:53.383  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:53.383 18683 18688 I zygote  : JIT allocated 72KB for compiled code of void android.widget.TextView.<init>(android.content.Context, android.util.AttributeSet, int, int)
+01-13 01:51:53.383 18683 18688 I zygote  : Compiler allocated 4MB to compile void android.widget.TextView.<init>(android.content.Context, android.util.AttributeSet, int, int)
+01-13 01:51:53.389  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:53.396  1666  1693 I ActivityManager: Displayed name.mlopatkin.shuttle/.MainActivity: +356ms
+01-13 01:51:53.404  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:53.417  1666  1740 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:53.418  1666  1740 D         : HostConnection::get() New Host Connection established 0xcfe66c00, tid 1740
+01-13 01:51:53.419  1666  1740 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:53.423  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:53.424  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:53.425  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:53.426  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:53.484  1451  1451 W SurfaceFlinger: couldn't log to binary event log: overflow.
+01-13 01:51:53.521  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:53.562  2348  2348 W SearchService: Abort, client detached.
+01-13 01:51:54.355  1666  1687 D AutofillManagerService: onBackKeyPressed()
+01-13 01:51:54.364 18683 18683 D AndroidPositionProvider: Stopped requesting position updates
+01-13 01:51:54.393  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:54.401  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:54.411  2116  2618 W GCoreFlp: No location to return for getLastLocation()
+01-13 01:51:54.415  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:54.417  1451  1451 D SurfaceFlinger: duplicate layer name: changing com.google.android.apps.nexuslauncher/com.google.android.apps.nexuslauncher.NexusLauncherActivity to com.google.android.apps.nexuslauncher/com.google.android.apps.nexuslauncher.NexusLauncherActivity#1
+01-13 01:51:54.424  2348  2728 D EGL_emulation: eglMakeCurrent: 0xe1085f00: ver 2 0 (tinfo 0xe1083ba0)
+01-13 01:51:54.427  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:54.441  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:54.447  2348  2348 W SessionLifecycleManager: Handover failed. Creating new session controller.
+01-13 01:51:54.449  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:54.451  1666  7572 I WifiService: getConnectionInfo uid=10032
+01-13 01:51:54.458  1666  7772 I WifiService: getConnectionInfo uid=10032
+01-13 01:51:54.468  2348  2348 I MicroDetectionWorker: #updateMicroDetector [detectionMode: [mDetectionMode: [1]]]
+01-13 01:51:54.468  2348  2348 I MicroDetectionWorker: #startMicroDetector [speakerMode: 0]
+01-13 01:51:54.468  2374  2504 D EGL_emulation: eglMakeCurrent: 0xce51d940: ver 2 0 (tinfo 0xce534ae0)
+01-13 01:51:54.468  2348  2348 I AudioController: Using mInputStreamFactoryBuilder
+01-13 01:51:54.472  2348 18403 I MicroRecognitionRunner: Starting detection.
+01-13 01:51:54.474  2348 18402 I MicrophoneInputStream: mic_starting com.google.android.apps.gsa.staticplugins.aa.c@aafa11e
+01-13 01:51:54.477  1526 15574 W ServiceManager: Permission failure: android.permission.RECORD_AUDIO from uid=10032 pid=2348
+01-13 01:51:54.477  1526 15574 E         : Request requires android.permission.RECORD_AUDIO
+01-13 01:51:54.478  1526 15574 E         : android.permission.CAPTURE_AUDIO_HOTWORD
+01-13 01:51:54.478  2348 18402 E AudioRecord: Could not get audio input for session 15945, record source 1999, sample rate 16000, format 0x1, channel mask 0x10, flags 0
+01-13 01:51:54.478  2348 18402 E AudioRecord-JNI: Error creating AudioRecord instance: initialization check failed with status -22.
+01-13 01:51:54.478  2348  2348 I MicroDetectionWorker: onReady
+01-13 01:51:54.478  2348 18402 E android.media.AudioRecord: Error code -20 when initializing native AudioRecord object.
+01-13 01:51:54.478  2348 18402 I MicrophoneInputStream: mic_started com.google.android.apps.gsa.staticplugins.aa.c@aafa11e
+01-13 01:51:54.480  2348 18402 E ActivityThread: Failed to find provider info for com.google.android.apps.gsa.testing.ui.audio.recorded
+01-13 01:51:54.487  2348  2348 I MicroDetectionWorker: onReady
+01-13 01:51:54.503  2348 18402 I MicrophoneInputStream: mic_close com.google.android.apps.gsa.staticplugins.aa.c@aafa11e
+01-13 01:51:54.503  2348 18403 I MicroRecognitionRunner: Detection finished
+01-13 01:51:54.503  2348 18403 W ErrorReporter: reportError [type: 211, code: 524300]: Error reading from input stream
+01-13 01:51:54.504  2348  2813 I MicroRecognitionRunner: Stopping hotword detection.
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: onFatalError, processing error from engine(4)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: com.google.android.apps.gsa.shared.speech.b.g: Error reading from input stream
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at com.google.android.apps.gsa.staticplugins.recognizer.j.a.a(SourceFile:28)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at com.google.android.apps.gsa.staticplugins.recognizer.j.b.run(SourceFile:15)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:457)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:457)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.ag.run(Unknown Source:4)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.bo.run(SourceFile:4)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.bo.run(SourceFile:4)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at java.lang.Thread.run(Thread.java:764)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at com.google.android.apps.gsa.shared.util.concurrent.a.ak.run(SourceFile:6)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: Caused by: com.google.android.apps.gsa.shared.exception.GsaIOException: Error code: 393238 | Buffer overflow, no available space.
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.Tee.f(SourceFile:103)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.au.read(SourceFile:2)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at java.io.InputStream.read(InputStream.java:101)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.ao.run(SourceFile:18)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	at com.google.android.apps.gsa.speech.audio.an.run(SourceFile:2)
+01-13 01:51:54.504  2348 18403 W ErrorProcessor: 	... 11 more
+01-13 01:51:54.504  2348 18403 I AudioController: internalShutdown
+01-13 01:51:54.507  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:54.509  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+01-13 01:51:54.515  1666  1740 D         : HostConnection::get() New Host Connection established 0xcfe660c0, tid 1740
+01-13 01:51:54.515 18683 18708 D EGL_emulation: eglMakeCurrent: 0xe10852a0: ver 2 0 (tinfo 0xe1083350)
+01-13 01:51:54.516  1451  1478 D         : HostConnection::get() New Host Connection established 0xf19a1580, tid 1478
+01-13 01:51:54.519  1451  1628 D         : HostConnection::get() New Host Connection established 0xf1cf2fc0, tid 1628
+01-13 01:51:54.519  1451  1628 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:54.520  1451  1628 D         : HostConnection::get() New Host Connection established 0xf1cf2fc0, tid 1628
+01-13 01:51:54.520  1451  1628 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:54.526  1451  1451 E EGL_emulation: tid 1451: eglCreateSyncKHR(2017): error 0x3004 (EGL_BAD_ATTRIBUTE)
+01-13 01:51:54.530  1451  1478 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:54.530  1451  1478 D         : HostConnection::get() New Host Connection established 0xf19a1580, tid 1478
+01-13 01:51:54.530  1451  1478 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:54.538  2348  2348 I MicroDetector: Keeping mic open: false
+01-13 01:51:54.538  2348 17656 I DeviceStateChecker: DeviceStateChecker cancelled
+01-13 01:51:54.538  2348  2348 I MicroDetectionWorker: #onError(false)
+01-13 01:51:54.561  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:54.561  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:54.562  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:54.562  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:54.562  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:54.562  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:54.566  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:54.569  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:54.570  1666  5180 I zygote  : android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 0
+01-13 01:51:54.570  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:54.570  1666  5180 I OpenGLRenderer: Initialized EGL, version 1.4
+01-13 01:51:54.570  1666  5180 D OpenGLRenderer: Swap behavior 1
+01-13 01:51:54.571  1666  5180 W OpenGLRenderer: Failed to choose config with EGL_SWAP_BEHAVIOR_PRESERVED, retrying without...
+01-13 01:51:54.571  1666  5180 D OpenGLRenderer: Swap behavior 0
+01-13 01:51:54.571 18683 18683 D Heartbeat: Disable heartbeat
+01-13 01:51:54.573  1666  5180 D EGL_emulation: eglCreateContext: 0xc9dc2ae0: maj 2 min 0 rcv 2
+01-13 01:51:54.579  1666  5180 D EGL_emulation: eglMakeCurrent: 0xc9dc2ae0: ver 2 0 (tinfo 0xcef36390)
+01-13 01:51:54.581  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:54.684  1812  2065 I chatty  : uid=10029(com.android.systemui) RenderThread identical 11 lines
+01-13 01:51:54.696  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:54.698  1666  1674 D         : HostConnection::get() New Host Connection established 0xca8e4480, tid 1674
+01-13 01:51:54.698  1666  1674 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:54.699  1666  1674 D         : HostConnection::get() New Host Connection established 0xca8e4480, tid 1674
+01-13 01:51:54.699  1666  1674 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:54.700  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:54.760  1812  2065 I chatty  : uid=10029(com.android.systemui) RenderThread identical 7 lines
+01-13 01:51:54.766  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:54.974  2374  2504 W OpenGLRenderer: Incorrectly called buildLayer on View: ShortcutAndWidgetContainer, destroying layer...
+01-13 01:51:55.389  1666  7772 I ActivityManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=name.mlopatkin.shuttle/.NewMainActivity bnds=[426,675][559,838]} from uid 10023
+01-13 01:51:55.410  2116  2618 W GCoreFlp: No location to return for getLastLocation()
+01-13 01:51:55.444  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3411968
+01-13 01:51:55.532 18683 18688 I zygote  : JIT allocated 56KB for compiled code of void android.view.View.<init>(android.content.Context, android.util.AttributeSet, int, int)
+01-13 01:51:55.535  2348  2728 D EGL_emulation: eglMakeCurrent: 0xe1085f00: ver 2 0 (tinfo 0xe1083ba0)
+01-13 01:51:55.535  2374  2504 D EGL_emulation: eglMakeCurrent: 0xce51d940: ver 2 0 (tinfo 0xce534ae0)
+01-13 01:51:55.537  1451  1478 D         : HostConnection::get() New Host Connection established 0xebe535c0, tid 1478
+01-13 01:51:55.537  1451  1478 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:55.537  1451  1478 D         : HostConnection::get() New Host Connection established 0xebe535c0, tid 1478
+01-13 01:51:55.538  1451  1478 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:55.539  1451  1478 D         : HostConnection::get() New Host Connection established 0xebe535c0, tid 1478
+01-13 01:51:55.539  1451  1478 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:55.540  1451  1478 D         : HostConnection::get() New Host Connection established 0xebe535c0, tid 1478
+01-13 01:51:55.540  1451  1478 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:55.551  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:55.560  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:55.567  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:55.567  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:55.568  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:55.568  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:55.569  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:55.569  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:55.569  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:55.570  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:55.570  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:55.570  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:55.570  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:55.571  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:55.571  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:55.572  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:55.572  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:55.572  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:55.579  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:55.581  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:55.630  1812  2065 I chatty  : uid=10029(com.android.systemui) RenderThread identical 5 lines
+01-13 01:51:55.634  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:55.644  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3411968
+01-13 01:51:55.649  1451  1628 D         : HostConnection::get() New Host Connection established 0xebe53300, tid 1628
+01-13 01:51:55.650  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3411968
+01-13 01:51:55.650  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:55.656  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3411968
+01-13 01:51:55.663  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:55.668  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:55.670 18683 18683 E RecyclerView: No adapter attached; skipping layout
+01-13 01:51:55.671 18683 18688 I zygote  : Do full code cache collection, code=250KB, data=129KB
+01-13 01:51:55.673 18683 18688 I zygote  : After code cache collection, code=125KB, data=54KB
+01-13 01:51:55.682  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:55.726  1812  2065 I chatty  : uid=10029(com.android.systemui) RenderThread identical 6 lines
+01-13 01:51:55.729  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:55.734 18683 18708 D EGL_emulation: eglMakeCurrent: 0xe10852a0: ver 2 0 (tinfo 0xe1083350)
+01-13 01:51:55.736  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:55.750  1812  2065 I chatty  : uid=10029(com.android.systemui) RenderThread identical 1 line
+01-13 01:51:55.754  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:51:55.765  1666  1693 I ActivityManager: Displayed name.mlopatkin.shuttle/.NewMainActivity: +355ms
+01-13 01:51:55.782  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:55.783  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:55.783  1666  1740 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:55.783  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:55.785  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+01-13 01:51:55.785  1666  1740 D         : HostConnection::get() New Host Connection established 0xcfe660c0, tid 1740
+01-13 01:51:55.786  1666  1740 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:51:55.819  1451  1451 W SurfaceFlinger: couldn't log to binary event log: overflow.
+01-13 01:51:55.921  2348  2348 W SearchService: Abort, client detached.
+01-13 01:51:56.836  2116  2536 I zygote  : Deoptimizing void egl.run() due to JIT inline cache
+01-13 01:51:56.856  2116 18741 E ctxmgr  : [NetworkUtil]No active synchronizable contexts. [CONTEXT service_id=47 ]
+01-13 01:51:56.866  2116 18741 I zygote  : Deoptimizing blju bgob.a(blju) due to JIT inline cache
+01-13 01:51:56.928  2116  2969 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+01-13 01:51:56.929  2116  2969 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 01:51:56.929  2116  2969 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : [BaseServerTask]Server task (GetConfigTask) got error statusCode=-1. [CONTEXT service_id=47 ]
+01-13 01:51:56.973  2116  2116 E ctxmgr  : com.android.volley.NoConnectionError: javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.volley.toolbox.BasicNetwork.performRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):46)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at rkj.performRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):13)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.volley.NetworkDispatcher.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):7)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.volley.NetworkDispatcher.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : Caused by: javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.startHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):43)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at aogy.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):20)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at aogy.createSocket(:com.google.android.gms@16089022@16.0.89 (040700-239467275):6)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.okhttp.internal.io.RealConnection.connectTls(RealConnection.java:181)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.okhttp.internal.io.RealConnection.connectSocket(RealConnection.java:149)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.okhttp.internal.io.RealConnection.connect(RealConnection.java:112)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.okhttp.internal.http.StreamAllocation.findConnection(StreamAllocation.java:184)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.okhttp.internal.http.StreamAllocation.findHealthyConnection(StreamAllocation.java:126)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.okhttp.internal.http.StreamAllocation.newStream(StreamAllocation.java:95)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:281)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:224)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:461)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.connect(HttpURLConnectionImpl.java:127)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getOutputStream(HttpURLConnectionImpl.java:258)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getOutputStream(DelegatingHttpsURLConnection.java:218)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getOutputStream(Unknown Source:0)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at abbg.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):39)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at abbg.execute(:com.google.android.gms@16089022@16.0.89 (040700-239467275):8)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at abbg.execute(:com.google.android.gms@16089022@16.0.89 (040700-239467275):7)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.volley.toolbox.HttpClientStack.performRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):10)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at rki.performRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at bry.executeRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.volley.toolbox.BasicNetwork.performRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):10)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	... 3 more
+01-13 01:51:56.973  2116  2116 E ctxmgr  : Caused by: java.security.cert.CertificateException: Chain validation failed
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:707)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:539)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:560)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:628)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:495)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:418)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.org.conscrypt.TrustManagerImpl.getTrustedChainForServer(TrustManagerImpl.java:339)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at android.security.net.config.NetworkSecurityTrustManager.checkServerTrusted(NetworkSecurityTrustManager.java:94)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at android.security.net.config.RootTrustManager.checkServerTrusted(RootTrustManager.java:88)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at java.lang.reflect.Method.invoke(Native Method)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.google.android.gms.org.conscrypt.Platform.checkTrusted(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.google.android.gms.org.conscrypt.Platform.checkServerTrusted(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.verifyCertificateChain(:com.google.android.gms@16089022@16.0.89 (040700-239467275):12)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.google.android.gms.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.google.android.gms.org.conscrypt.NativeSsl.doHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):7)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.startHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):14)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	... 25 more
+01-13 01:51:56.973  2116  2116 E ctxmgr  : Caused by: java.security.cert.CertPathValidatorException: timestamp check failed
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:133)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:222)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:140)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at sun.security.provider.certpath.PKIXCertPathValidator.engineValidate(PKIXCertPathValidator.java:79)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at java.security.cert.CertPathValidator.validate(CertPathValidator.java:301)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:703)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	... 40 more
+01-13 01:51:56.973  2116  2116 E ctxmgr  : Caused by: java.security.cert.CertificateNotYetValidException: Certificate not valid until Wed Feb 12 14:45:22 GMT+03:00 2020 (compared to Mon Jan 13 01:51:56 GMT+03:00 2020)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at com.google.android.gms.org.conscrypt.OpenSSLX509Certificate.checkValidity(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at sun.security.provider.certpath.BasicChecker.verifyTimestamp(BasicChecker.java:194)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at sun.security.provider.certpath.BasicChecker.check(BasicChecker.java:144)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:125)
+01-13 01:51:56.973  2116  2116 E ctxmgr  : 	... 45 more
+01-13 01:51:56.977  2116 18529 E ctxmgr  : [DailyCheckinOperation]Failed daily get config: network status=-1 [CONTEXT service_id=47 ]
+01-13 01:51:56.977  2116 18529 E ctxmgr  : com.android.volley.NoConnectionError: javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.volley.toolbox.BasicNetwork.performRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):46)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at rkj.performRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):13)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.volley.NetworkDispatcher.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):7)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.volley.NetworkDispatcher.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : Caused by: javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.startHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):43)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at aogy.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):20)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at aogy.createSocket(:com.google.android.gms@16089022@16.0.89 (040700-239467275):6)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.okhttp.internal.io.RealConnection.connectTls(RealConnection.java:181)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.okhttp.internal.io.RealConnection.connectSocket(RealConnection.java:149)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.okhttp.internal.io.RealConnection.connect(RealConnection.java:112)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.okhttp.internal.http.StreamAllocation.findConnection(StreamAllocation.java:184)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.okhttp.internal.http.StreamAllocation.findHealthyConnection(StreamAllocation.java:126)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.okhttp.internal.http.StreamAllocation.newStream(StreamAllocation.java:95)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:281)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:224)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:461)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.connect(HttpURLConnectionImpl.java:127)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getOutputStream(HttpURLConnectionImpl.java:258)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getOutputStream(DelegatingHttpsURLConnection.java:218)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getOutputStream(Unknown Source:0)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at abbg.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):39)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at abbg.execute(:com.google.android.gms@16089022@16.0.89 (040700-239467275):8)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at abbg.execute(:com.google.android.gms@16089022@16.0.89 (040700-239467275):7)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.volley.toolbox.HttpClientStack.performRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):10)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at rki.performRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at bry.executeRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.volley.toolbox.BasicNetwork.performRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):10)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	... 3 more
+01-13 01:51:56.977  2116 18529 E ctxmgr  : Caused by: java.security.cert.CertificateException: Chain validation failed
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:707)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:539)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:560)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:628)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:495)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:418)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.android.org.conscrypt.TrustManagerImpl.getTrustedChainForServer(TrustManagerImpl.java:339)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at android.security.net.config.NetworkSecurityTrustManager.checkServerTrusted(NetworkSecurityTrustManager.java:94)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at android.security.net.config.RootTrustManager.checkServerTrusted(RootTrustManager.java:88)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at java.lang.reflect.Method.invoke(Native Method)
+01-13 01:51:56.977  2116 18529 E ctxmgr  : 	at com.google.android.gms.org.conscrypt.Platform.checkTrusted(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	at com.google.android.gms.org.conscrypt.Platform.checkServerTrusted(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.verifyCertificateChain(:com.google.android.gms@16089022@16.0.89 (040700-239467275):12)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	at com.google.android.gms.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	at com.google.android.gms.org.conscrypt.NativeSsl.doHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):7)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.startHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):14)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	... 25 more
+01-13 01:51:56.978  2116 18529 E ctxmgr  : Caused by: java.security.cert.CertPathValidatorException: timestamp check failed
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:133)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:222)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:140)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	at sun.security.provider.certpath.PKIXCertPathValidator.engineValidate(PKIXCertPathValidator.java:79)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	at java.security.cert.CertPathValidator.validate(CertPathValidator.java:301)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:703)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	... 40 more
+01-13 01:51:56.978  2116 18529 E ctxmgr  : Caused by: java.security.cert.CertificateNotYetValidException: Certificate not valid until Wed Feb 12 14:45:22 GMT+03:00 2020 (compared to Mon Jan 13 01:51:56 GMT+03:00 2020)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	at com.google.android.gms.org.conscrypt.OpenSSLX509Certificate.checkValidity(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	at sun.security.provider.certpath.BasicChecker.verifyTimestamp(BasicChecker.java:194)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	at sun.security.provider.certpath.BasicChecker.check(BasicChecker.java:144)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:125)
+01-13 01:51:56.978  2116 18529 E ctxmgr  : 	... 45 more
+01-13 01:51:58.581  1433  1583 W audio_hw_generic: Not supplying enough data to HAL, expected position 28098532 , only wrote 27748800
+01-13 01:52:00.000  1442  1465 D hwcomposer: hw_composer sent 144 syncs in 60s
+01-13 01:52:00.022  1812  2065 D EGL_emulation: eglMakeCurrent: 0xcd6dab60: ver 2 0 (tinfo 0xcd6dcc00)
+01-13 01:52:00.849  2348  2367 E ReloadingLock: Finalizing LOCKED Token[shortcuts 2020-01-13 01:51:51.514]
+01-13 01:52:00.850  2348  2367 E ReloadingLock: Finalizing LOCKED Token[shortcuts 2020-01-13 01:51:54.471]
+01-13 01:52:00.942  2116 18734 I Places  : ?: Couldn't find platform key file.
+01-13 01:52:00.947  2116 18734 I Places  : ?: Couldn't find platform key file.
+01-13 01:52:00.962  2116 18740 I Places  : ?: PlacesBleScanner stop()
+01-13 01:52:00.963  2116  2116 I BeaconBle: Scan : No clients left, canceling alarm.
+01-13 01:52:00.964  2116  2116 I BeaconBle: Scan canceled successfully.
+01-13 01:52:00.968  2116 18740 I PlaceInferenceEngine: [anon] Changed inference mode: 0
+01-13 01:52:00.982  2116 18741 I Places  : ?: Couldn't find platform key file.
+01-13 01:52:00.983  2116 18529 I Places  : ?: Couldn't find platform key file.
+01-13 01:52:00.989  2116  2116 I GeofencerStateMachine: removeGeofences: removeRequest=RemoveGeofencingRequest[REMOVE_BY_PENDING_INTENT pendingIntent=PendingIntent[creatorPackage=com.google.android.gms], packageName=com.google.android.gms]
+01-13 01:52:03.814  2116 18669 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 01:52:03.814  2116 18669 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 01:52:04.311  2116 18752 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 01:52:04.312  2116 18752 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 01:52:05.923  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:52:05.923  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:52:05.925  2348 18754 I EventLogSendingHelper: Sending log events.
+01-13 01:52:05.972  2116  2116 I BeaconBle: Scan : No clients left, canceling alarm.
+01-13 01:52:11.049  1666 18756 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS connectivitycheck.gstatic.com 3ms OK 64.233.165.94,2a00:1450:4010:c08::5e
+01-13 01:52:11.052  1666 18755 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS www.google.com 7ms OK 64.233.162.99,2a00:1450:4010:c09::69
+01-13 01:52:11.078  1666 18756 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=28ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:13:35 GMT], X-Android-Received-Millis=[1578869531077], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869531051]}
+01-13 01:52:11.129  1666 18755 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:52:11.156  1666  2183 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_FALLBACK http://play.googleapis.com/generate_204 time=25ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:13:35 GMT], X-Android-Received-Millis=[1578869531156], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869531131]}
+01-13 01:52:11.158  1666  1775 D ConnectivityService: NetworkAgentInfo [MOBILE (LTE) - 100] validation failed
+01-13 01:52:21.003  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:52:21.003  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:52:25.488  1449  1449 I boot-pipe: done populating /dev/random
+01-13 01:52:30.934  2348 17010 W GmsLocationProvider: Error removing location updates: 16
+01-13 01:52:34.412  2116 18759 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 01:52:34.413  2116 18759 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 01:52:35.941  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:52:35.941  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:52:35.982  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:52:35.982  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:52:47.608  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 27748893 , only wrote 27748800
+01-13 01:52:50.834  1433  1583 W audio_hw_generic: Not supplying enough data to HAL, expected position 28056473 , only wrote 27903600
+01-13 01:52:54.542  2116 18763 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 01:52:54.542  2116 18763 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 01:52:54.545  2116 18763 W WakeLock: GCM_CONN_ALARM counter does not exist
+01-13 01:52:54.811  1666 18766 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS www.google.com 3ms OK 64.233.162.106,2a00:1450:4010:c09::69
+01-13 01:52:54.837  1666 18767 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS connectivitycheck.gstatic.com 28ms OK 173.194.220.94,2a00:1450:4010:c08::5e
+01-13 01:52:54.861  1666 18767 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=23ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:14:19 GMT], X-Android-Received-Millis=[1578869574861], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869574838]}
+01-13 01:52:54.871  1666 18766 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:52:54.898  1666  2854 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_FALLBACK http://www.google.com/gen_204 time=26ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Content-Type=[text/html; charset=UTF-8], Date=[Fri, 28 Feb 2020 19:14:19 GMT], Server=[gws], Set-Cookie=[1P_JAR=2020-02-28-19; expires=Sun, 29-Mar-2020 19:14:19 GMT; path=/; domain=.google.com; Secure], X-Android-Received-Millis=[1578869574898], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869574872], X-Frame-Options=[SAMEORIGIN], X-XSS-Protection=[0]}
+01-13 01:52:54.899  1666  1775 D ConnectivityService: NetworkAgentInfo [WIFI () - 101] validation failed
+01-13 01:52:54.899  1666  1771 D WifiStateMachine: NETWORK_STATUS_UNWANTED_VALIDATION_FAILED
+01-13 01:53:00.017  1442  1465 D hwcomposer: hw_composer sent 24 syncs in 60s
+01-13 01:53:06.595  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 01:53:15.227  1666 18773 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS www.google.com 3ms OK 64.233.162.103,2a00:1450:4010:c09::69
+01-13 01:53:15.229  1666 18774 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS connectivitycheck.gstatic.com 5ms OK 173.194.220.94,2a00:1450:4010:c08::5e
+01-13 01:53:15.256  1666 18774 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=25ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:14:39 GMT], X-Android-Received-Millis=[1578869595256], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869595231]}
+01-13 01:53:15.312  1666 18773 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:53:15.338  1666  2183 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_FALLBACK http://play.googleapis.com/generate_204 time=24ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:14:39 GMT], X-Android-Received-Millis=[1578869595338], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869595314]}
+01-13 01:53:15.339  1666  1775 D ConnectivityService: NetworkAgentInfo [MOBILE (LTE) - 100] validation failed
+01-13 01:53:25.490  1449  1449 I boot-pipe: done populating /dev/random
+01-13 01:53:28.691  1666  7572 D WificondControl: Scan result ready event
+01-13 01:53:31.694  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 01:53:34.680  2116 18771 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 01:53:34.681  2116 18771 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 01:53:35.067  2116 18779 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 01:53:35.067  2116 18779 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 01:54:00.011  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 01:54:11.605  1535  1596 D MDnsDS  : MDnsSdListener::Monitor poll timed out
+01-13 01:54:11.605  1535  1596 D MDnsDS  : Going to poll with pollCount 1
+01-13 01:54:15.070  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:54:15.070  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:54:25.491  1449  1449 I boot-pipe: done populating /dev/random
+01-13 01:54:35.165  2116 18785 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 01:54:35.165  2116 18785 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 01:54:55.311  2116 18789 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 01:54:55.311  2116 18789 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 01:54:55.313  2116 18789 W WakeLock: GCM_CONN_ALARM counter does not exist
+01-13 01:55:00.010  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 01:55:02.934  1666 18796 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS connectivitycheck.gstatic.com 1ms OK 173.194.220.94,2a00:1450:4010:c08::5e
+01-13 01:55:02.935  1666 18795 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS www.google.com 3ms OK 64.233.162.103,2a00:1450:4010:c09::69
+01-13 01:55:02.957  1666 18796 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=22ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:16:27 GMT], X-Android-Received-Millis=[1578869702957], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869702935]}
+01-13 01:55:02.997  1666 18795 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:55:03.025  1666  2854 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_FALLBACK http://www.google.com/gen_204 time=26ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Content-Type=[text/html; charset=UTF-8], Date=[Fri, 28 Feb 2020 19:16:27 GMT], Server=[gws], Set-Cookie=[1P_JAR=2020-02-28-19; expires=Sun, 29-Mar-2020 19:16:27 GMT; path=/; domain=.google.com; Secure], X-Android-Received-Millis=[1578869703025], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869702999], X-Frame-Options=[SAMEORIGIN], X-XSS-Protection=[0]}
+01-13 01:54:32.176  1666  1689 I chatty  : uid=1000(system) batterystats-wo identical 2 lines
+01-13 01:55:00.336  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 01:55:03.026  1666  1775 D ConnectivityService: NetworkAgentInfo [WIFI () - 101] validation failed
+01-13 01:55:03.026  1666  1771 D WifiStateMachine: NETWORK_STATUS_UNWANTED_VALIDATION_FAILED
+01-13 01:55:18.875  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 01:55:23.445  1666 18802 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS connectivitycheck.gstatic.com 3ms OK 173.194.220.94,2a00:1450:4010:c08::5e
+01-13 01:55:23.446  1666 18801 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS www.google.com 3ms OK 64.233.162.103,2a00:1450:4010:c09::69
+01-13 01:55:23.472  1666 18802 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=26ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:16:47 GMT], X-Android-Received-Millis=[1578869723472], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869723447]}
+01-13 01:55:23.516  1666 18801 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:55:23.542  1666  2183 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_FALLBACK http://play.googleapis.com/generate_204 time=24ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:16:47 GMT], X-Android-Received-Millis=[1578869723542], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869723518]}
+01-13 01:55:23.544  1666  1775 D ConnectivityService: NetworkAgentInfo [MOBILE (LTE) - 100] validation failed
+01-13 01:55:24.030  1666  1674 D         : HostConnection::get() New Host Connection established 0xcfe66440, tid 1674
+01-13 01:55:24.031  1666  1674 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:55:24.031  1666  1674 D         : HostConnection::get() New Host Connection established 0xcfe66440, tid 1674
+01-13 01:55:24.032  1666  1674 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+01-13 01:55:25.493  1449  1449 I boot-pipe: done populating /dev/random
+01-13 01:55:33.554  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 01:56:00.028  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 01:56:15.316  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:56:15.316  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:56:25.495  1449  1449 I boot-pipe: done populating /dev/random
+01-13 01:56:35.470  2116 18810 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 01:56:35.471  2116 18810 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 01:56:50.405 18819 18819 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+01-13 01:55:49.962  1666  1689 I chatty  : uid=1000(system) batterystats-wo identical 1 line
+01-13 01:56:22.034  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 01:56:50.408  1666  7771 I ActivityManager: Start proc 18819:com.google.android.apps.photos/u0a70 for service com.google.android.apps.photos/com.google.android.libraries.social.notifications.scheduled.GunsScheduledTaskService
+01-13 01:56:50.423 18819 18826 E zygote  : Failed sending reply to debugger: Broken pipe
+01-13 01:56:50.423 18819 18826 I zygote  : Debugger is no longer active
+01-13 01:56:50.443 18819 18819 I zygote  : The ClassLoaderContext is a special shared library.
+01-13 01:56:50.484 18819 18824 I zygote  : Do partial code cache collection, code=0B, data=15KB
+01-13 01:56:50.485 18819 18824 I zygote  : After code cache collection, code=0B, data=15KB
+01-13 01:56:50.485 18819 18824 I zygote  : Increasing code cache capacity to 128KB
+01-13 01:56:50.914 18840 18840 D AndroidRuntime: >>>>>> START com.android.internal.os.RuntimeInit uid 2000 <<<<<<
+01-13 01:56:50.926  1666  7777 W AlarmManager: Window length 3074457345618258602ms suspiciously long; limiting to 1 hour
+01-13 01:56:51.010 18840 18840 W app_process: Unexpected CPU variant for X86 using defaults: x86
+01-13 01:56:51.012 18840 18840 I app_process: The ClassLoaderContext is a special shared library.
+01-13 01:56:51.055 18840 18840 D AndroidRuntime: Calling main entry com.android.commands.pm.Pm
+01-13 01:56:51.064 18840 18840 I app_process: System.exit called, status: 0
+01-13 01:56:51.064 18840 18840 I AndroidRuntime: VM exiting with result code 0.
+01-13 01:56:51.521 18856 18856 D AndroidRuntime: >>>>>> START com.android.internal.os.RuntimeInit uid 2000 <<<<<<
+01-13 01:56:51.615 18856 18856 W app_process: Unexpected CPU variant for X86 using defaults: x86
+01-13 01:56:51.617 18856 18856 I app_process: The ClassLoaderContext is a special shared library.
+01-13 01:56:51.661 18856 18856 D AndroidRuntime: Calling main entry com.android.commands.pm.Pm
+01-13 01:56:51.665 18856 18864 W MessageQueue: Handler (android.os.Handler) {e748802} sending message to a Handler on a dead thread
+01-13 01:56:51.665 18856 18864 W MessageQueue: java.lang.IllegalStateException: Handler (android.os.Handler) {e748802} sending message to a Handler on a dead thread
+01-13 01:56:51.665 18856 18864 W MessageQueue: 	at android.os.MessageQueue.enqueueMessage(MessageQueue.java:545)
+01-13 01:56:51.665 18856 18864 W MessageQueue: 	at android.os.Handler.enqueueMessage(Handler.java:662)
+01-13 01:56:51.665 18856 18864 W MessageQueue: 	at android.os.Handler.sendMessageAtTime(Handler.java:631)
+01-13 01:56:51.665 18856 18864 W MessageQueue: 	at android.os.Handler.sendMessageDelayed(Handler.java:601)
+01-13 01:56:51.665 18856 18864 W MessageQueue: 	at android.os.Handler.post(Handler.java:357)
+01-13 01:56:51.665 18856 18864 W MessageQueue: 	at android.os.ResultReceiver$MyResultReceiver.send(ResultReceiver.java:57)
+01-13 01:56:51.665 18856 18864 W MessageQueue: 	at com.android.internal.os.IResultReceiver$Stub.onTransact(IResultReceiver.java:58)
+01-13 01:56:51.665 18856 18864 W MessageQueue: 	at android.os.Binder.execTransact(Binder.java:697)
+01-13 01:56:51.666 18856 18856 I app_process: System.exit called, status: 0
+01-13 01:56:51.666 18856 18856 I AndroidRuntime: VM exiting with result code 0.
+01-13 01:56:53.361  1666  7777 D WificondControl: Scan result ready event
+01-13 01:56:56.223  2116 18816 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 01:56:56.224  2116 18816 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 01:56:56.226  2116 18816 W WakeLock: GCM_CONN_ALARM counter does not exist
+01-13 01:57:00.026  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 01:57:00.255  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 01:57:06.272  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 01:57:06.273  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 01:57:06.273  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 01:57:08.412  2116 18528 W NetworkScheduler.TED: Enforcing binder timeout for ComponentInfo{com.google.android.apps.photos/com.google.android.libraries.social.notifications.scheduled.GunsScheduledTaskService}
+01-13 01:57:08.413  2116 18528 E NetworkScheduler.TED: Dropping task as app's play services SDK version does not support Android O. Either update the SDK or lower your app's target SDK version. Canceling all tasks for the service: ComponentInfo{com.google.android.apps.photos/com.google.android.libraries.social.notifications.scheduled.GunsScheduledTaskService}
+01-13 01:57:08.423  2116 18741 E NetworkScheduler: Unknown result code received: 4
+01-13 01:57:08.424  2116  2116 E NetworkScheduler.ATC: Called cancelTask for already completed task com.google.android.apps.photos/com.google.android.libraries.social.notifications.scheduled.GunsScheduledTaskService{u=0 tag="scheduled_sync_reg_status" trigger=window{start=0s,end=30s,earliest=-93s,latest=-63s} requirements=[NET_CONNECTED] attributes=[PERSISTED] scheduled=-93s last_run=-18s jid=N/A status=PENDING retries=14 client_lib=MANCHEGO_GCM-10400000} :INVALID_START
+01-13 01:57:20.593  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 01:57:20.593  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 01:57:20.593  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 01:57:25.497  1449  1449 I boot-pipe: done populating /dev/random
+01-13 01:57:50.390  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:57:50.390  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:57:50.418  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:57:50.418  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:58:00.021  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 01:58:25.498  1449  1449 I boot-pipe: done populating /dev/random
+01-13 01:58:25.752  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 01:58:25.752  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 01:58:25.753  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 01:58:35.793  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 01:58:35.793  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 01:58:35.793  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 01:59:00.003  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 01:59:00.003  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 01:59:00.027  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 01:59:19.118  1666 18888 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS www.google.com 31ms OK 173.194.73.104,2a00:1450:4010:c0b::68
+01-13 01:59:19.148  1666 18889 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS connectivitycheck.gstatic.com 60ms OK 64.233.165.94,2a00:1450:4010:c08::5e
+01-13 01:59:19.183  1666 18888 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:59:19.200  1666 18889 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=52ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:20:43 GMT], X-Android-Received-Millis=[1578869959200], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869959176]}
+01-13 01:59:19.251  1666  2854 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_FALLBACK http://www.google.com/gen_204 time=50ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Content-Type=[text/html; charset=UTF-8], Date=[Fri, 28 Feb 2020 19:20:43 GMT], Server=[gws], Set-Cookie=[1P_JAR=2020-02-28-19; expires=Sun, 29-Mar-2020 19:20:43 GMT; path=/; domain=.google.com; Secure], X-Android-Received-Millis=[1578869959251], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869959225], X-Frame-Options=[SAMEORIGIN], X-XSS-Protection=[0]}
+01-13 01:58:52.835  1666  1689 I chatty  : uid=1000(system) batterystats-wo identical 4 lines
+01-13 01:59:11.955  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 01:59:19.252  1666  1775 D ConnectivityService: NetworkAgentInfo [WIFI () - 101] validation failed
+01-13 01:59:19.252  1666  1771 D WifiStateMachine: NETWORK_STATUS_UNWANTED_VALIDATION_FAILED
+01-13 01:59:25.499  1449  1449 I boot-pipe: done populating /dev/random
+01-13 01:59:33.342  1666  7572 D WificondControl: Scan result ready event
+01-13 01:59:36.035  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 01:59:39.675  1666 18898 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS connectivitycheck.gstatic.com 31ms OK 64.233.165.94,2a00:1450:4010:c08::5e
+01-13 01:59:39.685  1666 18897 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS www.google.com 40ms OK 173.194.220.106,2a00:1450:4010:c0b::68
+01-13 01:59:39.726  1666 18898 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=50ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:21:04 GMT], X-Android-Received-Millis=[1578869979726], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869979702]}
+01-13 01:59:39.745  1666 18897 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 01:59:39.799  1666  2183 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_FALLBACK http://www.google.com/gen_204 time=52ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Content-Type=[text/html; charset=UTF-8], Date=[Fri, 28 Feb 2020 19:21:04 GMT], Server=[gws], Set-Cookie=[1P_JAR=2020-02-28-19; expires=Sun, 29-Mar-2020 19:21:04 GMT; path=/; domain=.google.com; Secure], X-Android-Received-Millis=[1578869979799], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578869979771], X-Frame-Options=[SAMEORIGIN], X-XSS-Protection=[0]}
+01-13 01:59:39.800  1666  1775 D ConnectivityService: NetworkAgentInfo [MOBILE (LTE) - 100] validation failed
+01-13 01:59:56.321  2116 18895 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 01:59:56.321  2116 18895 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 02:00:00.008  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:00:16.438  2116 18902 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 02:00:16.438  2116 18902 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 02:00:16.439  2116 18902 W WakeLock: GCM_CONN_ALARM counter does not exist
+01-13 02:00:21.474  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:00:25.501  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:01:00.006  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:01:00.006  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:01:00.021  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:01:00.059  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:01:00.059  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:01:00.100  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:01:00.100  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:01:00.141  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:01:00.141  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:01:00.174  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:01:00.174  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:01:25.503  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:01:48.592  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:01:48.592  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:01:48.592  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:01:49.473  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:01:49.473  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:01:49.473  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:02:00.014  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:02:13.341  1666  7777 D WificondControl: Scan result ready event
+01-13 02:02:14.512  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:02:14.512  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:02:14.512  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:02:21.552  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:02:21.552  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:02:21.552  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:02:25.505  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:02:58.992  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:02:58.992  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:02:58.992  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:03:00.002  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:03:00.002  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:03:00.008  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:03:00.061  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:03:00.061  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:03:00.096  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:03:00.096  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:03:00.128  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:03:00.128  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:03:19.216  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:03:19.216  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:03:19.216  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:03:25.507  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:04:00.031  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:04:05.059  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:04:05.059  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:04:05.059  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:04:05.067  1666  1689 E BluetoothAdapter: Bluetooth binder is null
+01-13 02:03:38.015  1666  1689 I chatty  : uid=1000(system) batterystats-wo identical 6 lines
+01-13 02:03:53.045  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:04:05.079  1666  1689 E KernelCpuSpeedReader: Failed to read cpu-freq: /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state (No such file or directory)
+01-13 02:04:05.085  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:04:25.509  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:04:59.072  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:04:59.072  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:04:59.072  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:05:00.006  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:05:00.006  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:05:00.014  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:05:07.364  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:05:07.364  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:05:07.364  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:05:21.467  1666  1768 D RecurrenceRule: Resolving using anchor 2020-01-13T02:05:21.467+03:00[Europe/Moscow]
+01-13 02:05:21.469  1666  1768 D RecurrenceRule: Resolving using anchor 2020-01-13T02:05:21.469+03:00[Europe/Moscow]
+01-13 02:05:21.471  1666  1768 D RecurrenceRule: Cycle 12 from 2020-01-13T00:00+03:00[Europe/Moscow] to 2020-02-13T00:00+03:00[Europe/Moscow]
+01-13 02:04:24.280  1666  1689 I chatty  : uid=1000(system) batterystats-wo identical 2 lines
+01-13 02:04:49.834  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:05:21.471  1666  1768 D NetworkStats: Resolving plan for NetworkTemplate: matchRule=MOBILE_ALL, subscriberId=310260..., matchSubscriberIds=[310260...]
+01-13 02:05:21.473  1666  1768 D NetworkStats: Found active matching subId 1
+01-13 02:05:21.479  1666  1768 D NetworkStats: Resolved to plan null
+01-13 02:05:21.582  2187 15992 I EventLogChimeraService: Aggregate from 1578868521210 (log), 1578868521210 (data)
+01-13 02:05:21.785  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.stats.service.DropBoxEntryAddedReceiver
+01-13 02:05:21.786  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+01-13 02:05:22.271  2116 18528 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+01-13 02:05:22.272  2116 18528 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:05:22.272  2116 18528 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:05:22.330  2116 18528 E Uploader: Clearcut transport failed to make network request.
+01-13 02:05:22.330  2116 18528 E Uploader: javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.startHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):43)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at aogy.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):20)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at aogy.createSocket(:com.google.android.gms@16089022@16.0.89 (040700-239467275):6)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.okhttp.internal.io.RealConnection.connectTls(RealConnection.java:181)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.okhttp.internal.io.RealConnection.connectSocket(RealConnection.java:149)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.okhttp.internal.io.RealConnection.connect(RealConnection.java:112)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.okhttp.internal.http.StreamAllocation.findConnection(StreamAllocation.java:184)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.okhttp.internal.http.StreamAllocation.findHealthyConnection(StreamAllocation.java:126)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.okhttp.internal.http.StreamAllocation.newStream(StreamAllocation.java:95)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:281)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:224)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:461)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.connect(HttpURLConnectionImpl.java:127)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getOutputStream(HttpURLConnectionImpl.java:258)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getOutputStream(DelegatingHttpsURLConnection.java:218)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getOutputStream(Unknown Source:0)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at abbg.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):39)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at abbg.execute(:com.google.android.gms@16089022@16.0.89 (040700-239467275):8)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at abbg.execute(:com.google.android.gms@16089022@16.0.89 (040700-239467275):7)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at qfx.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):11)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at qfx.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):54)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at qgn.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):213)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at qgn.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):291)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.google.android.gms.clearcut.uploader.QosUploaderChimeraService.d(:com.google.android.gms@16089022@16.0.89 (040700-239467275):28)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.google.android.gms.clearcut.uploader.QosUploaderChimeraService.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):14)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.google.android.gms.clearcut.uploader.QosUploaderChimeraService.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):6)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at zse.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):5)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at rrt.b(:com.google.android.gms@16089022@16.0.89 (040700-239467275):32)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at rrt.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):21)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at rxx.run(Unknown Source:7)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at java.lang.Thread.run(Thread.java:764)
+01-13 02:05:22.330  2116 18528 E Uploader: Caused by: java.security.cert.CertificateException: Chain validation failed
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:707)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:539)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:560)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:628)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:495)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:418)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at com.android.org.conscrypt.TrustManagerImpl.getTrustedChainForServer(TrustManagerImpl.java:339)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at android.security.net.config.NetworkSecurityTrustManager.checkServerTrusted(NetworkSecurityTrustManager.java:94)
+01-13 02:05:22.330  2116 18528 E Uploader: 	at android.security.net.config.RootTrustManager.checkServerTrusted(RootTrustManager.java:88)
+01-13 02:05:22.331  2116 18528 E Uploader: 	at java.lang.reflect.Method.invoke(Native Method)
+01-13 02:05:22.331  2116 18528 E Uploader: 	at com.google.android.gms.org.conscrypt.Platform.checkTrusted(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:05:22.331  2116 18528 E Uploader: 	at com.google.android.gms.org.conscrypt.Platform.checkServerTrusted(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+01-13 02:05:22.331  2116 18528 E Uploader: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.verifyCertificateChain(:com.google.android.gms@16089022@16.0.89 (040700-239467275):12)
+01-13 02:05:22.331  2116 18528 E Uploader: 	at com.google.android.gms.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method)
+01-13 02:05:22.331  2116 18528 E Uploader: 	at com.google.android.gms.org.conscrypt.NativeSsl.doHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):7)
+01-13 02:05:22.331  2116 18528 E Uploader: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.startHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):14)
+01-13 02:05:22.331  2116 18528 E Uploader: 	... 32 more
+01-13 02:05:22.331  2116 18528 E Uploader: Caused by: java.security.cert.CertPathValidatorException: timestamp check failed
+01-13 02:05:22.331  2116 18528 E Uploader: 	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:133)
+01-13 02:05:22.331  2116 18528 E Uploader: 	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:222)
+01-13 02:05:22.331  2116 18528 E Uploader: 	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:140)
+01-13 02:05:22.331  2116 18528 E Uploader: 	at sun.security.provider.certpath.PKIXCertPathValidator.engineValidate(PKIXCertPathValidator.java:79)
+01-13 02:05:22.331  2116 18528 E Uploader: 	at java.security.cert.CertPathValidator.validate(CertPathValidator.java:301)
+01-13 02:05:22.331  2116 18528 E Uploader: 	at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:703)
+01-13 02:05:22.331  2116 18528 E Uploader: 	... 47 more
+01-13 02:05:22.331  2116 18528 E Uploader: Caused by: java.security.cert.CertificateNotYetValidException: Certificate not valid until Wed Feb 12 14:45:22 GMT+03:00 2020 (compared to Mon Jan 13 02:05:22 GMT+03:00 2020)
+01-13 02:05:22.331  2116 18528 E Uploader: 	at com.google.android.gms.org.conscrypt.OpenSSLX509Certificate.checkValidity(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:05:22.331  2116 18528 E Uploader: 	at sun.security.provider.certpath.BasicChecker.verifyTimestamp(BasicChecker.java:194)
+01-13 02:05:22.331  2116 18528 E Uploader: 	at sun.security.provider.certpath.BasicChecker.check(BasicChecker.java:144)
+01-13 02:05:22.331  2116 18528 E Uploader: 	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:125)
+01-13 02:05:22.331  2116 18528 E Uploader: 	... 52 more
+01-13 02:05:22.391  2116 18741 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+01-13 02:05:22.392  2116 18741 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:05:22.392  2116 18741 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:05:22.435  2116 18741 W allj    : Sync failed for '' [CONTEXT service_id=51 ]
+01-13 02:05:22.435  2116 18741 W allj    : alif: 29504: Network error
+01-13 02:05:22.435  2116 18741 W allj    : 	at allj.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):202)
+01-13 02:05:22.435  2116 18741 W allj    : 	at allj.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):131)
+01-13 02:05:22.435  2116 18741 W allj    : 	at allj.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):324)
+01-13 02:05:22.435  2116 18741 W allj    : 	at allj.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):323)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.google.android.gms.phenotype.sync.HeterodyneSyncTaskChimeraService.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.google.android.gms.phenotype.sync.HeterodyneSyncTaskChimeraService.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):11)
+01-13 02:05:22.435  2116 18741 W allj    : 	at zse.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):5)
+01-13 02:05:22.435  2116 18741 W allj    : 	at rrt.b(:com.google.android.gms@16089022@16.0.89 (040700-239467275):32)
+01-13 02:05:22.435  2116 18741 W allj    : 	at rrt.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):21)
+01-13 02:05:22.435  2116 18741 W allj    : 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+01-13 02:05:22.435  2116 18741 W allj    : 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+01-13 02:05:22.435  2116 18741 W allj    : 	at rxx.run(Unknown Source:7)
+01-13 02:05:22.435  2116 18741 W allj    : 	at java.lang.Thread.run(Thread.java:764)
+01-13 02:05:22.435  2116 18741 W allj    : Caused by: javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.startHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):43)
+01-13 02:05:22.435  2116 18741 W allj    : 	at aogy.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):20)
+01-13 02:05:22.435  2116 18741 W allj    : 	at aogy.createSocket(:com.google.android.gms@16089022@16.0.89 (040700-239467275):6)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.okhttp.internal.io.RealConnection.connectTls(RealConnection.java:181)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.okhttp.internal.io.RealConnection.connectSocket(RealConnection.java:149)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.okhttp.internal.io.RealConnection.connect(RealConnection.java:112)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.okhttp.internal.http.StreamAllocation.findConnection(StreamAllocation.java:184)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.okhttp.internal.http.StreamAllocation.findHealthyConnection(StreamAllocation.java:126)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.okhttp.internal.http.StreamAllocation.newStream(StreamAllocation.java:95)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:281)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:224)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:461)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.connect(HttpURLConnectionImpl.java:127)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getOutputStream(HttpURLConnectionImpl.java:258)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getOutputStream(DelegatingHttpsURLConnection.java:218)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getOutputStream(Unknown Source:0)
+01-13 02:05:22.435  2116 18741 W allj    : 	at abbg.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):39)
+01-13 02:05:22.435  2116 18741 W allj    : 	at abbg.execute(:com.google.android.gms@16089022@16.0.89 (040700-239467275):8)
+01-13 02:05:22.435  2116 18741 W allj    : 	at abbg.execute(:com.google.android.gms@16089022@16.0.89 (040700-239467275):7)
+01-13 02:05:22.435  2116 18741 W allj    : 	at allr.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):37)
+01-13 02:05:22.435  2116 18741 W allj    : 	at allj.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):306)
+01-13 02:05:22.435  2116 18741 W allj    : 	at allj.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):188)
+01-13 02:05:22.435  2116 18741 W allj    : 	... 12 more
+01-13 02:05:22.435  2116 18741 W allj    : Caused by: java.security.cert.CertificateException: Chain validation failed
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:707)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:539)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:560)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:628)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:495)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:418)
+01-13 02:05:22.435  2116 18741 W allj    : 	at com.android.org.conscrypt.TrustManagerImpl.getTrustedChainForServer(TrustManagerImpl.java:339)
+01-13 02:05:22.436  2116 18741 W allj    : 	at android.security.net.config.NetworkSecurityTrustManager.checkServerTrusted(NetworkSecurityTrustManager.java:94)
+01-13 02:05:22.436  2116 18741 W allj    : 	at android.security.net.config.RootTrustManager.checkServerTrusted(RootTrustManager.java:88)
+01-13 02:05:22.436  2116 18741 W allj    : 	at java.lang.reflect.Method.invoke(Native Method)
+01-13 02:05:22.436  2116 18741 W allj    : 	at com.google.android.gms.org.conscrypt.Platform.checkTrusted(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:05:22.436  2116 18741 W allj    : 	at com.google.android.gms.org.conscrypt.Platform.checkServerTrusted(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+01-13 02:05:22.436  2116 18741 W allj    : 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.verifyCertificateChain(:com.google.android.gms@16089022@16.0.89 (040700-239467275):12)
+01-13 02:05:22.436  2116 18741 W allj    : 	at com.google.android.gms.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method)
+01-13 02:05:22.436  2116 18741 W allj    : 	at com.google.android.gms.org.conscrypt.NativeSsl.doHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):7)
+01-13 02:05:22.436  2116 18741 W allj    : 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.startHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):14)
+01-13 02:05:22.436  2116 18741 W allj    : 	... 33 more
+01-13 02:05:22.436  2116 18741 W allj    : Caused by: java.security.cert.CertPathValidatorException: timestamp check failed
+01-13 02:05:22.436  2116 18741 W allj    : 	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:133)
+01-13 02:05:22.436  2116 18741 W allj    : 	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:222)
+01-13 02:05:22.436  2116 18741 W allj    : 	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:140)
+01-13 02:05:22.436  2116 18741 W allj    : 	at sun.security.provider.certpath.PKIXCertPathValidator.engineValidate(PKIXCertPathValidator.java:79)
+01-13 02:05:22.436  2116 18741 W allj    : 	at java.security.cert.CertPathValidator.validate(CertPathValidator.java:301)
+01-13 02:05:22.436  2116 18741 W allj    : 	at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:703)
+01-13 02:05:22.436  2116 18741 W allj    : 	... 48 more
+01-13 02:05:22.436  2116 18741 W allj    : Caused by: java.security.cert.CertificateNotYetValidException: Certificate not valid until Wed Feb 12 14:45:22 GMT+03:00 2020 (compared to Mon Jan 13 02:05:22 GMT+03:00 2020)
+01-13 02:05:22.436  2116 18741 W allj    : 	at com.google.android.gms.org.conscrypt.OpenSSLX509Certificate.checkValidity(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:05:22.436  2116 18741 W allj    : 	at sun.security.provider.certpath.BasicChecker.verifyTimestamp(BasicChecker.java:194)
+01-13 02:05:22.436  2116 18741 W allj    : 	at sun.security.provider.certpath.BasicChecker.check(BasicChecker.java:144)
+01-13 02:05:22.436  2116 18741 W allj    : 	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:125)
+01-13 02:05:22.436  2116 18741 W allj    : 	... 53 more
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: Sync task failure [CONTEXT service_id=51 ]
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: alif: 29504: Network error
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at allj.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):202)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at allj.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):131)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at allj.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):324)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at allj.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):323)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.google.android.gms.phenotype.sync.HeterodyneSyncTaskChimeraService.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.google.android.gms.phenotype.sync.HeterodyneSyncTaskChimeraService.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):11)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at zse.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):5)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at rrt.b(:com.google.android.gms@16089022@16.0.89 (040700-239467275):32)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at rrt.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):21)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at rxx.run(Unknown Source:7)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at java.lang.Thread.run(Thread.java:764)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: Caused by: javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.startHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):43)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at aogy.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):20)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at aogy.createSocket(:com.google.android.gms@16089022@16.0.89 (040700-239467275):6)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.okhttp.internal.io.RealConnection.connectTls(RealConnection.java:181)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.okhttp.internal.io.RealConnection.connectSocket(RealConnection.java:149)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.okhttp.internal.io.RealConnection.connect(RealConnection.java:112)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.okhttp.internal.http.StreamAllocation.findConnection(StreamAllocation.java:184)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.okhttp.internal.http.StreamAllocation.findHealthyConnection(StreamAllocation.java:126)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.okhttp.internal.http.StreamAllocation.newStream(StreamAllocation.java:95)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:281)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:224)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:461)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.connect(HttpURLConnectionImpl.java:127)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getOutputStream(HttpURLConnectionImpl.java:258)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getOutputStream(DelegatingHttpsURLConnection.java:218)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getOutputStream(Unknown Source:0)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at abbg.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):39)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at abbg.execute(:com.google.android.gms@16089022@16.0.89 (040700-239467275):8)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at abbg.execute(:com.google.android.gms@16089022@16.0.89 (040700-239467275):7)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at allr.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):37)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at allj.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):306)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at allj.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):188)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	... 12 more
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: Caused by: java.security.cert.CertificateException: Chain validation failed
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:707)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:539)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:560)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:628)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:495)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:418)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.org.conscrypt.TrustManagerImpl.getTrustedChainForServer(TrustManagerImpl.java:339)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at android.security.net.config.NetworkSecurityTrustManager.checkServerTrusted(NetworkSecurityTrustManager.java:94)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at android.security.net.config.RootTrustManager.checkServerTrusted(RootTrustManager.java:88)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at java.lang.reflect.Method.invoke(Native Method)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.google.android.gms.org.conscrypt.Platform.checkTrusted(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.google.android.gms.org.conscrypt.Platform.checkServerTrusted(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.verifyCertificateChain(:com.google.android.gms@16089022@16.0.89 (040700-239467275):12)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.google.android.gms.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.google.android.gms.org.conscrypt.NativeSsl.doHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):7)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.startHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):14)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	... 33 more
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: Caused by: java.security.cert.CertPathValidatorException: timestamp check failed
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:133)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:222)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:140)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at sun.security.provider.certpath.PKIXCertPathValidator.engineValidate(PKIXCertPathValidator.java:79)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at java.security.cert.CertPathValidator.validate(CertPathValidator.java:301)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:703)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	... 48 more
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: Caused by: java.security.cert.CertificateNotYetValidException: Certificate not valid until Wed Feb 12 14:45:22 GMT+03:00 2020 (compared to Mon Jan 13 02:05:22 GMT+03:00 2020)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at com.google.android.gms.org.conscrypt.OpenSSLX509Certificate.checkValidity(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at sun.security.provider.certpath.BasicChecker.verifyTimestamp(BasicChecker.java:194)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at sun.security.provider.certpath.BasicChecker.check(BasicChecker.java:144)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:125)
+01-13 02:05:22.643  2116 18741 E HeterodyneSyncTaskChime: 	... 53 more
+01-13 02:05:22.670  2116 18741 I aljh    : updateFromConfigurations using legacy put method [CONTEXT service_id=51 ]
+01-13 02:05:22.692  2116 18741 I aljh    : updateFromConfigurations using legacy put method [CONTEXT service_id=51 ]
+01-13 02:05:22.700  2116 18741 I alle    : Scheduling adaptive one off task with window [14400, 604800] in seconds [CONTEXT service_id=51 ]
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: Retrieving snapshot for com.google.android.gms.phenotype failed
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: java.lang.InterruptedException
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedNanos(AbstractQueuedSynchronizer.java:1063)
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at java.util.concurrent.locks.AbstractQueuedSynchronizer.tryAcquireSharedNanos(AbstractQueuedSynchronizer.java:1352)
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:278)
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at asip.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):27)
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at alhm.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at alhm.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):19)
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at alhm.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):29)
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at alim.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):6)
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at com.google.android.gms.phenotype.sync.HeterodyneSyncTaskChimeraService.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at com.google.android.gms.phenotype.sync.HeterodyneSyncTaskChimeraService.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):11)
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at zse.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):5)
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at rrt.b(:com.google.android.gms@16089022@16.0.89 (040700-239467275):32)
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at rrt.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):21)
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at rxx.run(Unknown Source:7)
+01-13 02:05:22.715  2116 18741 E PhenotypeFlagCommitter: 	at java.lang.Thread.run(Thread.java:764)
+01-13 02:05:24.431  1666  7777 D WificondControl: Scan result ready event
+01-13 02:05:24.454  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:05:25.510  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:05:56.561  2116 18957 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 02:05:56.562  2116 18957 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 02:05:56.965  2116 18961 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 02:05:56.965  2116 18961 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 02:06:00.003  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:06:00.003  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:06:00.019  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:06:00.052  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:06:00.052  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:06:00.085  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:06:00.085  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:06:25.512  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:05:53.576  1666  1689 I chatty  : uid=1000(system) batterystats-wo identical 1 line
+01-13 02:06:27.634  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:06:35.839  1666  1685 I UsageStatsService: User[0] Flushing usage stats to disk
+01-13 02:06:45.632  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:06:45.632  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:06:45.633  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:06:50.821  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:06:50.821  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:06:50.821  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:07:00.008  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:07:00.008  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:07:00.011  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:07:07.915  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:07:20.953  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:07:20.953  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:07:20.953  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:07:21.953  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:07:21.953  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:07:21.953  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:07:25.514  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:07:46.992  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:07:46.992  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:07:46.992  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:07:51.311  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:07:51.311  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:07:51.311  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:07:51.338  1666 18977 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS connectivitycheck.gstatic.com 29ms OK 64.233.165.94,2a00:1450:4010:c01::5e
+01-13 02:07:51.339  1666 18976 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS www.google.com 30ms OK 173.194.222.103,2a00:1450:4010:c02::69
+01-13 02:07:51.387  1666 18977 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=48ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:29:15 GMT], X-Android-Received-Millis=[1578870471386], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578870471363]}
+01-13 02:07:51.399  1666 18976 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 02:07:51.449  1666  2854 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_FALLBACK http://www.google.com/gen_204 time=49ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Content-Type=[text/html; charset=UTF-8], Date=[Fri, 28 Feb 2020 19:29:15 GMT], Server=[gws], Set-Cookie=[1P_JAR=2020-02-28-19; expires=Sun, 29-Mar-2020 19:29:15 GMT; path=/; domain=.google.com; Secure], X-Android-Received-Millis=[1578870471448], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578870471423], X-Frame-Options=[SAMEORIGIN], X-XSS-Protection=[0]}
+01-13 02:07:38.994  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:07:51.449  1666  1775 D ConnectivityService: NetworkAgentInfo [WIFI () - 101] validation failed
+01-13 02:07:51.450  1666  1771 D WifiStateMachine: NETWORK_STATUS_UNWANTED_VALIDATION_FAILED
+01-13 02:08:00.002  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:08:00.002  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:08:00.023  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:08:04.422  1666  7770 D WificondControl: Scan result ready event
+01-13 02:08:11.075  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:08:11.907  1666 18987 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS connectivitycheck.gstatic.com 6ms OK 64.233.165.94,2a00:1450:4010:c01::5e
+01-13 02:08:11.909  1666 18986 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS www.google.com 8ms OK 173.194.222.103,2a00:1450:4010:c02::69
+01-13 02:08:11.957  1666 18987 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=49ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:29:36 GMT], X-Android-Received-Millis=[1578870491957], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578870491933]}
+01-13 02:08:11.968  1666 18986 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 02:08:12.023  1666  2183 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_FALLBACK http://www.google.com/gen_204 time=52ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Content-Type=[text/html; charset=UTF-8], Date=[Fri, 28 Feb 2020 19:29:36 GMT], Server=[gws], Set-Cookie=[1P_JAR=2020-02-28-19; expires=Sun, 29-Mar-2020 19:29:36 GMT; path=/; domain=.google.com; Secure], X-Android-Received-Millis=[1578870492022], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578870491995], X-Frame-Options=[SAMEORIGIN], X-XSS-Protection=[0]}
+01-13 02:08:12.023  1666  1775 D ConnectivityService: NetworkAgentInfo [MOBILE (LTE) - 100] validation failed
+01-13 02:08:22.035  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:08:25.515  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:08:29.275  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:08:29.275  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:08:29.275  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:08:50.192  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:08:50.192  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:08:50.192  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:09:00.009  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:09:00.009  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:09:00.016  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:09:20.312  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:09:20.312  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:09:20.312  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:09:21.311  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:09:21.311  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:09:21.311  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:09:25.518  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:09:46.353  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:09:46.353  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:09:46.353  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:09:53.392  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:09:53.392  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:09:53.392  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:10:00.002  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:10:00.002  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:10:00.027  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:10:00.037  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:10:00.037  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:10:25.518  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:10:28.313  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:10:28.313  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:10:28.313  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:10:41.839  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:10:41.839  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:10:41.839  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:10:44.432  1666  7777 D WificondControl: Scan result ready event
+01-13 02:11:00.010  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:11:00.010  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:11:00.020  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:11:25.520  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:11:37.992  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:11:37.993  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:11:37.993  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:11:44.992  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:11:44.992  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:11:44.992  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:12:00.008  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:12:20.032  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:12:20.032  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:12:20.032  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:12:22.534  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:12:22.534  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:12:22.534  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:12:25.522  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:12:32.297  2249  2259 I zygote  : Debugger is no longer active
+01-13 02:12:32.297  2116  2124 I zygote  : Debugger is no longer active
+01-13 02:12:32.297  2374  2384 I zygote  : Debugger is no longer active
+01-13 02:12:32.297  1812  1817 I zygote  : Debugger is no longer active
+01-13 02:12:32.297  1666  1672 I zygote  : Debugger is no longer active
+01-13 02:12:32.298  5069  5076 I zygote  : Debugger is no longer active
+01-13 02:12:32.298  4070  4077 I zygote  : Debugger is no longer active
+01-13 02:12:32.298  2155  2166 I zygote  : Debugger is no longer active
+01-13 02:12:32.298 17932 17939 I zygote  : Debugger is no longer active
+01-13 02:12:32.298  1797  1804 I zygote  : Debugger is no longer active
+01-13 02:12:32.298 18819 18826 I zygote  : Debugger is no longer active
+01-13 02:12:32.298  2348  2365 I zygote  : Debugger is no longer active
+01-13 02:12:32.298  2187  2195 I zygote  : Debugger is no longer active
+01-13 02:12:32.298 18683 18690 I zygote  : Debugger is no longer active
+01-13 02:12:32.299 17666 17673 I zygote  : Debugger is no longer active
+01-13 02:12:32.299 17969 17979 I zygote  : Debugger is no longer active
+01-13 02:12:32.299  2271  2279 I zygote  : Debugger is no longer active
+01-13 02:12:32.299 17696 17703 I zygote  : Debugger is no longer active
+01-13 02:12:32.299  1879  1888 I zygote  : Debugger is no longer active
+01-13 02:13:00.012  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:13:00.012  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:13:00.016  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:13:18.753  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:13:18.753  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:13:18.753  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:13:24.432  1666  7776 D WificondControl: Scan result ready event
+01-13 02:13:25.524  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:13:25.792  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:13:25.793  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:13:25.793  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:14:00.014  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:14:00.993  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:14:00.993  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:14:00.993  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:14:11.406  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:14:11.406  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:14:11.407  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:14:25.526  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:15:00.013  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:15:00.013  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:15:00.034  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:15:07.552  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:15:07.552  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:15:07.552  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:15:14.591  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:15:14.591  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:15:14.591  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:15:25.527  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:15:49.672  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:15:49.672  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:15:49.672  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:16:00.011  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:16:01.461  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:16:01.461  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:16:01.501  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:16:01.502  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:16:01.542  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:16:01.542  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:16:01.572  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:16:01.572  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:16:04.432  1666  7772 D WificondControl: Scan result ready event
+01-13 02:16:25.529  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:16:35.108  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:16:35.108  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:16:35.108  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:14:59.563  1666  1689 I chatty  : uid=1000(system) batterystats-wo identical 16 lines
+01-13 02:15:32.154  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:16:52.219  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:16:57.115  2116 19219 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 02:16:57.115  2116 19219 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 02:17:00.014  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:17:00.014  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:17:00.020  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:17:17.257  2116 19223 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 02:17:17.258  2116 19223 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 02:17:17.259  2116 19223 W WakeLock: GCM_CONN_ALARM counter does not exist
+01-13 02:17:25.531  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:17:31.312  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:17:31.312  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:17:31.312  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:17:38.351  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:17:38.351  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:17:38.351  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:17:51.545  1666 19232 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS www.google.com 58ms OK 64.233.162.103,2a00:1450:4010:c0d::6a
+01-13 02:17:51.545  1666 19233 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS connectivitycheck.gstatic.com 57ms OK 108.177.14.94,2a00:1450:4010:c08::5e
+01-13 02:17:51.596  1666 19233 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=50ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:39:15 GMT], X-Android-Received-Millis=[1578871071596], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578871071572]}
+01-13 02:17:54.587  1666  2854 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_FALLBACK http://play.googleapis.com/generate_204 time=98ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:39:18 GMT], X-Android-Received-Millis=[1578871074586], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578871074564]}
+01-13 02:18:00.005  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:18:00.005  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:18:00.017  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:18:00.047  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:18:00.047  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:18:00.084  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:18:00.084  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:18:01.612  1666 19232 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 02:17:22.295  1666  1689 I chatty  : uid=1000(system) batterystats-wo identical 1 line
+01-13 02:17:55.395  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:18:01.613  1666  1775 D ConnectivityService: NetworkAgentInfo [WIFI () - 101] validation failed
+01-13 02:18:01.614  1666  1771 D WifiStateMachine: NETWORK_STATUS_UNWANTED_VALIDATION_FAILED
+01-13 02:18:12.132  1666 19241 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS connectivitycheck.gstatic.com 7ms OK 108.177.14.94,2a00:1450:4010:c08::5e
+01-13 02:18:12.133  1666 19240 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS www.google.com 8ms OK 64.233.162.105,2a00:1450:4010:c0d::6a
+01-13 02:18:12.178  1666 19241 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=45ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:39:36 GMT], X-Android-Received-Millis=[1578871092178], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578871092156]}
+01-13 02:18:15.182  1666  2183 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_FALLBACK http://www.google.com/gen_204 time=57ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Content-Type=[text/html; charset=UTF-8], Date=[Fri, 28 Feb 2020 19:39:39 GMT], Server=[gws], Set-Cookie=[1P_JAR=2020-02-28-19; expires=Sun, 29-Mar-2020 19:39:39 GMT; path=/; domain=.google.com; Secure], X-Android-Received-Millis=[1578871095182], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578871095152], X-Frame-Options=[SAMEORIGIN], X-XSS-Protection=[0]}
+01-13 02:18:20.592  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:18:20.592  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:18:20.592  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:18:22.207  1666 19240 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 02:18:22.207  1666  1775 D ConnectivityService: NetworkAgentInfo [MOBILE (LTE) - 100] validation failed
+01-13 02:18:24.156  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:18:24.157  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:18:24.157  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:18:25.533  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:18:36.183  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:18:41.461  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:18:41.461  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:18:44.432  1666  7770 D WificondControl: Scan result ready event
+01-13 02:18:59.834  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:18:59.835  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:18:59.835  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:19:00.005  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:19:00.005  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:19:00.033  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:19:00.073  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:19:00.073  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:19:00.831  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:19:00.831  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:19:00.831  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:19:25.535  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:19:28.871  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:19:28.871  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:19:28.872  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:19:32.912  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:19:32.912  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:19:32.912  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:20:00.023  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:20:08.083  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:20:08.084  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:20:08.084  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:20:25.537  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:21:00.002  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:21:00.002  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:21:00.016  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:21:21.463  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:21:21.463  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:21:24.445  1666  7777 D WificondControl: Scan result ready event
+01-13 02:21:25.538  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:21:51.604  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:21:51.604  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:21:51.604  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:22:00.009  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:22:09.671  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:22:09.672  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:22:09.672  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:19:17.875  1666  1689 I chatty  : uid=1000(system) batterystats-wo identical 2 lines
+01-13 02:19:52.475  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:22:25.235  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:22:25.540  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:22:51.599  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:22:51.599  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:22:51.599  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:23:00.002  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:23:00.002  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:23:00.018  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:23:00.044  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:23:00.044  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:23:09.632  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:23:09.633  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:23:09.633  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:23:25.543  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:24:00.003  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:24:00.004  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:24:00.024  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:24:04.431  1666  7770 D WificondControl: Scan result ready event
+01-13 02:24:25.545  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:24:43.198  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:24:43.198  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:24:43.198  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:23:25.194  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:24:53.213  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:24:58.234  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:24:58.234  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:24:58.234  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:25:00.008  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:25:25.547  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:26:00.004  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:26:00.005  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:26:00.026  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:26:25.548  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:26:44.434  1666  7777 D WificondControl: Scan result ready event
+01-13 02:27:00.031  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:27:25.549  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:28:00.005  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:28:00.005  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:28:00.039  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:28:00.070  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:28:00.070  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:28:01.667  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:28:01.667  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:28:01.667  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:28:01.695  1666 19277 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS www.google.com 33ms OK 173.194.222.103,2a00:1450:4010:c05::63
+01-13 02:28:01.723  1666 19278 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS connectivitycheck.gstatic.com 60ms OK 64.233.165.94,2a00:1450:4010:c0a::5e
+01-13 02:28:01.774  1666 19277 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 02:28:01.778  1666 19278 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=53ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:49:26 GMT], X-Android-Received-Millis=[1578871681777], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578871681752]}
+01-13 02:28:01.855  1666  2854 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_FALLBACK http://play.googleapis.com/generate_204 time=76ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:49:26 GMT], X-Android-Received-Millis=[1578871681855], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578871681831]}
+01-13 02:28:01.856  1666  1775 D ConnectivityService: NetworkAgentInfo [WIFI () - 101] validation failed
+01-13 02:28:01.856  1666  1771 D WifiStateMachine: NETWORK_STATUS_UNWANTED_VALIDATION_FAILED
+01-13 02:28:16.872  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:28:16.872  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:28:16.872  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:28:22.316  1666 19286 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS connectivitycheck.gstatic.com 5ms OK 64.233.165.94,2a00:1450:4010:c0a::5e
+01-13 02:28:22.345  1666 19285 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS www.google.com 35ms OK 173.194.222.106,2a00:1450:4010:c05::63
+01-13 02:28:22.374  1666 19286 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=58ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:49:46 GMT], X-Android-Received-Millis=[1578871702373], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578871702343]}
+01-13 02:28:22.420  1666 19285 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTPS https://www.google.com/generate_204 Probe failed with exception javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 02:28:22.474  1666  2183 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_FALLBACK http://play.googleapis.com/generate_204 time=53ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:49:46 GMT], X-Android-Received-Millis=[1578871702474], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1578871702450]}
+01-13 02:28:22.475  1666  1775 D ConnectivityService: NetworkAgentInfo [MOBILE (LTE) - 100] validation failed
+01-13 02:28:25.550  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:28:32.496  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:29:00.012  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:29:24.431  1666  7777 D WificondControl: Scan result ready event
+01-13 02:29:25.552  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:30:00.009  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:30:00.010  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:30:00.010  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:30:25.554  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:31:00.022  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:31:25.555  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:32:00.002  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:32:00.002  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:32:00.010  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:32:00.056  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:32:00.056  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:32:00.101  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:32:00.101  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:32:00.133  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:32:00.133  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:32:00.161  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:32:00.161  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:32:01.779  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:32:01.780  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:32:01.780  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:32:04.441  1666  7777 D WificondControl: Scan result ready event
+01-13 02:32:16.912  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:32:16.912  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:32:16.912  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:32:17.263  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:32:17.263  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:32:17.263  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:32:25.556  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:32:34.414  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:32:37.405  2116 19296 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 02:32:37.405  2116 19296 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 02:32:37.800  2116 19301 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+01-13 02:32:37.800  2116 19301 W WakeLock: GCM_HB_ALARM counter does not exist
+01-13 02:32:52.831  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:32:52.831  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:32:52.831  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:33:00.004  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:33:00.004  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:33:00.025  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:33:00.043  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:33:00.043  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:33:00.080  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:33:00.080  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:33:01.779  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:33:01.779  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:33:01.779  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:33:16.872  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:33:16.872  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:33:16.872  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:33:25.559  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:33:32.693  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:33:32.693  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:33:32.693  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:34:00.011  1666  1685 E memtrack: Couldn't load memtrack module
+01-13 02:34:00.011  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+01-13 02:34:00.017  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:34:02.751  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:34:02.752  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:34:02.752  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:34:05.049  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:34:05.049  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:34:05.050  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:34:05.058  1666  1689 E BluetoothAdapter: Bluetooth binder is null
+01-13 02:33:32.496  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:34:05.063  1666  1689 E KernelCpuSpeedReader: Failed to read cpu-freq: /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state (No such file or directory)
+01-13 02:34:05.066  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:34:16.795  1666  1666 I EntropyMixer: Added HW RNG output to entropy pool
+01-13 02:34:16.796  1666  1666 I EntropyMixer: Writing entropy...
+01-13 02:34:25.561  1449  1449 I boot-pipe: done populating /dev/random
+01-13 02:34:38.772  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:34:38.772  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:34:38.772  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:34:48.795  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+01-13 02:34:53.791  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:34:53.791  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:34:53.791  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:35:00.011  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+01-13 02:35:21.822  1666  1768 D RecurrenceRule: Resolving using anchor 2020-01-13T02:35:21.822+03:00[Europe/Moscow]
+01-13 02:35:21.824  1666  1768 D RecurrenceRule: Resolving using anchor 2020-01-13T02:35:21.824+03:00[Europe/Moscow]
+01-13 02:35:21.826  1666  1768 D RecurrenceRule: Cycle 12 from 2020-01-13T00:00+03:00[Europe/Moscow] to 2020-02-13T00:00+03:00[Europe/Moscow]
+01-13 02:35:21.826  1666  1768 D NetworkStats: Resolving plan for NetworkTemplate: matchRule=MOBILE_ALL, subscriberId=310260..., matchSubscriberIds=[310260...]
+01-13 02:35:21.829  1666  1768 D NetworkStats: Found active matching subId 1
+01-13 02:35:21.835  1666  1768 D NetworkStats: Resolved to plan null
+01-13 02:35:21.952  2187 15992 I EventLogChimeraService: Aggregate from 1578870321582 (log), 1578870321582 (data)
+01-13 02:35:22.166  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.stats.service.DropBoxEntryAddedReceiver
+01-13 02:35:22.167  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+01-13 02:35:22.407  2187 15992 I CheckinChimeraService: Starting Checkin Task: PeriodicTaskTag Reason : -1 Force : false UserId: 0
+01-13 02:35:22.423  2187 15992 I EventLogChimeraService: Accumulating logs since 1578872121953
+01-13 02:35:22.430  2187 15992 I zygote  : Deoptimizing long plo.a(android.content.Context, long, long, android.os.DropBoxManager, boolean) due to JIT inline cache
+01-13 02:35:22.693  2187 15992 I CheckinRequestProcessor: Gmscore running on device, checkin will use Gmscore context
+01-13 02:35:22.693  2187 15992 I CheckinRequestBuilder: Checkin reason type: 0 attempt count: 1
+01-13 02:35:22.702  1666  7772 I WifiService: getConnectionInfo uid=10013
+01-13 02:35:22.769  1666  1689 I WifiService: requestActivityInfo uid=1000
+01-13 02:35:22.769  1666  1689 I WifiService: reportActivityInfo uid=1000
+01-13 02:35:22.769  1666  1689 I WifiService: getSupportedFeatures uid=1000
+01-13 02:35:22.967 19329 19329 W dex2oat : Unexpected CPU variant for X86 using defaults: x86
+01-13 02:35:22.967 19329 19329 I dex2oat : The ClassLoaderContext is a special shared library.
+01-13 02:35:22.968 19329 19329 W dex2oat : Mismatch between dex2oat instruction set features (ISA: X86 Feature string: -ssse3,-sse4.1,-sse4.2,-avx,-avx2,-popcnt) and those of dex2oat executable (ISA: X86 Feature string: ssse3,-sse4.1,-sse4.2,-avx,-avx2,-popcnt) for the command line:
+01-13 02:35:22.968 19329 19329 W dex2oat : /system/bin/dex2oat --instruction-set=x86 --instruction-set-features=ssse3,-sse4.1,-sse4.2,-avx,-avx2,-popcnt --runtime-arg -Xrelocate --boot-image=/system/framework/boot.art --runtime-arg -Xms64m --runtime-arg -Xmx512m --instruction-set-variant=x86 --instruction-set-features=default --dex-file=/data/data/com.google.android.gms/app_fb/f.apk --output-vdex-fd=50 --oat-fd=51 --oat-location=/data/data/com.google.android.gms/app_fb/oat/x86/f.odex --compiler-filter=quicken --class-loader-context=&
+01-13 02:35:22.968 19329 19329 I dex2oat : /system/bin/dex2oat --dex-file=/data/data/com.google.android.gms/app_fb/f.apk --output-vdex-fd=50 --oat-fd=51 --oat-location=/data/data/com.google.android.gms/app_fb/oat/x86/f.odex --compiler-filter=quicken --class-loader-context=&
+01-13 02:35:23.069 19329 19329 I dex2oat : dex2oat took 101.705ms (71.446ms cpu) (threads: 4) arena alloc=5KB (5928B) java alloc=32KB (32784B) native alloc=988KB (1011800B) free=1571KB (1609640B)
+01-13 02:35:23.073 17969 17984 I zygote  : The ClassLoaderContext is a special shared library.
+01-13 02:35:23.077 17969 17984 D         : HostConnection::get() New Host Connection established 0xcbd6f240, tid 17984
+01-13 02:35:23.081 17969 17984 I zygote  : android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 0
+01-13 02:35:23.088 17969 17984 D EGL_emulation: eglCreateContext: 0xe0da92c0: maj 2 min 0 rcv 2
+01-13 02:35:23.121 17969 17984 D EGL_emulation: eglMakeCurrent: 0xe0da92c0: ver 2 0 (tinfo 0xcb326290)
+01-13 02:35:23.214  2187 15992 I CheckinUtil: Classify the device as Phone.
+01-13 02:35:23.220  2187 15992 I CheckinConnFactory: Get token from PseudonymousIdApi: 196=t_HU9Mp8-ePSaU7LkWbT1VDIMea5ty0DPpdFxMOHvCDA8T-2qUrK2rnSL6Qm_quiM_vSWyMsQC2jtftS6BeaXUKRZmJNSobJ2Qi3QI4m70btsgfYk2WBd_zf2OiuFm1uX2Y9hfIx6fHy0XRjjKltHiLH8yV3lHI6purOVJnUPpU
+01-13 02:35:23.283  2187  2187 I zygote  : Deoptimizing void zhe.onServiceConnected(android.content.ComponentName, android.os.IBinder) due to JIT inline cache
+01-13 02:35:23.284  2187 15992 I CheckinRequestProcessor: set cookie as: NID=196=t_HU9Mp8-ePSaU7LkWbT1VDIMea5ty0DPpdFxMOHvCDA8T-2qUrK2rnSL6Qm_quiM_vSWyMsQC2jtftS6BeaXUKRZmJNSobJ2Qi3QI4m70btsgfYk2WBd_zf2OiuFm1uX2Y9hfIx6fHy0XRjjKltHiLH8yV3lHI6purOVJnUPpU
+01-13 02:35:23.413  2116  2536 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+01-13 02:35:23.413  2116  2536 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:35:23.413  2116  2536 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:35:23.416  2187 15992 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+01-13 02:35:23.416  2187 15992 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:35:23.416  2187 15992 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:35:23.455  2116  2536 W GLSUser : [AppCertManager] IOException while requesting key: 
+01-13 02:35:23.455  2116  2536 W GLSUser : javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.startHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):43)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at aogy.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):20)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at aogy.createSocket(:com.google.android.gms@16089022@16.0.89 (040700-239467275):6)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.okhttp.internal.io.RealConnection.connectTls(RealConnection.java:181)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.okhttp.internal.io.RealConnection.connectSocket(RealConnection.java:149)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.okhttp.internal.io.RealConnection.connect(RealConnection.java:112)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.okhttp.internal.http.StreamAllocation.findConnection(StreamAllocation.java:184)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.okhttp.internal.http.StreamAllocation.findHealthyConnection(StreamAllocation.java:126)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.okhttp.internal.http.StreamAllocation.newStream(StreamAllocation.java:95)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:281)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:224)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:461)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.connect(HttpURLConnectionImpl.java:127)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getOutputStream(HttpURLConnectionImpl.java:258)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getOutputStream(DelegatingHttpsURLConnection.java:218)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getOutputStream(Unknown Source:0)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at abbg.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):39)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at jaz.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at gzo.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):12)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at gzo.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):8)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at hzz.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):13)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at hzz.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):115)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at hzx.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):6)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at hzt.a(Unknown Source:0)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at hzs.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):8)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.google.android.gms.auth.account.be.legacy.AuthCronChimeraService.b(:com.google.android.gms@16089022@16.0.89 (040700-239467275):6)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at gyi.call(:com.google.android.gms@16089022@16.0.89 (040700-239467275):3)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at rrt.b(:com.google.android.gms@16089022@16.0.89 (040700-239467275):32)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at rrt.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):21)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at rxx.run(Unknown Source:7)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at java.lang.Thread.run(Thread.java:764)
+01-13 02:35:23.455  2116  2536 W GLSUser : Caused by: java.security.cert.CertificateException: Chain validation failed
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:707)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:539)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:560)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:628)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:495)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:418)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.org.conscrypt.TrustManagerImpl.getTrustedChainForServer(TrustManagerImpl.java:339)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at android.security.net.config.NetworkSecurityTrustManager.checkServerTrusted(NetworkSecurityTrustManager.java:94)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at android.security.net.config.RootTrustManager.checkServerTrusted(RootTrustManager.java:88)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at java.lang.reflect.Method.invoke(Native Method)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.google.android.gms.org.conscrypt.Platform.checkTrusted(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.google.android.gms.org.conscrypt.Platform.checkServerTrusted(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.verifyCertificateChain(:com.google.android.gms@16089022@16.0.89 (040700-239467275):12)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.google.android.gms.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.google.android.gms.org.conscrypt.NativeSsl.doHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):7)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.startHandshake(:com.google.android.gms@16089022@16.0.89 (040700-239467275):14)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	... 33 more
+01-13 02:35:23.455  2116  2536 W GLSUser : Caused by: java.security.cert.CertPathValidatorException: timestamp check failed
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:133)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:222)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:140)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at sun.security.provider.certpath.PKIXCertPathValidator.engineValidate(PKIXCertPathValidator.java:79)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at java.security.cert.CertPathValidator.validate(CertPathValidator.java:301)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:703)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	... 48 more
+01-13 02:35:23.455  2116  2536 W GLSUser : Caused by: java.security.cert.CertificateNotYetValidException: Certificate not valid until Wed Feb 12 14:52:15 GMT+03:00 2020 (compared to Mon Jan 13 02:35:23 GMT+03:00 2020)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at com.google.android.gms.org.conscrypt.OpenSSLX509Certificate.checkValidity(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at sun.security.provider.certpath.BasicChecker.verifyTimestamp(BasicChecker.java:194)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at sun.security.provider.certpath.BasicChecker.check(BasicChecker.java:144)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:125)
+01-13 02:35:23.455  2116  2536 W GLSUser : 	... 53 more
+01-13 02:35:23.470  2187 15992 E CheckinRequestProcessor: SSL error, attempting time correction: javax.net.ssl.SSLHandshakeException: Chain validation failed
+01-13 02:35:23.525  2187  2198 I zygote  : Deoptimizing void com.google.android.gms.org.conscrypt.NativeRef.finalize() due to JIT inline cache
+01-13 02:35:23.538  2187 15992 I CheckinRequestBuilder: Checkin reason type: 0 attempt count: 1
+01-13 02:35:23.575  2187 15992 W CheckinRequestProcessor: Changing time from 1578872123570 to 1582919807863
+01-13 02:35:23.576  1666  7771 D AlarmManagerService: Setting time of day to sec=1582919807
+02-28 22:56:47.863  1666  7771 W AlarmManagerService: Unable to set rtc to 1582919807: No such device
+02-28 22:56:47.866  2187 15992 I CheckinRequestProcessor: set cookie as: NID=196=t_HU9Mp8-ePSaU7LkWbT1VDIMea5ty0DPpdFxMOHvCDA8T-2qUrK2rnSL6Qm_quiM_vSWyMsQC2jtftS6BeaXUKRZmJNSobJ2Qi3QI4m70btsgfYk2WBd_zf2OiuFm1uX2Y9hfIx6fHy0XRjjKltHiLH8yV3lHI6purOVJnUPpU
+02-28 22:56:47.869  1666  1666 D ConditionProviders.SCP: onReceive android.intent.action.TIME_SET
+02-28 22:56:47.881 19343 19343 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+02-28 22:56:47.884  1666  1686 I ActivityManager: Start proc 19343:com.google.android.calendar/u0a45 for broadcast com.google.android.calendar/com.android.calendar.widget.CalendarAppWidgetProvider
+02-28 22:56:47.894  1666  1666 D ConditionProviders.SCP: notifyCondition condition://android/schedule?days=6.7&start=23.30&end=10.0&exitAtAlarm=false STATE_FALSE reason=!meetsSchedule
+02-28 22:56:47.895  1666  1666 D ConditionProviders.SCP: notifyCondition condition://android/schedule?days=1.2.3.4.5&start=22.0&end=7.0&exitAtAlarm=false STATE_FALSE reason=!meetsSchedule
+02-28 22:56:47.895  1666  1666 D ConditionProviders.SCP: Scheduling evaluate for Fri Feb 28 23:30:00 GMT+03:00 2020 (1582921800000), in +33m12s131ms, now=Fri Feb 28 22:56:47 GMT+03:00 2020 (1582919807869)
+02-28 22:56:47.900  1666  1666 D ConditionProviders.SCP: onReceive ScheduleConditionProvider.EVALUATE
+02-28 22:56:47.900  1666  1666 D ConditionProviders.SCP: notifyCondition condition://android/schedule?days=6.7&start=23.30&end=10.0&exitAtAlarm=false STATE_FALSE reason=!meetsSchedule
+02-28 22:56:47.900  1666  1666 D ConditionProviders.SCP: notifyCondition condition://android/schedule?days=1.2.3.4.5&start=22.0&end=7.0&exitAtAlarm=false STATE_FALSE reason=!meetsSchedule
+02-28 22:56:47.913  1666  1781 I ActivityManager: Start proc 19359:com.android.providers.calendar/u0a3 for content provider com.android.providers.calendar/.CalendarProvider2
+02-28 22:56:47.916  1666  1666 D ConditionProviders.SCP: Scheduling evaluate for Fri Feb 28 23:30:00 GMT+03:00 2020 (1582921800000), in +33m12s100ms, now=Fri Feb 28 22:56:47 GMT+03:00 2020 (1582919807900)
+02-28 22:56:47.919 19359 19359 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+02-28 22:56:47.929  1666  1666 D ZenLog  : config: conditionChanged,ZenModeConfig[user=0,allowCalls=true,allowRepeatCallers=false,allowMessages=false,allowCallsFrom=contacts,allowMessagesFrom=contacts,allowReminders=true,allowEvents=true,allowWhenScreenOff=true,allowWhenScreenOn=true,automaticRules={EVENTS_DEFAULT_RULE=ZenRule[enabled=false,snoozing=false,name=Event,zenMode=ZEN_MODE_ALARMS,conditionId=condition://android/event?userId=-10000&calendar=&reply=1,condition=Condition[id=condition://android/event?userId=-10000&calendar=&reply=1,summary=...,line1=...,line2=...,icon=0,state=STATE_FALSE,flags=2],component=ComponentInfo{android/com.android.server.notification.EventConditionProvider},id=EVENTS_DEFAULT_RULE,creationTime=1563054733958,enabler=null], SCHEDULED_DEFAULT_RULE_1=ZenRule[enabled=false,snoozing=false,name=Weeknight,zenMode=ZEN_MODE_ALARMS,conditionId=condition://android/schedule?days=1.2.3.4.5&start=22.0&end=7.0&exitAtAlarm=false,condition=Condition[id=condition://android/schedule?days=1.2.3.4.5&start=22.0&end=7.0&exitAtAlarm=false,summary=...,line1=...,line2=...,icon=0,state=STATE_FALSE,flags=2],component=ComponentInfo{android/com.android.server.notification.ScheduleConditionProvider},id=SCHEDULED_DEFAULT_RULE_1,creationTime=1563054733958,enabler=null], SCHEDULED_DEFAULT_RULE_2=ZenRule[enabled=false,snoozing=false,name=Weekend,zenMode=ZEN_MODE_ALARMS,conditionId=condition://android/schedule?days=6.7&start=23.30&end=10.0&exitAtAlarm=false,condition=Condition[id=condition://android/schedule?days=6.7&start=23.30&end=10.0&exitAtAlarm=false,summary=...,line1=...,line2=...,icon=0,state=STATE_FALSE,flags=2],component=ComponentInfo{android/com.android.server.notification.ScheduleConditionProvider},id=SCHEDULED_DEFAULT_RULE_2,creationTime=1563054733958,enabler=null]},manualRule=null],Diff[automaticRule[SCHEDULED_DEFAULT_RULE_1].condition:Condition[id=condition://android/schedule?days=1.2.3.4.5&start=22.0&end=7.0&exitAtAlarm=false,summary=...,line1=...,line2=...,icon=0,state=STATE_TRUE,flags=2]->Condition[id=condition://android/schedule?days=1.2.3.4.5&start=22.0&end=7.0&exitAtAlarm=false,summary=...,line1=...,line2=...,icon=0,state=STATE_FALSE,flags=2]]
+02-28 22:56:47.937 19343 19343 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 22:56:47.957  1666  1685 I UsageStatsService: Time changed in UsageStats by 4047684 seconds
+02-28 22:56:47.957  1666  1685 I UsageStatsService: User[0] Flushing usage stats to disk
+02-28 22:56:47.957  1666  1666 D ZenLog  : set_zen_mode: off,conditionChanged
+02-28 22:56:47.991 19359 19359 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 22:56:48.010  1666  1685 I UsageStatsDatabase: Time changed by +46d20h21m24s286ms. files deleted: 0 files moved: 11
+02-28 22:56:47.994 19359 19359 I chatty  : uid=10003(com.android.providers.calendar) identical 1 line
+02-28 22:56:47.996 19359 19359 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 22:56:48.027 19359 19359 I CalendarProvider2: Created com.android.providers.calendar.CalendarAlarmManager@27a0ea0(com.android.providers.calendar.CalendarProvider2@e2d2a59)
+02-28 22:56:48.027 19343 19343 I PerformanceMetricCollec: Logging experiments memory-false, lantency-false
+02-28 22:56:48.037  1666  1685 I UsageStatsService: User[0] Rollover scheduled @ 2020-02-29 22:56:47(1583006207957)
+02-28 22:56:48.073 19343 19343 D PhenotypeJobService: Job scheduled successfully
+02-28 22:56:48.079 19343 19343 E PrefServiceImpl: Primary account is null
+02-28 22:56:48.082 19343 19343 I PerformanceMetricCollec: Logging experiments memory-false, lantency-false
+02-28 22:56:48.142 19406 19406 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+02-28 22:56:48.145  1666  7572 I ActivityManager: Start proc 19406:com.google.android.deskclock/u0a68 for broadcast com.google.android.deskclock/com.android.deskclock.AlarmInitReceiver
+02-28 22:56:48.154 19343 19343 D PhenotypeManager: Registered: Status{statusCode=SUCCESS, resolution=null}
+02-28 22:56:48.189  1666  1676 I zygote  : Background concurrent copying GC freed 32183(1908KB) AllocSpace objects, 17(660KB) LOS objects, 34% free, 11MB/17MB, paused 1.049ms total 113.609ms
+02-28 22:56:48.191 19406 19406 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 22:56:48.243 19406 19406 I GAv4    : Google Analytics 10.0.84 is starting up. To enable debug logging on a device run:
+02-28 22:56:48.243 19406 19406 I GAv4    :   adb shell setprop log.tag.GAv4 DEBUG
+02-28 22:56:48.243 19406 19406 I GAv4    :   adb logcat -s GAv4
+02-28 22:56:48.254 19343 19405 I PhenotypeFlagCommitter: Experiment Configs successfully retrieved for com.google.android.calendar
+02-28 22:56:48.258 19406 19434 W GAv4    : AnalyticsReceiver is not registered or is disabled. Register the receiver for reliable dispatching on non-Google Play devices. See http://goo.gl/8Rd3yj for instructions.
+02-28 22:56:48.264 19406 19434 W GAv4    : CampaignTrackingReceiver is not registered, not exported or is disabled. Installation campaign tracking is not possible. See http://goo.gl/8Rd3yj for instructions.
+02-28 22:56:48.267 19406 19434 W GAv4    : AnalyticsService not registered in the app manifest. Hits might not be delivered reliably. See http://goo.gl/8Rd3yj for instructions.
+02-28 22:56:48.270 19406 19406 I AlarmClock: AlarmInitReceiver android.intent.action.TIME_SET
+02-28 22:56:48.288 19440 19440 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+02-28 22:56:48.291  1666  7770 I ActivityManager: Start proc 19440:android.process.media/u0a10 for content provider com.android.providers.media/.MediaProvider
+02-28 22:56:48.311 19440 19440 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 22:56:48.324 19440 19440 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 22:56:48.395 19406 19439 W RingtoneManager: No READ_EXTERNAL_STORAGE permission, ignoring ringtones on ext storage
+02-28 22:56:48.407  1534  1534 D NuPlayerDriver: NuPlayerDriver(0xefb94070) created, clientPid(19406)
+02-28 22:56:48.412  1534 19467 D GenericSource: FileSource remote
+02-28 22:56:48.421  1534 19466 D NuPlayerDriver: notifyListener_l(0xefb94070), (1, 0, 0, -1), loop setting(0, 0)
+02-28 22:56:48.426 19406 19439 D Ringtone: Successfully created local player
+02-28 22:56:48.441 19406 19439 I AlarmClock: Removing AlarmClockInfo
+02-28 22:56:48.444 19406 19406 I DigitalWidgetProvider: onReceive: Intent { act=android.intent.action.TIME_SET flg=0x25200010 cmp=com.google.android.deskclock/com.android.alarmclock.DigitalAppWidgetProvider }
+02-28 22:56:48.455  2187 19357 I SystemUpdate: [Installation,ReceiverIntentOperation] Received intent: Intent { act=android.intent.action.TIME_SET flg=0x25200010 cmp=com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver }.
+02-28 22:56:48.467 19406 19475 I AlarmClock: Started indexing all application data.
+02-28 22:56:48.469  1666  7572 I ActivityManager: Start proc 19470:com.google.android.apps.messaging/u0a69 for broadcast com.google.android.apps.messaging/.shared.analytics.AnalyticsAlarmReceiver
+02-28 22:56:48.475  2187 19318 I SystemUpdate: [Execution,InstallationEventIntentOperation] Handling event of type 6.
+02-28 22:56:48.475 19470 19470 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+02-28 22:56:48.483  2187 19479 I SystemUpdate: [Execution,InstallationIntentOperation] Received intent: Intent { act=com.google.android.gms.update.INSTALL_UPDATE cat=[targeted_intent_op_prefix:.update.execution.InstallationIntentOperation] cmp=com.google.android.gms/.chimera.GmsIntentOperationService }.
+02-28 22:56:48.489  2187 19479 I SystemUpdate: [Execution,ExecutionManager] Action finished-execution executed for 0.00 seconds.
+02-28 22:56:48.501 19406 19475 D AppIndexApi: Logging objectbjr@8b1a8fc
+02-28 22:56:48.513 19470 19470 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 22:56:48.533 19470 19470 I MultiDex: VM with version 2.1.0 has multidex support
+02-28 22:56:48.534 19470 19470 I MultiDex: install
+02-28 22:56:48.534 19470 19470 I MultiDex: VM has multidex support, MultiDex support library is disabled.
+02-28 22:56:48.546 19406 19416 V MediaPlayer: resetDrmState:  mDrmInfo=null mDrmProvisioningThread=null mPrepareDrmInProgress=false mActiveDrmScheme=false
+02-28 22:56:48.546 19406 19416 V MediaPlayer: cleanDrmObj: mDrmObj=null mDrmSessionId=null
+02-28 22:56:48.547  1534  1534 D NuPlayerDriver: reset(0xefb94070) at state 4
+02-28 22:56:48.547  1534  1534 D NuPlayerDriver: notifyListener_l(0xefb94070), (8, 0, 0, -1), loop setting(1, 0)
+02-28 22:56:48.548 19470 19470 D FirebaseApp: com.google.firebase.auth.FirebaseAuth is not linked. Skipping initialization.
+02-28 22:56:48.549 19470 19470 D FirebaseApp: com.google.firebase.iid.FirebaseInstanceId is not linked. Skipping initialization.
+02-28 22:56:48.549 19470 19470 D FirebaseApp: com.google.firebase.crash.FirebaseCrash is not linked. Skipping initialization.
+02-28 22:56:48.549 19470 19470 D FirebaseApp: com.google.android.gms.measurement.AppMeasurement is not linked. Skipping initialization.
+02-28 22:56:48.549 19470 19470 I FirebaseInitProvider: FirebaseApp initialization successful
+02-28 22:56:48.550  1534 19466 D NuPlayerDriver: notifyResetComplete(0xefb94070)
+02-28 22:56:48.554  1533  2043 D MediaAnalyticsService: MediaAnalyticsService::newSummarizerSet
+02-28 22:56:48.563 19470 19470 I CarrierServices: [2] a.a: Initializing Carrier Services Library.
+02-28 22:56:48.564 19470 19470 W CarrierServices: Trying to log through cs.apk when it has not been initialized yet
+02-28 22:56:48.592  2116 18741 W Icing   : isOptedInForAppHistory: empty Account Name encountered
+02-28 22:56:48.609 19406 19475 I AlarmClock: Finished indexing all application data.
+02-28 22:56:48.626 19470 19470 I BugleBackup: Registering preference change listener for "bugle".
+02-28 22:56:48.636 19470 19500 I Bugle   : GServicesValues:
+02-28 22:56:48.636 19470 19500 I Bugle   : bugle_enable_primes_crash_metrics: true
+02-28 22:56:48.636 19470 19500 I Bugle   : bugle_max_telemetry_upload_retries: 10
+02-28 22:56:48.636 19470 19500 I Bugle   : bugle_sticker_set_list_version: 3
+02-28 22:56:48.732 19470 19470 I Bugle   : ApnsOta: OTA version -1
+02-28 22:56:48.735 19470 19502 I BugleDataModel: Fixup: Send failed - 0 Download failed - 0
+02-28 22:56:48.750 19470 19502 W BugleDataModel: tried to cancel job 100 that can't be found. already finished?
+02-28 22:56:48.753 19470 19502 I BugleDataModel: ProcessPendingMessagesAction: process from ProcessPendingMessagesAction due to scheduled processing with 0 earliest sms sending messages, with 0 earliest mms sending messages, with 0 earliest rcs sending messages, with 0 earliest rcsFT sending messages, and 0 earliest downloading messages
+02-28 22:56:48.756 19470 19502 V Bugle   : Executing sticker action: com.google.android.apps.messaging.shared.datamodel.sticker.ProcessPendingStickerSyncAction
+02-28 22:56:48.761 19470 19502 V Bugle   : Executing sticker action: com.google.android.apps.messaging.shared.datamodel.sticker.SyncStickerSetListAction
+02-28 22:56:48.764  1666  7776 I ActivityManager: Start proc 19508:com.google.android.apps.wallpaper/u0a31 for broadcast com.google.android.apps.wallpaper/.module.DailyLoggingAlarmReceiver
+02-28 22:56:48.765 19470 19470 D Bugle   : onServiceStateChanged: 3 to 0
+02-28 22:56:48.760 19470 19506 W Bugle   : canonicalizeMccMnc: invalid mccmnc:null ,null
+02-28 22:56:48.770 19508 19508 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+02-28 22:56:48.770 19470 19470 I Bugle   : Carrier config changed. Reloading MMS config.
+02-28 22:56:48.771 19470 19470 I BugleRcs: updating RCS availability
+02-28 22:56:48.777 19470 19470 I CarrierServices: [2] a.connect: Binding to local JibeService
+02-28 22:56:48.780  1666  7772 D MmsServiceBroker: getCarrierConfigValues() by com.google.android.apps.messaging
+02-28 22:56:48.782  1879  2218 D MmsService: getCarrierConfigValues
+02-28 22:56:48.782  1879  2218 I MmsService: mms config for sub 1: Bundle[{httpSocketTimeout=60000, aliasMinChars=2, smsToMmsTextThreshold=-1, enableSMSDeliveryReports=true, maxMessageTextSize=-1, supportMmsContentDisposition=true, enabledTransID=false, aliasEnabled=false, supportHttpCharsetHeader=false, allowAttachAudio=true, smsToMmsTextLengthThreshold=-1, recipientLimit=2147483647, uaProfTagName=x-wap-profile, aliasMaxChars=48, maxImageHeight=1944, enableMMSDeliveryReports=false, userAgent=, mmsCloseConnection=false, config_cellBroadcastAppLinks=true, maxSubjectLength=40, httpParams=, enableGroupMms=true, emailGatewayNumber=, maxMessageSize=1048576, naiSuffix=, enableMMSReadReports=false, maxImageWidth=2592, uaProfUrl=, enabledMMS=false, enabledNotifyWapMMSC=false, sendMultipartSmsAsSeparateMessages=false, enableMultipartSMS=true}]
+02-28 22:56:48.783 19470 19506 I Bugle   : Carrier configs loaded: Bundle[{httpSocketTimeout=60000, aliasMinChars=2, smsToMmsTextThreshold=-1, enableSMSDeliveryReports=true, maxMessageTextSize=-1, supportMmsContentDisposition=true, enabledTransID=false, aliasEnabled=false, supportHttpCharsetHeader=false, allowAttachAudio=true, spamForwardingNumber=7726, smsToMmsTextLengthThreshold=-1, recipientLimit=2147483647, uaProfTagName=x-wap-profile, aliasMaxChars=48, maxImageHeight=1944, enableMMSDeliveryReports=false, userAgent=, mmsCloseConnection=false, config_cellBroadcastAppLinks=true, maxSubjectLength=40, httpParams=, enableGroupMms=true, allowEnablingWapPushSI=false, emailGatewayNumber=, maxMessageSize=1048576, naiSuffix=, enableMMSReadReports=false, maxImageWidth=2592, uaProfUrl=, enabledMMS=false, enabledNotifyWapMMSC=false, enableWapPushSI=true, sendMultipartSmsAsSeparateMessages=false, enableMultipartSMS=true}] from resources+system for subId=1
+02-28 22:56:48.796 19524 19524 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+02-28 22:56:48.796  1666  7772 I ActivityManager: Start proc 19524:com.google.android.apps.messaging:rcs/u0a69 for service com.google.android.apps.messaging/com.google.android.ims.service.JibeService
+02-28 22:56:48.797 19470 19470 I CarrierServices: [2] a.connect: Binding to local JibeService
+02-28 22:56:48.812 19470 19514 W Bugle   : canonicalizeMccMnc: invalid mccmnc:null ,null
+02-28 22:56:48.813 19508 19508 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 22:56:48.824  1666  7776 D MmsServiceBroker: getCarrierConfigValues() by com.google.android.apps.messaging
+02-28 22:56:48.824  1879  2144 D MmsService: getCarrierConfigValues
+02-28 22:56:48.824  1879  2144 I MmsService: mms config for sub 1: Bundle[{httpSocketTimeout=60000, aliasMinChars=2, smsToMmsTextThreshold=-1, enableSMSDeliveryReports=true, maxMessageTextSize=-1, supportMmsContentDisposition=true, enabledTransID=false, aliasEnabled=false, supportHttpCharsetHeader=false, allowAttachAudio=true, smsToMmsTextLengthThreshold=-1, recipientLimit=2147483647, uaProfTagName=x-wap-profile, aliasMaxChars=48, maxImageHeight=1944, enableMMSDeliveryReports=false, userAgent=, mmsCloseConnection=false, config_cellBroadcastAppLinks=true, maxSubjectLength=40, httpParams=, enableGroupMms=true, emailGatewayNumber=, maxMessageSize=1048576, naiSuffix=, enableMMSReadReports=false, maxImageWidth=2592, uaProfUrl=, enabledMMS=false, enabledNotifyWapMMSC=false, sendMultipartSmsAsSeparateMessages=false, enableMultipartSMS=true}]
+02-28 22:56:48.825 19470 19470 I BugleRcs: RCS availability is already updating
+02-28 22:56:48.826 19470 19514 I Bugle   : Carrier configs loaded: Bundle[{httpSocketTimeout=60000, aliasMinChars=2, smsToMmsTextThreshold=-1, enableSMSDeliveryReports=true, maxMessageTextSize=-1, supportMmsContentDisposition=true, enabledTransID=false, aliasEnabled=false, supportHttpCharsetHeader=false, allowAttachAudio=true, spamForwardingNumber=7726, smsToMmsTextLengthThreshold=-1, recipientLimit=2147483647, uaProfTagName=x-wap-profile, aliasMaxChars=48, maxImageHeight=1944, enableMMSDeliveryReports=false, userAgent=, mmsCloseConnection=false, config_cellBroadcastAppLinks=true, maxSubjectLength=40, httpParams=, enableGroupMms=true, allowEnablingWapPushSI=false, emailGatewayNumber=, maxMessageSize=1048576, naiSuffix=, enableMMSReadReports=false, maxImageWidth=2592, uaProfUrl=, enabledMMS=false, enabledNotifyWapMMSC=false, enableWapPushSI=true, sendMultipartSmsAsSeparateMessages=false, enableMultipartSMS=true}] from resources+system for subId=1
+02-28 22:56:48.826 19524 19524 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 22:56:48.846 19470 19507 D CrashMetricService: onPrimesInitialize
+02-28 22:56:48.855 19524 19524 I MultiDex: VM with version 2.1.0 has multidex support
+02-28 22:56:48.855 19524 19524 I MultiDex: install
+02-28 22:56:48.855 19524 19524 I MultiDex: VM has multidex support, MultiDex support library is disabled.
+02-28 22:56:48.862 19470 19513 W Bugle   : canonicalizeMccMnc: invalid mccmnc:null ,null
+02-28 22:56:48.872  1666  7770 D MmsServiceBroker: getCarrierConfigValues() by com.google.android.apps.messaging
+02-28 22:56:48.873  1879  2218 D MmsService: getCarrierConfigValues
+02-28 22:56:48.873  1879  2218 I MmsService: mms config for sub 1: Bundle[{httpSocketTimeout=60000, aliasMinChars=2, smsToMmsTextThreshold=-1, enableSMSDeliveryReports=true, maxMessageTextSize=-1, supportMmsContentDisposition=true, enabledTransID=false, aliasEnabled=false, supportHttpCharsetHeader=false, allowAttachAudio=true, smsToMmsTextLengthThreshold=-1, recipientLimit=2147483647, uaProfTagName=x-wap-profile, aliasMaxChars=48, maxImageHeight=1944, enableMMSDeliveryReports=false, userAgent=, mmsCloseConnection=false, config_cellBroadcastAppLinks=true, maxSubjectLength=40, httpParams=, enableGroupMms=true, emailGatewayNumber=, maxMessageSize=1048576, naiSuffix=, enableMMSReadReports=false, maxImageWidth=2592, uaProfUrl=, enabledMMS=false, enabledNotifyWapMMSC=false, sendMultipartSmsAsSeparateMessages=false, enableMultipartSMS=true}]
+02-28 22:56:48.874 19470 19500 I BugleBackup: Registering preference change listener for "buglesub_1".
+02-28 22:56:48.874 19470 19513 I Bugle   : Carrier configs loaded: Bundle[{httpSocketTimeout=60000, aliasMinChars=2, smsToMmsTextThreshold=-1, enableSMSDeliveryReports=true, maxMessageTextSize=-1, supportMmsContentDisposition=true, enabledTransID=false, aliasEnabled=false, supportHttpCharsetHeader=false, allowAttachAudio=true, spamForwardingNumber=7726, smsToMmsTextLengthThreshold=-1, recipientLimit=2147483647, uaProfTagName=x-wap-profile, aliasMaxChars=48, maxImageHeight=1944, enableMMSDeliveryReports=false, userAgent=, mmsCloseConnection=false, config_cellBroadcastAppLinks=true, maxSubjectLength=40, httpParams=, enableGroupMms=true, allowEnablingWapPushSI=false, emailGatewayNumber=, maxMessageSize=1048576, naiSuffix=, enableMMSReadReports=false, maxImageWidth=2592, uaProfUrl=, enabledMMS=false, enabledNotifyWapMMSC=false, enableWapPushSI=true, sendMultipartSmsAsSeparateMessages=false, enableMultipartSMS=true}] from resources+system for subId=1
+02-28 22:56:48.911 19524 19524 I CarrierServices: [2] a.a: Initializing Carrier Services Library.
+02-28 22:56:48.920 19470 19500 I BugleRcs: RcsAvailability updated: RCS is disabled for this carrier by Google
+02-28 22:56:48.920 19470 19470 I BugleRcs: Broadcast disable RCS for availability (2)
+02-28 22:56:48.939 19406 19406 I DigitalWidgetProvider: onReceive: Intent { act=com.android.deskclock.ALARM_CHANGED flg=0x10 cmp=com.google.android.deskclock/com.android.alarmclock.DigitalAppWidgetProvider }
+02-28 22:56:48.948 19524 19556 I Bugle   : GServicesValues:
+02-28 22:56:48.948 19524 19556 I Bugle   : bugle_enable_primes_crash_metrics: true
+02-28 22:56:48.948 19524 19556 I Bugle   : bugle_max_telemetry_upload_retries: 10
+02-28 22:56:48.948 19524 19556 I Bugle   : bugle_sticker_set_list_version: 3
+02-28 22:56:48.948  1666  7771 I ActivityManager: Killing 4070:com.android.keychain/1000 (adj 906): empty for 3397s
+02-28 22:56:48.950  1666  1688 W zygote  : kill(-4070, 9) failed: No such process
+02-28 22:56:48.991  1666  1688 W zygote  : kill(-4070, 9) failed: No such process
+02-28 22:56:49.003 19524 19524 I CarrierServices: [2] a.c: Initializing Carrier Services Logging.
+02-28 22:56:49.022 19524 19524 I com.google.android.ims.util.z: LogSaver new instance with filename: carrier_services
+02-28 22:56:49.036  1666  1688 W zygote  : kill(-4070, 9) failed: No such process
+02-28 22:56:49.037  1666  1688 I zygote  : Successfully killed process cgroup uid 1000 pid 4070 in 86ms
+02-28 22:56:49.053 19524 19524 I CarrierServices: [2] zzbgb$zza.shouldUseCarrierServicesApkForV1Apis: Checking if using CarrierServices.apk is possible. Enabled: true, isAtLeastM: true, runningInsideBugle: true
+02-28 22:56:49.056 19524 19524 W CarrierServices: [2] zzbgb$zza.C: Carrier Services Apk was not found.
+02-28 22:56:49.057 19524 19524 W CarrierServices: [2] zzbgb$zza.a: CarrierServices.apk was not found, not pre-loaded or is disabled.
+02-28 22:56:49.057 19524 19524 I CarrierServices: [2] t.c: Using AndroidNetworkFactory
+02-28 22:56:49.059 19524 19524 I CarrierServices: [2] zzbgb$zza.shouldUseCarrierServicesApkForV1Apis: Checking if using CarrierServices.apk is possible. Enabled: true, isAtLeastM: true, runningInsideBugle: true
+02-28 22:56:49.059 19524 19524 W CarrierServices: [2] zzbgb$zza.C: Carrier Services Apk was not found.
+02-28 22:56:49.060 19524 19524 W CarrierServices: [2] zzbgb$zza.a: CarrierServices.apk was not found, not pre-loaded or is disabled.
+02-28 22:56:49.093 19524 19524 V RcsProvisioning: No legacy config file found, migration not necessary
+02-28 22:56:49.097  1666  7772 D WificondControl: Scan result ready event
+02-28 22:56:49.100 19524 19524 W RcsProvisioning: Failed to read configuration: /data/user/0/com.google.android.apps.messaging/files/rcsconfig (No such file or directory)
+02-28 22:56:49.100 19524 19524 D RcsProvisioning: Retrieving backup token
+02-28 22:56:49.204 19524 19524 D RcsProvisioning: No backup token found
+02-28 22:56:49.218 19524 19524 W CarrierServices: [2] zzbgb$zza.av: No config URL. RCS will be disabled!
+02-28 22:56:49.236 19524 19524 W DynamiteModule: Local module descriptor class for com.google.android.gms.googlecertificates not found.
+02-28 22:56:49.254 19524 19524 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 22:56:49.255 19524 19524 I chatty  : uid=10069 com.google.android.apps.messaging:rcs identical 1 line
+02-28 22:56:49.260 19524 19524 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 22:56:49.267 19524 19524 I DynamiteModule: Considering local module com.google.android.gms.googlecertificates:0 and remote module com.google.android.gms.googlecertificates:4
+02-28 22:56:49.267 19524 19524 I DynamiteModule: Selected remote version of com.google.android.gms.googlecertificates, version >= 4
+02-28 22:56:49.268  2116  2719 I zygote  : Deoptimizing int ebi.a(bmql, ebh, java.lang.Comparable) due to JIT inline cache
+02-28 22:56:49.283 19524 19524 W zygote  : Unsupported class loader
+02-28 22:56:49.287 19524 19524 W zygote  : Skipping duplicate class check due to unsupported classloader
+02-28 22:56:49.292  1666  1768 D RecurrenceRule: Resolving using anchor 2020-02-28T22:56:49.292+03:00[Europe/Moscow]
+02-28 22:56:49.294  1666  1768 D RecurrenceRule: Resolving using anchor 2020-02-28T22:56:49.294+03:00[Europe/Moscow]
+02-28 22:56:49.296  1666  1768 D RecurrenceRule: Cycle 13 from 2020-02-13T00:00+03:00[Europe/Moscow] to 2020-03-13T00:00+03:00[Europe/Moscow]
+02-28 22:56:49.296  1666  1768 D NetworkStats: Resolving plan for NetworkTemplate: matchRule=MOBILE_ALL, subscriberId=310260..., matchSubscriberIds=[310260...]
+02-28 22:56:49.299 19524 19524 D GoogleCertificates: com.google.android.gms.googlecertificates module is loaded
+02-28 22:56:49.300  1666  1768 D NetworkStats: Found active matching subId 1
+02-28 22:56:49.307  1666  1768 D NetworkStats: Resolved to plan null
+02-28 22:56:49.312 19470 19503 E Bugle   : RcsUtils. Error getting default configuration value for fallback setting
+02-28 22:56:49.312 19470 19503 E Bugle   : com.google.android.rcs.client.e: Jibe SDK Service not available. Is the Jibe SDK service running? Did you call connect() and wait for the notification before calling an API function?
+02-28 22:56:49.312 19470 19503 E Bugle   : 	at com.google.android.rcs.client.a.c(SourceFile:76)
+02-28 22:56:49.312 19470 19503 E Bugle   : 	at com.google.android.rcs.client.profile.RcsProfileService.getRcsConfig(SourceFile:67)
+02-28 22:56:49.312 19470 19503 E Bugle   : 	at com.google.android.apps.messaging.shared.sms.al.i(SourceFile:772)
+02-28 22:56:49.312 19470 19503 E Bugle   : 	at com.google.android.apps.messaging.shared.analytics.RecurringTelemetryUploaderAction.doBackgroundWork(SourceFile:208)
+02-28 22:56:49.312 19470 19503 E Bugle   : 	at com.google.android.apps.messaging.shared.datamodel.action.ActionExecutorImpl$BackgroundWorkerRunnable.run(SourceFile:12)
+02-28 22:56:49.312 19470 19503 E Bugle   : 	at android.os.Handler.handleCallback(Handler.java:790)
+02-28 22:56:49.312 19470 19503 E Bugle   : 	at android.os.Handler.dispatchMessage(Handler.java:99)
+02-28 22:56:49.312 19470 19503 E Bugle   : 	at android.os.Looper.loop(Looper.java:164)
+02-28 22:56:49.312 19470 19503 E Bugle   : 	at com.google.android.apps.messaging.shared.datamodel.action.c.run(SourceFile:10)
+02-28 22:56:49.313  1666  1768 D RecurrenceRule: Resolving using anchor 2020-02-28T22:56:49.313+03:00[Europe/Moscow]
+02-28 22:56:49.315  1666  1768 D RecurrenceRule: Resolving using anchor 2020-02-28T22:56:49.315+03:00[Europe/Moscow]
+02-28 22:56:49.318  1666  1768 D RecurrenceRule: Cycle 13 from 2020-02-13T00:00+03:00[Europe/Moscow] to 2020-03-13T00:00+03:00[Europe/Moscow]
+02-28 22:56:49.318  1666  1768 D NetworkStats: Resolving plan for NetworkTemplate: matchRule=MOBILE_ALL, subscriberId=310260..., matchSubscriberIds=[310260...]
+02-28 22:56:49.321  1666  1768 D NetworkStats: Found active matching subId 1
+02-28 22:56:49.327  1666  1768 D NetworkStats: Resolved to plan null
+02-28 22:56:49.328 19470 19503 I ShortcutBadger: Checking if platform supports badge counters, attempt 1/3.
+02-28 22:56:49.329 19524 19524 D CarrierServices: log_saver already enabled
+02-28 22:56:49.333 19470 19503 I ShortcutBadger: Checking if platform supports badge counters, attempt 2/3.
+02-28 22:56:49.337 19470 19503 I ShortcutBadger: Checking if platform supports badge counters, attempt 3/3.
+02-28 22:56:49.341 19470 19503 W ShortcutBadger: Badge counter seems not supported in this platform: unable to resolve intent: Intent { act=android.intent.action.BADGE_COUNT_UPDATE (has extras) }
+02-28 22:56:49.354 19524 19524 I CarrierServices: [2] e.onReceive: intent=Intent { act=android.net.conn.CONNECTIVITY_CHANGE flg=0x4000010 (has extras) }, isDeviceIdleMode=false
+02-28 22:56:49.355 19524 19524 W CarrierServices: [2] zzbgb$zza.C: Carrier Services Apk was not found.
+02-28 22:56:49.356 19524 19524 W CarrierServices: [2] zzbgb$zza.a: CarrierServices.apk was not found, not pre-loaded or is disabled.
+02-28 22:56:49.358  1666  7773 I ActivityManager: Killing 5069:com.android.defcontainer/u0a9 (adj 906): empty for 3390s
+02-28 22:56:49.359  1666  1688 W zygote  : kill(-5069, 9) failed: No such process
+02-28 22:56:49.397  1666  1688 W zygote  : kill(-5069, 9) failed: No such process
+02-28 22:56:49.410 19581 19581 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+02-28 22:56:49.417  1666  7772 I ActivityManager: Start proc 19581:android.process.acore/u0a2 for content provider com.android.providers.contacts/.ContactsProvider2
+02-28 22:56:49.434  1666  7321 I ActivityManager: Killing 17696:com.google.android.packageinstaller/u0a19 (adj 906): empty for 2852s
+02-28 22:56:49.437  1666  1688 W zygote  : kill(-5069, 9) failed: No such process
+02-28 22:56:49.437  1666  1688 I zygote  : Successfully killed process cgroup uid 10009 pid 5069 in 78ms
+02-28 22:56:49.437  1666  1688 W zygote  : kill(-17696, 9) failed: No such process
+02-28 22:56:49.444 19581 19581 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 22:56:49.477  1666  1688 W zygote  : kill(-17696, 9) failed: No such process
+02-28 22:56:49.516  1666  1688 W zygote  : kill(-17696, 9) failed: No such process
+02-28 22:56:49.516  1666  1688 I zygote  : Successfully killed process cgroup uid 10019 pid 17696 in 79ms
+02-28 22:56:49.522 19581 19581 I ContactsPerf: VoicemailContentProvider.onCreate start
+02-28 22:56:49.533 19581 19581 I ContactsPerf: VoicemailContentProvider.onCreate finish
+02-28 22:56:49.534 19581 19605 D ContactsDatabaseHelper: WAL enabled for contacts2.db: true
+02-28 22:56:49.544 19581 19581 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 22:56:49.594 19581 19581 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 22:56:49.645 19581 19605 I ContactLocale: AddressBook Labels [[en_US]]: […, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, Α, Β, Γ, Δ, Ε, Ζ, Η, Θ, Ι, Κ, Λ, Μ, Ν, Ξ, Ο, Π, Ρ, Σ, Τ, Υ, Φ, Χ, Ψ, Ω, …, А, Б, В, Г, Д, Ђ, Е, Є, Ж, З, И, І, Й, Ј, К, Л, Љ, М, Н, Њ, О, П, Р, С, Т, Ћ, У, Ф, Х, Ц, Ч, Џ, Ш, Щ, Ю, Я, …, א, ב, ג, ד, ה, ו, ז, ח, ט, י, כ, ל, מ, נ, ס, ע, פ, צ, ק, ר, ש, ת, …, ا, ب, ت, ث, ج, ح, خ, د, ذ, ر, ز, س, ش, ص, ض, ط, ظ, ع, غ, ف, ق, ك, ل, م, ن, ه, و, ي, …, ก, ข, ฃ, ค, ฅ, ฆ, ง, จ, ฉ, ช, ซ, ฌ, ญ, ฎ, ฏ, ฐ, ฑ, ฒ, ณ, ด, ต, ถ, ท, ธ, น, บ, ป, ผ, ฝ, พ, ฟ, ภ, ม, ย, ร, ฤ, ล, ฦ, ว, ศ, ษ, ส, ห, ฬ, อ, ฮ, …, ㄱ, ㄴ, ㄷ, ㄹ, ㅁ, ㅂ, ㅅ, ㅇ, ㅈ, ㅊ, ㅋ, ㅌ, ㅍ, ㅎ, …, あ, か, さ, た, な, は, ま, や, ら, わ, #, …]
+02-28 22:56:49.664 19581 19605 D ContactsDatabaseHelper: WAL enabled for profile.db: false
+02-28 22:56:49.741  1666  7772 D CountryDetector: The first listener is added
+02-28 22:56:49.848  1449  1449 I boot-pipe: done populating /dev/random
+02-28 22:56:49.866  2187 15669 I Icing   : IndexChimeraService.getServiceInterface callingPackage=com.google.android.apps.messaging componentName=null serviceId=SEARCH_CORPORA
+02-28 22:56:49.906  2187 15669 I chatty  : uid=10013(com.google.android.gms) highpool[8] identical 1 line
+02-28 22:56:49.938  2187 15669 I Icing   : IndexChimeraService.getServiceInterface callingPackage=com.google.android.apps.messaging componentName=null serviceId=SEARCH_CORPORA
+02-28 22:56:49.945  2187 18200 I zygote  : Deoptimizing boolean zf.add(java.lang.Object) due to JIT inline cache
+02-28 22:56:49.945  2187 18200 I zygote  : Deoptimizing void zp.<init>(zo, int) due to JIT inline cache
+02-28 22:56:49.946  2187 17169 I zygote  : Deoptimizing void brar.a(long) due to JIT inline cache
+02-28 22:56:50.141  2187 17169 I Icing   : Usage reports ok 15, Failed Usage reports 0, indexed 1, rejected 0, imm upload false
+02-28 22:56:50.177  2187 17169 I Icing   : Usage reports ok 0, Failed Usage reports 0, indexed 0, rejected 0, imm upload false
+02-28 22:56:50.190  2187 17169 I Icing   : Usage reports ok 0, Failed Usage reports 0, indexed 0, rejected 0, imm upload false
+02-28 22:56:50.198  1797 19614 E IcingDataProcessor: getCorpusHandlesRegisteredForIME call failed: Status{statusCode=API Disabled, resolution=null}
+02-28 22:56:53.518 19470 19491 I zygote  : Waiting for a blocking GC ProfileSaver
+02-28 22:56:53.525 19470 19491 I zygote  : WaitForGcToComplete blocked ProfileSaver on HeapTrim for 6.869ms
+02-28 22:56:54.487 19581 19600 I zygote  : Waiting for a blocking GC ProfileSaver
+02-28 22:56:54.491 19581 19600 I zygote  : WaitForGcToComplete blocked ProfileSaver on HeapTrim for 20.081ms
+02-28 22:57:04.900  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 22:57:09.010  1666  7773 I ActivityManager: Killing 18819:com.google.android.apps.photos/u0a70 (adj 906): empty for 2316s
+02-28 22:57:09.011  1666  7773 I ActivityManager: Killing 2155:com.google.android.dialer/u0a21 (adj 906): empty for 2744s
+02-28 22:57:09.017  1666  1688 W zygote  : kill(-18819, 9) failed: No such process
+02-28 22:57:09.057  1666  1688 I chatty  : uid=1000(system) ActivityManager identical 1 line
+02-28 22:57:09.097  1666  1688 W zygote  : kill(-18819, 9) failed: No such process
+02-28 22:57:09.097  1666  1688 I zygote  : Successfully killed process cgroup uid 10070 pid 18819 in 79ms
+02-28 22:57:09.097  1666  1688 W zygote  : kill(-2155, 9) failed: No such process
+02-28 22:57:09.097  1666  1688 I zygote  : Successfully killed process cgroup uid 10021 pid 2155 in 0ms
+02-28 22:57:17.958  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 22:57:17.958  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 22:57:17.958  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 22:57:18.958  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 22:57:18.958  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 22:57:18.958  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 22:57:36.003  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 22:57:43.998  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 22:57:43.998  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 22:57:43.998  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 22:57:46.116  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 22:57:46.116  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 22:57:46.164  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 22:57:46.164  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 22:57:46.208  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 22:57:46.209  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 22:57:46.238  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 22:57:46.239  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 22:57:46.266  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 22:57:46.266  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 22:57:46.294  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 22:57:46.294  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 22:57:46.326  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 22:57:46.326  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 22:57:46.355  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 22:57:46.355  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 22:57:46.388  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 22:57:46.388  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 22:57:46.416  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 22:57:46.416  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 22:57:49.850  1449  1449 I boot-pipe: done populating /dev/random
+02-28 22:57:51.038  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 22:57:51.038  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 22:57:51.038  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 22:58:00.003  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 22:58:00.003  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 22:58:00.015  1442  1465 D hwcomposer: hw_composer sent 30 syncs in 95s
+02-28 22:58:03.183  2187 15992 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 22:58:03.184  2187 15992 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 22:58:03.184  2187 15992 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 22:58:03.240  2187 15992 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 22:58:03.241  2187 15992 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 22:58:03.241  2187 15992 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 22:58:03.248  2187 15992 I zygote  : Deoptimizing void braw.a(int, java.util.List) due to JIT inline cache
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: PeriodicTaskTag : Checkin failed: https://android.googleapis.com/checkin (fragment #0): java.io.InterruptedIOException: thread interrupted
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: java.io.InterruptedIOException: thread interrupted
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at com.android.okhttp.okio.Timeout.throwIfReached(Timeout.java:145)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at com.android.okhttp.okio.Okio$1.write(Okio.java:73)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at com.android.okhttp.okio.AsyncTimeout$1.write(AsyncTimeout.java:155)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at com.android.okhttp.okio.RealBufferedSink.flush(RealBufferedSink.java:221)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at com.android.okhttp.internal.http.Http1xStream.finishRequest(Http1xStream.java:161)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at com.android.okhttp.internal.http.HttpEngine.readNetworkResponse(HttpEngine.java:735)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at com.android.okhttp.internal.http.HttpEngine.readResponse(HttpEngine.java:609)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:471)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:407)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponseCode(HttpURLConnectionImpl.java:538)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getResponseCode(DelegatingHttpsURLConnection.java:105)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getResponseCode(Unknown Source:0)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at plc.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):27)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at plc.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):199)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at com.google.android.gms.checkin.CheckinChimeraService.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):131)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at com.google.android.gms.checkin.CheckinChimeraService.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):287)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at zse.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):5)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at rrt.b(:com.google.android.gms@16089022@16.0.89 (040700-239467275):32)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at rrt.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):21)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at rxx.run(Unknown Source:7)
+02-28 22:58:03.256  2187 15992 E CheckinRequestProcessor: 	at java.lang.Thread.run(Thread.java:764)
+02-28 22:58:03.267  2187 15992 I CheckinChimeraService: Checkin result code: 0 will be retried.
+02-28 22:58:03.278 19634 19634 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+02-28 22:58:03.282  1666  7771 I ActivityManager: Start proc 19634:com.google.process.gapps/u0a13 for broadcast com.google.android.gsf/.settings.GoogleLocationSettings$LocationSettingsChangedListener
+02-28 22:58:03.301 19634 19634 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 22:58:03.323 19634 19634 I GoogleHttpClient: GMS http client unavailable, use old client
+02-28 22:58:03.353  2116 18529 I zygote  : Deoptimizing java.lang.String zxx.a(android.os.Bundle) due to JIT inline cache
+02-28 22:58:08.080  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 22:58:26.198  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 22:58:26.199  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 22:58:26.199  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 22:58:49.851  1449  1449 I boot-pipe: done populating /dev/random
+02-28 22:59:00.002  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 22:59:00.002  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 22:59:00.011  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 22:59:26.093  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 22:59:26.093  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 22:59:26.201  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 22:59:26.201  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 22:59:26.201  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 22:59:26.227  1666 19660 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS www.google.com 29ms OK 173.194.222.106,2a00:1450:4010:c07::63
+02-28 22:59:26.232  1666 19661 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_DNS connectivitycheck.gstatic.com 33ms OK 64.233.165.94,2a00:1450:4010:c08::5e
+02-28 22:59:26.279  1666 19661 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=47ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:59:26 GMT], X-Android-Received-Millis=[1582919966278], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1582919966256]}
+02-28 22:59:26.319  1666 19660 D NetworkMonitor/NetworkAgentInfo [WIFI () - 101]: PROBE_HTTPS https://www.google.com/generate_204 time=91ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Alt-Svc=[quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443"; ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:59:26 GMT], X-Android-Received-Millis=[1582919966319], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1582919966295]}
+02-28 22:59:26.320  1666  1775 D ConnectivityService: NetworkAgentInfo [WIFI () - 101] validation passed
+02-28 22:59:26.328  2348 19666 I zygote  : Deoptimizing java.lang.Object com.google.common.util.concurrent.aj.dY(java.util.List) due to JIT inline cache
+02-28 22:59:29.067  1666  7777 D WificondControl: Scan result ready event
+02-28 22:59:36.328  1666  1771 W AlarmManager: Unrecognized alarm listener com.android.server.wifi.WifiConfigStore$1@4247093
+02-28 22:59:36.335  1666  1771 D WifiConfigStore: Writing to stores completed in 7 ms.
+02-28 22:59:41.358  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 22:59:41.358  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 22:59:41.358  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 22:59:46.819  1666 19670 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS www.google.com 6ms OK 173.194.222.103,2a00:1450:4010:c07::63
+02-28 22:59:46.819  1666 19671 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_DNS connectivitycheck.gstatic.com 6ms OK 64.233.165.94,2a00:1450:4010:c08::5e
+02-28 22:59:46.869  1666 19671 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTP http://connectivitycheck.gstatic.com/generate_204 time=49ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:59:46 GMT], X-Android-Received-Millis=[1582919986869], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1582919986845]}
+02-28 22:59:46.889  1666 19670 D NetworkMonitor/NetworkAgentInfo [MOBILE (LTE) - 100]: PROBE_HTTPS https://www.google.com/generate_204 time=69ms ret=204 request={User-Agent=[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36]} headers={null=[HTTP/1.1 204 No Content], Alt-Svc=[quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443"; ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000], Content-Length=[0], Date=[Fri, 28 Feb 2020 19:59:46 GMT], X-Android-Received-Millis=[1582919986889], X-Android-Response-Source=[NETWORK 204], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1582919986867]}
+02-28 22:59:46.891  1666  1775 D ConnectivityService: NetworkAgentInfo [MOBILE (LTE) - 100] validation passed
+02-28 22:59:49.852  1449  1449 I boot-pipe: done populating /dev/random
+02-28 22:59:56.962  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 23:00:00.003  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:00:00.003  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:00:00.017  1442  1465 D hwcomposer: hw_composer sent 12 syncs in 60s
+02-28 23:00:00.041  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:00:00.041  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:00:26.109  1666  1685 I ProcessStatsService: Pruning old procstats: /data/system/procstats/state-2019-08-14-23-01-00.bin
+02-28 23:00:26.205  2187 15992 I CheckinChimeraService: Starting Checkin Task: RetryTaskTag Reason : -1 Force : false UserId: 0
+02-28 23:00:26.219  2187 15992 I EventLogChimeraService: Accumulating logs since 1578872122430
+02-28 23:00:26.435  2187 15992 I CheckinRequestProcessor: Gmscore running on device, checkin will use Gmscore context
+02-28 23:00:26.435  2187 15992 I CheckinRequestBuilder: Checkin reason type: 0 attempt count: 1
+02-28 23:00:26.446  1666  7771 I WifiService: getConnectionInfo uid=10013
+02-28 23:00:26.488  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:00:26.488  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:00:26.489  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:00:43.520  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 23:00:49.854  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:00:56.767 17969 17976 I zygote  : Do partial code cache collection, code=30KB, data=27KB
+02-28 23:00:56.768 17969 17976 I zygote  : After code cache collection, code=28KB, data=27KB
+02-28 23:00:56.768 17969 17976 I zygote  : Increasing code cache capacity to 128KB
+02-28 23:00:56.832 19686 19686 W dex2oat : Unexpected CPU variant for X86 using defaults: x86
+02-28 23:00:56.832 19686 19686 I dex2oat : The ClassLoaderContext is a special shared library.
+02-28 23:00:56.832 19686 19686 W dex2oat : Mismatch between dex2oat instruction set features (ISA: X86 Feature string: -ssse3,-sse4.1,-sse4.2,-avx,-avx2,-popcnt) and those of dex2oat executable (ISA: X86 Feature string: ssse3,-sse4.1,-sse4.2,-avx,-avx2,-popcnt) for the command line:
+02-28 23:00:56.832 19686 19686 W dex2oat : /system/bin/dex2oat --instruction-set=x86 --instruction-set-features=ssse3,-sse4.1,-sse4.2,-avx,-avx2,-popcnt --runtime-arg -Xrelocate --boot-image=/system/framework/boot.art --runtime-arg -Xms64m --runtime-arg -Xmx512m --instruction-set-variant=x86 --instruction-set-features=default --dex-file=/data/data/com.google.android.gms/app_dg_cache/02E902B6A2D8590C965EAED5529BD80BA58BFED2/the.apk --output-vdex-fd=55 --oat-fd=56 --oat-location=/data/data/com.google.android.gms/app_dg_cache/02E902B6A2D8590C965EAED5529BD80BA58BFED2/oat/x86/the.odex --compiler-filter=quicken --class-loader-context=&
+02-28 23:00:56.833 19686 19686 I dex2oat : /system/bin/dex2oat --dex-file=/data/data/com.google.android.gms/app_dg_cache/02E902B6A2D8590C965EAED5529BD80BA58BFED2/the.apk --output-vdex-fd=55 --oat-fd=56 --oat-location=/data/data/com.google.android.gms/app_dg_cache/02E902B6A2D8590C965EAED5529BD80BA58BFED2/oat/x86/the.odex --compiler-filter=quicken --class-loader-context=&
+02-28 23:00:56.927 19686 19686 I dex2oat : dex2oat took 95.439ms (108.941ms cpu) (threads: 4) arena alloc=6KB (7120B) java alloc=64KB (66072B) native alloc=1365KB (1398552B) free=1706KB (1747176B)
+02-28 23:00:56.932 17969 17986 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 23:00:56.939 17969 17986 W linker  : "/data/data/com.google.android.gms/app_dg_cache/02E902B6A2D8590C965EAED5529BD80BA58BFED2/the.apk!/libd9A8A5BB67AEA.so" has unsupported flags DT_FLAGS_1=0x1001
+02-28 23:00:57.179 17969 17986 D         : HostConnection::get() New Host Connection established 0xcbd75b80, tid 17986
+02-28 23:00:57.181 17969 17986 I zygote  : android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 0
+02-28 23:00:57.190 17969 17986 D EGL_emulation: eglCreateContext: 0xe0da9ce0: maj 2 min 0 rcv 2
+02-28 23:00:57.220 17969 17986 D EGL_emulation: eglMakeCurrent: 0xe0da9ce0: ver 2 0 (tinfo 0xcb326800)
+02-28 23:00:57.286 17969 17986 I zygote  : android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 0
+02-28 23:00:57.287 17969 17986 D EGL_emulation: eglCreateContext: 0xe0da9f80: maj 2 min 0 rcv 2
+02-28 23:00:57.290 17969 17986 D EGL_emulation: eglMakeCurrent: 0xe0da9f80: ver 2 0 (tinfo 0xcb326800)
+02-28 23:00:57.345 17969 17986 W SystemServiceRegistry: No service published for: persistent_data_block
+02-28 23:00:57.408  2187 15992 I CheckinUtil: Classify the device as Phone.
+02-28 23:00:57.414  2187 15992 I CheckinConnFactory: Get token from PseudonymousIdApi: 196=t_HU9Mp8-ePSaU7LkWbT1VDIMea5ty0DPpdFxMOHvCDA8T-2qUrK2rnSL6Qm_quiM_vSWyMsQC2jtftS6BeaXUKRZmJNSobJ2Qi3QI4m70btsgfYk2WBd_zf2OiuFm1uX2Y9hfIx6fHy0XRjjKltHiLH8yV3lHI6purOVJnUPpU
+02-28 23:00:57.416  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:00:57.416  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:00:57.437  2187 15992 I CheckinRequestProcessor: set cookie as: NID=196=t_HU9Mp8-ePSaU7LkWbT1VDIMea5ty0DPpdFxMOHvCDA8T-2qUrK2rnSL6Qm_quiM_vSWyMsQC2jtftS6BeaXUKRZmJNSobJ2Qi3QI4m70btsgfYk2WBd_zf2OiuFm1uX2Y9hfIx6fHy0XRjjKltHiLH8yV3lHI6purOVJnUPpU
+02-28 23:00:57.468  2187 15992 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:00:57.468  2187 15992 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:00:57.468  2187 15992 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:00:57.491  2187 15992 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:00:57.492  2187 15992 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:00:57.492  2187 15992 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:00:57.793  2187 15992 I CheckinResponseProcess: From server: 1686 gservices [full]
+02-28 23:00:58.202  2249  3070 I GservicesProvider: main update completed
+02-28 23:00:58.212 19702 19702 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+02-28 23:00:58.216  1666  1686 I ActivityManager: Start proc 19702:com.google.android.apps.photos/u0a70 for broadcast com.google.android.apps.photos/com.google.android.apps.moviemaker.app.ApplicationEnabler$Receiver
+02-28 23:00:58.262 19702 19702 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 23:00:58.303 19470 19470 I BugleRcs: updating RCS availability
+02-28 23:00:58.324  2187 15992 I CheckinRequestProcessor: RetryTaskTag : Checkin Succeeded: https://android.googleapis.com/checkin (fragment #1): 
+02-28 23:00:58.329 19470 19502 V Bugle   : Executing sticker action: com.google.android.apps.messaging.shared.datamodel.sticker.SyncStickerSetListAction
+02-28 23:00:58.333 19470 19470 I CarrierServices: [2] a.connect: Binding to local JibeService
+02-28 23:00:58.344 19470 19725 I Bugle   : ApnsOta: OTA version -1
+02-28 23:00:58.358 19470 19470 I CarrierServices: [2] a.connect: Binding to local JibeService
+02-28 23:00:58.365 19702 19707 I zygote  : Do partial code cache collection, code=0B, data=15KB
+02-28 23:00:58.367 19702 19707 I zygote  : After code cache collection, code=0B, data=15KB
+02-28 23:00:58.367 19702 19707 I zygote  : Increasing code cache capacity to 128KB
+02-28 23:00:58.404 19524 19700 D CarrierServices: log_saver already enabled
+02-28 23:00:58.445 19470 19727 V BugleRcs: RcsAvailability updated but unchanged: RCS is disabled for this carrier by Google
+02-28 23:00:58.549  2116 19739 I NetRec  : [1141] aisw.b: onConfigChanged()
+02-28 23:00:58.585  2116 19739 I NetRec  : [1141] aisw.b: Cancelling all NetRec GCM tasks
+02-28 23:00:58.589  2116 19742 I GCoreUlr: Starting service, intent=Intent { act=com.google.android.location.reporting.ACTION_UPDATE_WORLD cmp=com.google.android.gms/com.google.android.location.reporting.service.DispatchingService (has extras) }, extras=Bundle[{receiverAction=com.google.gservices.intent.action.GSERVICES_CHANGED}]
+02-28 23:00:58.602  2116 19744 I NetRec  : [1145] ClearDatabaseService.onHandleIntent: Clearing score cache
+02-28 23:00:58.616  1666  1676 I zygote  : Background concurrent copying GC freed 96833(4MB) AllocSpace objects, 17(560KB) LOS objects, 35% free, 11MB/17MB, paused 723us total 158.021ms
+02-28 23:00:58.641  2187 19736 I zygote  : Deoptimizing int brdn.a(java.lang.Object, byte[], int, int, int, int, int, int, long, int, long, bqzs) due to JIT inline cache
+02-28 23:00:58.645  2116  2116 E BluetoothAdapter: Bluetooth binder is null
+02-28 23:00:58.665  2116 18741 I GCoreUlr: WorldUpdater received intent Intent { act=com.google.android.location.reporting.ACTION_UPDATE_WORLD cmp=com.google.android.gms/com.google.android.location.reporting.service.DispatchingService (has extras) } with receiverAction com.google.gservices.intent.action.GSERVICES_CHANGED
+02-28 23:00:58.671  2116 18528 I zygote  : Deoptimizing void blim.b(java.lang.Runnable, java.util.concurrent.Executor) due to JIT inline cache
+02-28 23:00:58.671  2116 18528 I GCoreUlr: Successfully sent flags updated to controllers.
+02-28 23:00:58.687  2116  2128 I zygote  : Background concurrent copying GC freed 103102(5MB) AllocSpace objects, 5(136KB) LOS objects, 41% free, 8MB/14MB, paused 829us total 144.317ms
+02-28 23:00:58.694  2116 18741 I GCoreUlr: WorldUpdater:com.google.gservices.intent.action.GSERVICES_CHANGED: Ensuring that reporting is stopped because of reasons: (no Google accounts)
+02-28 23:00:58.703  2116 18741 I GCoreUlr: Unbound from all signal providers.
+02-28 23:00:58.705  2116 18734 I GCoreUlr: Successfully accounts update
+02-28 23:00:58.712  2116 18741 I GCoreUlr: DispatchingService ignoring Intent { act=android.net.wifi.WIFI_STATE_CHANGED flg=0x4000010 (has extras) } because ULR inactive
+02-28 23:00:58.720  1666  3589 W ActivityManager: Unable to start service Intent { cmp=com.google.android.gms/.analytics.service.RefreshEnabledStateService } U=0: not found
+02-28 23:00:58.726  2187 19736 W ChimeraUtils: Non Chimera context
+02-28 23:00:58.726  2187 19736 W ChimeraUtils: Non Chimera context
+02-28 23:00:58.731  2116  2116 I GCoreUlr: Unbound from all signal providers.
+02-28 23:00:58.731  2116  2116 I GCoreUlr: Stopping handler for UlrDispSvcFast
+02-28 23:00:58.733  2116 18741 I GCoreUlr: Successfully accounts update
+02-28 23:00:58.740  2187 19752 W DynamiteModule: Local module descriptor class for providerinstaller not found.
+02-28 23:00:58.741  2187 19752 I DynamiteModule: Considering local module providerinstaller:0 and remote module providerinstaller:0
+02-28 23:00:58.741  2187 19752 W ProviderInstaller: Failed to load providerinstaller module: No acceptable module found. Local version is 0 and remote version is 0.
+02-28 23:00:58.749  2187 19752 W DynamiteModule: Local module descriptor class for providerinstaller not found.
+02-28 23:00:58.750  2187 19752 I DynamiteModule: Considering local module providerinstaller:0 and remote module providerinstaller:0
+02-28 23:00:58.750  2187 19752 W ProviderInstaller: Failed to load providerinstaller module: No acceptable module found. Local version is 0 and remote version is 0.
+02-28 23:00:58.767  2187 19752 W DynamiteModule: Local module descriptor class for providerinstaller not found.
+02-28 23:00:58.767  2187 19752 I DynamiteModule: Considering local module providerinstaller:0 and remote module providerinstaller:0
+02-28 23:00:58.768  2187 19752 W ProviderInstaller: Failed to load providerinstaller module: No acceptable module found. Local version is 0 and remote version is 0.
+02-28 23:00:58.774  2187 19752 W DynamiteModule: Local module descriptor class for providerinstaller not found.
+02-28 23:00:58.774  2187 19752 I DynamiteModule: Considering local module providerinstaller:0 and remote module providerinstaller:0
+02-28 23:00:58.774  2187 19752 W ProviderInstaller: Failed to load providerinstaller module: No acceptable module found. Local version is 0 and remote version is 0.
+02-28 23:00:58.775  2187 19747 D CAR.SETUP: Received GService flag change intent.
+02-28 23:00:58.779  2187 19736 I ChromeSync: [Sync,SyncIntentOperation] Handling the intent: Intent { act=com.google.gservices.intent.action.GSERVICES_CHANGED flg=0x1000010 cmp=com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver }.
+02-28 23:00:58.788  2187 19747 D CAR.SETUP: update DrivingMode components to false
+02-28 23:00:58.792  2116  2116 I GeofencerStateMachine: sendQueryLocationOptIn
+02-28 23:00:58.807  2116  2116 I chatty  : uid=10013 com.google.android.gms.persistent identical 1 line
+02-28 23:00:58.820  2116  2116 I GeofencerStateMachine: sendQueryLocationOptIn
+02-28 23:00:58.824  2187 19752 W DynamiteModule: Local module descriptor class for providerinstaller not found.
+02-28 23:00:58.824  2187 19752 I DynamiteModule: Considering local module providerinstaller:0 and remote module providerinstaller:0
+02-28 23:00:58.825  2187 19752 W ProviderInstaller: Failed to load providerinstaller module: No acceptable module found. Local version is 0 and remote version is 0.
+02-28 23:00:58.838  2187 19752 W DynamiteModule: Local module descriptor class for providerinstaller not found.
+02-28 23:00:58.838  2187 19752 I DynamiteModule: Considering local module providerinstaller:0 and remote module providerinstaller:0
+02-28 23:00:58.839  2187 19752 W ProviderInstaller: Failed to load providerinstaller module: No acceptable module found. Local version is 0 and remote version is 0.
+02-28 23:00:58.839  2116  2116 I GeofencerStateMachine: sendQueryLocationOptIn
+02-28 23:00:58.849  2187 19752 W DynamiteModule: Local module descriptor class for providerinstaller not found.
+02-28 23:00:58.849  2187 19752 I DynamiteModule: Considering local module providerinstaller:0 and remote module providerinstaller:0
+02-28 23:00:58.849  2187 19752 W ProviderInstaller: Failed to load providerinstaller module: No acceptable module found. Local version is 0 and remote version is 0.
+02-28 23:00:58.862  2187 19752 W DynamiteModule: Local module descriptor class for providerinstaller not found.
+02-28 23:00:58.863  2187 19752 I DynamiteModule: Considering local module providerinstaller:0 and remote module providerinstaller:0
+02-28 23:00:58.863  2187 19752 W ProviderInstaller: Failed to load providerinstaller module: No acceptable module found. Local version is 0 and remote version is 0.
+02-28 23:00:58.870  2116  2116 I GeofencerStateMachine: sendQueryLocationOptIn
+02-28 23:00:58.897  2116  2116 I chatty  : uid=10013 com.google.android.gms.persistent identical 1 line
+02-28 23:00:58.935  2116  2116 I GeofencerStateMachine: sendQueryLocationOptIn
+02-28 23:00:59.004  2187 19758 I GCM-GMS : Scheduling task to register GMS
+02-28 23:00:59.069  2116 19739 I Herrevad: [1141] ModuleSwitchIntentOperation.a: reconfiguring Herrevad
+02-28 23:00:59.085  2187 19747 I MobileDataHub: Scheduling periodic tasks
+02-28 23:00:59.159  2187 19747 I MS_Utils: version of com.google.android.apps.maps = 956702030
+02-28 23:00:59.309  2187 19736 I ChromeSync: [Persistence,AffiliationManager] Fetching affiliations from the server.
+02-28 23:00:59.322  2116 18741 W zygote  : Long monitor contention with owner netscheduler-queue-handler (2988) at void aaat.a(aaaq, zxr)(:com.google.android.gms@16089022@16.0.89 (040700-239467275):97) waiters=0 in void aaat.a(boolean, zyn) for 333ms
+02-28 23:00:59.331  2187 19736 I zygote  : Deoptimizing blju bgob.a(blju) due to JIT inline cache
+02-28 23:00:59.355  2187 17169 I CheckinChimeraService: Starting Checkin Task: PeriodicTaskTag Reason : -1 Force : false UserId: 0
+02-28 23:00:59.431  2187  3404 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:00:59.431  2187  3404 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:00:59.431  2187  3404 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:00:59.458  2187 19753 I SystemUpdate: [Installation,ReceiverIntentOperation] Received intent: Intent { act=com.google.gservices.intent.action.GSERVICES_CHANGED flg=0x1000010 cmp=com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver }.
+02-28 23:00:59.494  2187 19758 I SystemUpdate: [Execution,InstallationEventIntentOperation] Handling event of type 2.
+02-28 23:00:59.499  2187 19751 I SystemUpdate: [Execution,InstallationIntentOperation] Received intent: Intent { act=com.google.android.gms.update.INSTALL_UPDATE cat=[targeted_intent_op_prefix:.update.execution.InstallationIntentOperation] cmp=com.google.android.gms/.chimera.GmsIntentOperationService }.
+02-28 23:00:59.500  2187 17169 I EventLogChimeraService: Accumulating logs since 1582920026223
+02-28 23:00:59.507  2187 19751 I SystemUpdate: [Execution,ExecutionManager] Action finished-execution executed for 0.00 seconds.
+02-28 23:00:59.516  2187  3404 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:00:59.516  2187  3404 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:00:59.516  2187  3404 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:00:59.517  2187 19747 I OcrModelUpStIntentOp: Updating ocr activity enabled=true (phenotypeFlag=true, lowRamDevice=false, prereqCheck=true)
+02-28 23:00:59.591  2187 19747 I OcrModelUpStIntentOp: Downloading text recognizer
+02-28 23:00:59.638  2116  2116 I zygote  : Deoptimizing void raq.<init>(android.content.Context, int, int[], byte) due to JIT inline cache
+02-28 23:00:59.682  2116 19762 I CheckinUtil: Classify the device as Phone.
+02-28 23:00:59.780  2116 19762 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:00:59.780  2116 19762 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:00:59.780  2116 19762 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:00:59.846  2116 19762 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:00:59.847  2116 19762 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:00:59.847  2116 19762 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:00:59.848  2116 19762 I zygote  : Deoptimizing void braw.d(int, long) due to JIT inline cache
+02-28 23:00:59.893  2116 18528 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:00:59.893  2116 18528 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:00:59.893  2116 18528 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:00:59.910  2116 19762 I zygote  : Deoptimizing int brao.a() due to JIT inline cache
+02-28 23:00:59.910  2116 19762 I zygote  : Deoptimizing int brao.p() due to JIT inline cache
+02-28 23:00:59.910  2116 19762 I zygote  : Deoptimizing java.lang.Object brao.c(bree, brbd) due to JIT inline cache
+02-28 23:00:59.910  2116 19762 I zygote  : Deoptimizing void brao.a(java.util.List, bree, brbd) due to JIT inline cache
+02-28 23:00:59.910  2187 17169 I CheckinRequestProcessor: Gmscore running on device, checkin will use Gmscore context
+02-28 23:00:59.910  2116 19762 I zygote  : Deoptimizing void brao.a(java.util.List, bree, brbd) due to JIT inline cache
+02-28 23:00:59.911  2187 17169 I CheckinRequestBuilder: Checkin reason type: 0 attempt count: 1
+02-28 23:00:59.942  2187 19747 I Vision  : Details: ocr_x86.zip, ff3dcfd5e3828224849fbeffe1ed2e71a7ad3400
+02-28 23:00:59.944  2187 19747 I Vision  : Engine already satisfied by existing download for ocr
+02-28 23:00:59.959  2116 18528 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:00:59.959  2116 18528 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:00:59.959  2116 18528 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:01:00.002  1666  7776 I WifiService: getConnectionInfo uid=10013
+02-28 23:01:00.008  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:01:00.348 17969 17986 I zygote  : android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 0
+02-28 23:01:00.350 17969 17986 D EGL_emulation: eglCreateContext: 0xe8de5ac0: maj 2 min 0 rcv 2
+02-28 23:01:00.352 17969 17986 D EGL_emulation: eglMakeCurrent: 0xe8de5ac0: ver 2 0 (tinfo 0xcb326800)
+02-28 23:01:00.398 17969 17986 I zygote  : android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 0
+02-28 23:01:00.400 17969 17986 D EGL_emulation: eglCreateContext: 0xe8de5e20: maj 2 min 0 rcv 2
+02-28 23:01:00.402 17969 17986 D EGL_emulation: eglMakeCurrent: 0xe8de5e20: ver 2 0 (tinfo 0xcb326800)
+02-28 23:01:00.450 17969 17986 W SystemServiceRegistry: No service published for: persistent_data_block
+02-28 23:01:00.525  2187 17169 I CheckinUtil: Classify the device as Phone.
+02-28 23:01:00.532  2116 18528 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:01:00.532  2116 18528 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:01:00.532  2116 18528 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:01:00.535  2187 17169 I CheckinConnFactory: Get token from PseudonymousIdApi: 199=DURY95uNHoyqisIRPcdbuL4n3t32nFAWUp0g7kM_EUc4o7XaBqDD-oXKOECKLpNc_RuhFMD5NFuY2DSVUu176aKRS-YLeSC-Jjko0Z9rR3wgCOhftU1Ye3OmZJbN6XMmi_9zL_C117zGmfjs9WKXq9n2CqBeowGXTc2V3zxhscc
+02-28 23:01:00.546  2187 17169 I CheckinRequestProcessor: set cookie as: NID=199=DURY95uNHoyqisIRPcdbuL4n3t32nFAWUp0g7kM_EUc4o7XaBqDD-oXKOECKLpNc_RuhFMD5NFuY2DSVUu176aKRS-YLeSC-Jjko0Z9rR3wgCOhftU1Ye3OmZJbN6XMmi_9zL_C117zGmfjs9WKXq9n2CqBeowGXTc2V3zxhscc
+02-28 23:01:00.561  2116 18528 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:01:00.561  2116 18528 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:01:00.561  2116 18528 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:01:00.572  2187 17169 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:01:00.572  2187 17169 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:01:00.572  2187 17169 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:01:00.597  2187 17169 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:01:00.597  2187 17169 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:01:00.597  2187 17169 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:01:00.748  2187 17169 I CheckinRequestProcessor: updateCheckinIdTokenFileFromResponse, Reading existing AID
+02-28 23:01:00.761  2187 15992 I GCM-GMS : Registering GMS 745476177629
+02-28 23:01:00.766  2187 17169 I CheckinRequestProcessor: PeriodicTaskTag : Checkin Succeeded: https://android.googleapis.com/checkin (fragment #1): 
+02-28 23:01:00.769  2187 15992 I zygote  : Deoptimizing void rrs.<init>(int, int, java.util.concurrent.BlockingQueue) due to JIT inline cache
+02-28 23:01:00.788  2187 19747 I GCM-GMS : Scheduling task to register GMS
+02-28 23:01:00.938  2116 18734 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:01:00.938  2116 18734 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:01:00.938  2116 18734 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:01:01.000  2116 18734 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:01:01.000  2116 18734 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:01:01.001  2116 18734 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:01:01.029  2116 18528 E NetworkScheduler.ATC: Called cancelTask for already completed task com.google.android.gms/.gcm.gmsproc.GcmInGmsTaskService{u=0 tag="groups_upload" trigger=window{start=0s,end=30s,earliest=-1s,latest=28s} requirements=[NET_CONNECTED] attributes=[PERSISTED] scheduled=-1s last_run=0s jid=N/A status=ACTIVE retries=0 client_lib=MANCHEGO_GCM-16089000} :RESCHEDULED
+02-28 23:01:01.031  2187 15992 W GCM-GMS : Failed to get registration: java.io.IOException: SERVICE_NOT_AVAILABLE
+02-28 23:01:01.145  2187 15992 I GCM-GMS : Registering GMS 745476177629
+02-28 23:01:01.237  2116 18528 W zygote  : Long monitor contention with owner netscheduler-queue-handler (2988) at void aaat.a(aaaq, zxr)(:com.google.android.gms@16089022@16.0.89 (040700-239467275):97) waiters=0 in void aaat.b(zxr) for 134ms
+02-28 23:01:01.313  2187 15992 I GCM-GMS : Got GMS registration
+02-28 23:01:03.472  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.stats.service.DropBoxEntryAddedReceiver
+02-28 23:01:03.472  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+02-28 23:01:08.212 19777 19777 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+02-28 23:01:08.214  1666  1666 I ActivityManager: Start proc 19777:com.google.android.configupdater/u0a5 for service com.google.android.configupdater/.MainJobService
+02-28 23:01:08.230 19777 19777 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 23:01:08.308 19777 19809 I ConfigUpdater: Update started
+02-28 23:01:08.389 19440 19813 D DownloadManager: [16] Starting
+02-28 23:01:08.421 19440 19813 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+02-28 23:01:08.425 19440 19813 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+02-28 23:01:08.636 19440 19813 D DownloadManager: [16] Finished with status SUCCESS
+02-28 23:01:08.730 19440 19832 D DownloadManager: [17] Starting
+02-28 23:01:08.752 19440 19832 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+02-28 23:01:08.895 19440 19832 W DownloadManager: [17] Stop requested with status HTTP_DATA_ERROR: Failed reading response: java.net.ProtocolException: unexpected end of stream
+02-28 23:01:08.896 19440 19832 D DownloadManager: [17] Finished with status CANNOT_RESUME
+02-28 23:01:08.956 19777 19777 I ConfigUpdater: Download failed, retrying...
+02-28 23:01:13.673  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.stats.service.DropBoxEntryAddedReceiver
+02-28 23:01:13.674  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+02-28 23:01:23.918  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:01:23.918  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:01:23.918  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:01:28.697  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:01:28.697  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:01:28.743  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:01:28.743  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:01:28.773  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:01:28.773  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:01:41.748  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:01:41.748  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:01:41.748  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:01:49.856  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:02:00.004  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:02:00.004  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:02:00.017  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:02:00.036  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:02:00.036  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:02:00.066  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:02:00.066  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:02:00.099  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:02:00.099  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:02:00.128  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:02:00.128  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:02:09.058  1666  7772 D WificondControl: Scan result ready event
+02-28 23:02:18.002  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 23:02:22.999  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:02:22.999  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:02:22.999  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:02:49.857  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:03:00.008  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:03:06.314  2116 18734 I NetRec  : [1104] aivq.a: Refreshing scores for 1 networks.
+02-28 23:03:06.384  2116  2536 E aljp    : Phenotype API error. Event # btjh@ff8d1cd8, EventCode: GET_COMMITTED_CONFIGURATION [CONTEXT service_id=51 ]
+02-28 23:03:06.384  2116  2536 E aljp    : alif: 29503
+02-28 23:03:06.384  2116  2536 E aljp    : 	at aljw.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):38)
+02-28 23:03:06.384  2116  2536 E aljp    : 	at aljv.b(Unknown Source:2)
+02-28 23:03:06.384  2116  2536 E aljp    : 	at aljp.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):101)
+02-28 23:03:06.384  2116  2536 E aljp    : 	at aljp.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):95)
+02-28 23:03:06.384  2116  2536 E aljp    : 	at zgb.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):27)
+02-28 23:03:06.384  2116  2536 E aljp    : 	at bgot.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:03:06.384  2116  2536 E aljp    : 	at rrt.b(:com.google.android.gms@16089022@16.0.89 (040700-239467275):32)
+02-28 23:03:06.384  2116  2536 E aljp    : 	at rrt.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):21)
+02-28 23:03:06.384  2116  2536 E aljp    : 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+02-28 23:03:06.384  2116  2536 E aljp    : 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+02-28 23:03:06.384  2116  2536 E aljp    : 	at rxx.run(Unknown Source:7)
+02-28 23:03:06.384  2116  2536 E aljp    : 	at java.lang.Thread.run(Thread.java:764)
+02-28 23:03:06.388  2116  2536 E AsyncOperation: serviceID=51, operation=GetCommittedConfigurationOperationCall
+02-28 23:03:06.388  2116  2536 E AsyncOperation: OperationException[Status{statusCode=unknown status code: 29503, resolution=null}]
+02-28 23:03:06.388  2116  2536 E AsyncOperation: 	at aljp.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):109)
+02-28 23:03:06.388  2116  2536 E AsyncOperation: 	at aljp.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):95)
+02-28 23:03:06.388  2116  2536 E AsyncOperation: 	at zgb.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):27)
+02-28 23:03:06.388  2116  2536 E AsyncOperation: 	at bgot.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:03:06.388  2116  2536 E AsyncOperation: 	at rrt.b(:com.google.android.gms@16089022@16.0.89 (040700-239467275):32)
+02-28 23:03:06.388  2116  2536 E AsyncOperation: 	at rrt.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):21)
+02-28 23:03:06.388  2116  2536 E AsyncOperation: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+02-28 23:03:06.388  2116  2536 E AsyncOperation: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+02-28 23:03:06.388  2116  2536 E AsyncOperation: 	at rxx.run(Unknown Source:7)
+02-28 23:03:06.388  2116  2536 E AsyncOperation: 	at java.lang.Thread.run(Thread.java:764)
+02-28 23:03:06.389  2116  2972 E NetRec  : [126] aiss.a: Could not retrieve server token for package com.google.android.apps.gcs
+02-28 23:03:06.389  2116  2972 E NetRec  : java.util.concurrent.ExecutionException: qkj: 29503: 
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at asip.b(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at asip.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):29)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at aiss.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at aiss.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):4)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at aisp.getHeaders(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at com.android.volley.toolbox.HttpClientStack.performRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):9)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at rki.performRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at bry.executeRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):1)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at com.android.volley.toolbox.BasicNetwork.performRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):10)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at rkj.performRequest(:com.google.android.gms@16089022@16.0.89 (040700-239467275):13)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at com.android.volley.NetworkDispatcher.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):7)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at com.android.volley.NetworkDispatcher.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:03:06.389  2116  2972 E NetRec  : Caused by: qkj: 29503: 
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at qqg.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):3)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at alhk.b(:com.google.android.gms@16089022@16.0.89 (040700-239467275):3)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at aljv.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):5)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at zfv.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):5)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at zgb.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):34)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at bgot.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at rrt.b(:com.google.android.gms@16089022@16.0.89 (040700-239467275):32)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at rrt.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):21)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at rxx.run(Unknown Source:7)
+02-28 23:03:06.389  2116  2972 E NetRec  : 	at java.lang.Thread.run(Thread.java:764)
+02-28 23:03:06.389  2116  2972 W NetRec  : [126] aiss.a: No server tokens extracted.
+02-28 23:03:06.401  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:03:06.401  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:03:06.401  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:03:06.491  2116  2972 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:03:06.491  2116  2972 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:03:06.491  2116  2972 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:03:06.550  2116  2972 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:03:06.551  2116  2972 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:03:06.551  2116  2972 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:03:06.634  2116 18734 I NetRec  : [1104] aivq.a: Completed rapid_refresh_scores_task score refresh task in 324 ms, returning 0
+02-28 23:03:21.678  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:03:21.678  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:03:21.678  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:03:26.292  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:03:26.292  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:03:26.292  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:03:41.398  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:03:41.398  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:03:41.398  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:03:49.860  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:03:56.961  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 23:04:00.005  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:04:00.005  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:04:00.009  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:04:26.282  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:04:26.282  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:04:26.282  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:04:41.358  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:04:41.358  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:04:41.358  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:04:49.077  1666  7772 D WificondControl: Scan result ready event
+02-28 23:04:49.861  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:04:56.662  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:04:56.662  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:04:56.662  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:05:00.015  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:05:16.359  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:05:16.359  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:05:16.359  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:05:49.863  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:05:56.770  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:05:56.770  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:05:56.770  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:06:00.007  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:06:00.007  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:06:00.026  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:06:16.318  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:06:16.318  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:06:16.318  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:06:49.865  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:07:00.015  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:07:06.634  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:07:06.634  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:07:06.634  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:07:21.679  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:07:21.679  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:07:21.679  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:07:29.067  1666  7772 D WificondControl: Scan result ready event
+02-28 23:07:49.865  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:08:00.007  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:08:00.007  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:08:00.026  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:08:06.616  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:08:06.616  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:08:06.616  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:08:21.637  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:08:21.637  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:08:21.637  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:08:26.106  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:08:26.106  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:08:26.148  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:08:26.148  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:08:26.192  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:08:26.192  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:08:26.224  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:08:26.224  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:08:49.867  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:08:55.087  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:08:55.087  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:08:55.087  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:09:00.018  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:04:56.921  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 23:09:05.099  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 23:09:10.118  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:09:10.118  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:09:10.118  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:09:49.870  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:10:00.003  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:10:00.003  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:10:00.026  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:10:00.071  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:10:00.071  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:10:00.107  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:10:00.107  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:10:00.145  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:10:00.145  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:10:06.102  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:10:06.102  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:10:09.077  1666  7321 D WificondControl: Scan result ready event
+02-28 23:10:49.872  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:11:00.014  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:11:49.874  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:12:00.009  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:12:00.009  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:12:00.014  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:12:49.068  1666  7321 D WificondControl: Scan result ready event
+02-28 23:12:49.068  1869  1869 I wpa_supplicant: nl80211: send_and_recv->nl_recvmsgs failed: -33
+02-28 23:12:49.877  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:13:00.013  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:13:03.278  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:13:03.278  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:13:03.278  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:13:03.408  1666  7321 I WifiService: getConnectionInfo uid=10013
+02-28 23:13:03.475  1666  7776 I WifiService: getConnectionInfo uid=10013
+02-28 23:13:03.500  1666  7776 I WifiService: getConnectionInfo uid=10013
+02-28 23:13:18.518  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:13:18.518  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:13:18.518  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:13:49.878  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:14:00.011  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:14:00.011  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:14:00.025  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:14:49.880  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:15:00.003  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:15:00.003  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:15:00.019  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:15:26.115 19879 19879 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+02-28 23:15:26.120  1666  1666 I ActivityManager: Start proc 19879:com.google.android.dialer/u0a21 for service com.google.android.dialer/com.google.android.apps.dialer.spam.impl.SpamJobService
+02-28 23:15:26.145 19879 19879 W System  : ClassLoader referenced unknown path: /system/framework/com.google.android.dialer.support.jar
+02-28 23:15:26.151 19879 19879 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 23:15:26.206 19879 19879 I Dialer  : GoogleDialerApplication.onCreate - enter
+02-28 23:15:26.216 19879 19879 I Dialer  : DialerExecutors.newThread - creating low priority thread
+02-28 23:15:26.217 19879 19879 I Dialer  : CallLogFramework.registerContentObservers - enter
+02-28 23:15:26.222 19879 19879 I Dialer  : CallLogFramework.registerContentObservers - new call log not enabled
+02-28 23:15:26.246 19879 19879 I Dialer  : NonUiTaskBuilder.newThread - creating serial thread
+02-28 23:15:26.248 19879 19879 I Dialer  : DialerExecutors.newThread - creating low priority thread
+02-28 23:15:26.248 19879 19879 I Dialer  : ShortcutsJobScheduler.scheduleAllJobs - enter
+02-28 23:15:26.252 19879 19879 I Dialer  : ShortcutsJobScheduler.scheduleAllJobs - enabling shortcuts
+02-28 23:15:26.252 19879 19879 I Dialer  : PeriodicJobService.schedulePeriodicJob - enter
+02-28 23:15:26.254 19879 19879 I Dialer  : PeriodicJobService.schedulePeriodicJob - job already scheduled.
+02-28 23:15:26.255 19879 19879 I Dialer  : GoogleDialerApplication.onCreate - register new client
+02-28 23:15:26.265 19879 19879 I Dialer  : GoogleDialerApplication.onCreate - registered new client
+02-28 23:15:26.311 19879 19879 I Dialer  : Flags.register - phenotype register status: true
+02-28 23:15:26.321 19879 19913 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+02-28 23:15:26.335 19879 19879 I Dialer  : SpamAsyncTaskUtil.getAndUpdateServerSpamList - request:a: "us"
+02-28 23:15:26.335 19879 19879 I Dialer  : b: 231341
+02-28 23:15:26.335 19879 19879 I Dialer  : c: 231341
+02-28 23:15:26.335 19879 19879 I Dialer  : d: 1579187852000
+02-28 23:15:26.335 19879 19879 I Dialer  : e: "us"
+02-28 23:15:26.335 19879 19879 I Dialer  : f: ""
+02-28 23:15:26.335 19879 19879 I Dialer  : p: -1
+02-28 23:15:26.344  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:15:26.344  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:15:26.344  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:15:26.368 19879 19879 I Dialer  : Flags.register - commit succeeded: true
+02-28 23:15:26.374 19879 19916 I Dialer  : DialerExecutors.newThread - creating low priority thread
+02-28 23:15:26.455 19879 19919 I Dialer  : DialerExecutors.newThread - creating low priority thread
+02-28 23:15:26.479 19879 19920 I Dialer  : DialerExecutors.newThread - creating low priority thread
+02-28 23:15:27.915 19879 19922 I Dialer  : SpamAsyncTaskUtil.onNext - gRPC data received from server
+02-28 23:15:27.915 19879 19922 I Dialer  : SpamAsyncTaskUtil.onNext - updated spam list for countryIso: us  blacklist version: 1582910257000
+02-28 23:15:29.097  1666  7772 D WificondControl: Scan result ready event
+02-28 23:15:31.159 19879 19898 I zygote  : Waiting for a blocking GC ProfileSaver
+02-28 23:15:31.174 19879 19898 I zygote  : Waiting for a blocking GC ProfileSaver
+02-28 23:15:31.175 19879 19898 I zygote  : WaitForGcToComplete blocked ProfileSaver on HeapTrim for 16.265ms
+02-28 23:15:42.799  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:15:42.799  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:15:42.799  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:15:45.183  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:15:45.183  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:15:45.183  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:15:45.340 19879 19922 I Dialer  : SpamDatabaseHelper.bulkInsertNumbersToServerTable - inserted 100041 numbers into the server spam list.
+02-28 23:15:45.388 19879 19922 I Dialer  : SpamAsyncTaskUtil.onNext - updated spam list with complete list to blacklist version: 1582910257000
+02-28 23:15:45.390 19879 19922 I Dialer  : SpamAsyncTaskUtil.onCompleted - gRPC blocked list fetching completed.
+02-28 23:15:49.882  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:15:55.202  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 23:16:00.017  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:16:00.198  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:16:00.198  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:16:00.198  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:16:00.458  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:16:00.458  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:16:26.124  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:16:26.124  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:16:47.513  1666  1685 I UsageStatsService: User[0] Flushing usage stats to disk
+02-28 23:16:49.884  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:17:00.019  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:17:49.886  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:18:00.019  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:18:06.221  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:18:06.221  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:18:06.462  2187 15992 I EventLogChimeraService: Aggregate from 1582920059560 (log), 1578872121953 (data)
+02-28 23:18:06.697  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.stats.service.DropBoxEntryAddedReceiver
+02-28 23:18:06.697  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+02-28 23:18:06.844  2187  2198 I zygote  : Deoptimizing void rrs.shutdown() due to JIT inline cache
+02-28 23:18:09.188  1666  7776 D WificondControl: Scan result ready event
+02-28 23:18:49.888  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:19:00.016  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:19:24.262  2116 19745 W NetworkScheduler.TED: Enforcing binder timeout for ComponentInfo{com.google.android.apps.photos/com.google.android.libraries.social.notifications.scheduled.GunsScheduledTaskService}
+02-28 23:19:24.262  2116 19745 E NetworkScheduler.TED: Dropping task as app's play services SDK version does not support Android O. Either update the SDK or lower your app's target SDK version. Canceling all tasks for the service: ComponentInfo{com.google.android.apps.photos/com.google.android.libraries.social.notifications.scheduled.GunsScheduledTaskService}
+02-28 23:19:24.264  2116 18734 E NetworkScheduler: Unknown result code received: 4
+02-28 23:19:24.265  2116  2116 E NetworkScheduler.ATC: Called cancelTask for already completed task com.google.android.apps.photos/com.google.android.libraries.social.notifications.scheduled.GunsScheduledTaskService{u=0 tag="scheduled_sync_reg_status" trigger=window{start=0s,end=30s,earliest=-51s,latest=-21s} requirements=[NET_CONNECTED] attributes=[PERSISTED] scheduled=-51s last_run=-18s jid=N/A status=PENDING retries=15 client_lib=MANCHEGO_GCM-10400000} :INVALID_START
+02-28 23:19:27.761  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:19:27.761  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:19:27.761  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:19:42.798  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:19:42.798  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:19:42.799  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:19:49.890  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:20:00.002  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:20:00.002  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:20:00.013  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:20:43.880  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:20:43.880  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:20:43.881  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:20:43.890  1666  7777 I WifiService: getConnectionInfo uid=10013
+02-28 23:20:46.223  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:20:46.223  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:20:49.187  1666  7771 D WificondControl: Scan result ready event
+02-28 23:20:49.892  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:20:58.918  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:20:58.918  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:20:58.918  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:21:00.020  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:21:10.257  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:21:10.257  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:21:10.257  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:21:20.283  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 23:21:25.277  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:21:25.277  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:21:25.277  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:21:49.893  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:22:00.011  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:22:49.894  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:23:00.004  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:23:00.004  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:23:00.024  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:23:26.225  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:23:26.225  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:23:26.266  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:23:26.266  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:23:26.307  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:23:26.307  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:23:26.340  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:23:26.340  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:23:29.188  1666  7771 D WificondControl: Scan result ready event
+02-28 23:23:49.895  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:24:00.015  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:24:49.896  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:25:00.004  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:25:00.004  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:25:00.018  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:25:00.071  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:25:00.071  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:25:00.110  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:25:00.110  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:25:00.144  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:25:00.144  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:25:29.337  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:25:29.337  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:25:29.337  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:25:29.346  1666  1689 E BluetoothAdapter: Bluetooth binder is null
+02-28 23:25:29.351  1666  1689 E KernelCpuSpeedReader: Failed to read cpu-freq: /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state (No such file or directory)
+02-28 23:25:29.354  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 23:25:49.897  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:26:00.009  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:26:06.255  1666  1768 D RecurrenceRule: Resolving using anchor 2020-02-28T23:26:06.254+03:00[Europe/Moscow]
+02-28 23:26:06.256  1666  1768 D RecurrenceRule: Resolving using anchor 2020-02-28T23:26:06.256+03:00[Europe/Moscow]
+02-28 23:26:06.258  1666  1768 D RecurrenceRule: Cycle 13 from 2020-02-13T00:00+03:00[Europe/Moscow] to 2020-03-13T00:00+03:00[Europe/Moscow]
+02-28 23:26:06.258  1666  1768 D NetworkStats: Resolving plan for NetworkTemplate: matchRule=MOBILE_ALL, subscriberId=310260..., matchSubscriberIds=[310260...]
+02-28 23:26:06.259  1666  1768 D NetworkStats: Found active matching subId 1
+02-28 23:26:06.262  1666  1768 D NetworkStats: Resolved to plan null
+02-28 23:26:09.198  1666  7771 D WificondControl: Scan result ready event
+02-28 23:26:49.899  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:27:00.001  1666  1666 I ActivityManager: Killing 19581:android.process.acore/u0a2 (adj 902): empty for 1810s
+02-28 23:27:00.002  1666  1666 I ActivityManager: Killing 19406:com.google.android.deskclock/u0a68 (adj 904): empty for 1811s
+02-28 23:27:00.002  1666  1666 I ActivityManager: Killing 19508:com.google.android.apps.wallpaper/u0a31 (adj 904): empty for 1811s
+02-28 23:27:00.003  1666  1666 I ActivityManager: Killing 19343:com.google.android.calendar/u0a45 (adj 904): empty for 1811s
+02-28 23:27:00.003  1666  1666 I ActivityManager: Killing 19359:com.android.providers.calendar/u0a3 (adj 904): empty for 1811s
+02-28 23:27:00.004  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:27:00.004  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:27:00.005  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:27:00.005  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:27:00.010  1666  1688 W zygote  : kill(-19581, 9) failed: No such process
+02-28 23:27:00.036  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:27:00.053  1666  1688 W zygote  : kill(-19581, 9) failed: No such process
+02-28 23:27:00.061  1666  7572 D CountryDetector: No listener is left
+02-28 23:27:00.098  1666  1688 W zygote  : kill(-19581, 9) failed: No such process
+02-28 23:27:00.098  1666  1688 I zygote  : Successfully killed process cgroup uid 10002 pid 19581 in 96ms
+02-28 23:27:00.098  1666  1688 W zygote  : kill(-19406, 9) failed: No such process
+02-28 23:27:00.099  1666  1688 I zygote  : Successfully killed process cgroup uid 10068 pid 19406 in 0ms
+02-28 23:27:00.099  1666  1688 W zygote  : kill(-19508, 9) failed: No such process
+02-28 23:27:00.099  1666  1688 I zygote  : Successfully killed process cgroup uid 10031 pid 19508 in 0ms
+02-28 23:27:00.099  1666  1688 W zygote  : kill(-19343, 9) failed: No such process
+02-28 23:27:00.099  1666  1688 I zygote  : Successfully killed process cgroup uid 10045 pid 19343 in 0ms
+02-28 23:27:00.100  1666  1688 W zygote  : kill(-19359, 9) failed: No such process
+02-28 23:27:00.100  1666  1688 I zygote  : Successfully killed process cgroup uid 10003 pid 19359 in 0ms
+02-28 23:27:49.900  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:28:00.004  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:28:00.004  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:28:00.016  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:28:00.041  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:28:00.041  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:28:49.198  1666  7775 D WificondControl: Scan result ready event
+02-28 23:28:49.902  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:29:00.007  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:29:00.007  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:29:00.017  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:29:49.903  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:29:53.895  1666  7770 I WifiService: getConnectionInfo uid=10013
+02-28 23:29:53.897  2116 19873 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+02-28 23:29:53.899  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:29:53.899  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:29:53.899  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:29:53.933  1666  7770 I WifiService: getConnectionInfo uid=10013
+02-28 23:30:00.003  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:30:00.004  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:30:00.010  1666  1666 D ConditionProviders.SCP: onReceive ScheduleConditionProvider.EVALUATE
+02-28 23:30:00.010  1666  1666 D ConditionProviders.SCP: notifyCondition condition://android/schedule?days=6.7&start=23.30&end=10.0&exitAtAlarm=false STATE_TRUE reason=meetsSchedule
+02-28 23:30:00.010  1666  1666 D ConditionProviders.SCP: notifyCondition condition://android/schedule?days=1.2.3.4.5&start=22.0&end=7.0&exitAtAlarm=false STATE_FALSE reason=!meetsSchedule
+02-28 23:30:00.011  1666  1666 D ConditionProviders.SCP: Scheduling evaluate for Sat Feb 29 07:00:00 GMT+03:00 2020 (1582948800000), in +7h29m59s990ms, now=Fri Feb 28 23:30:00 GMT+03:00 2020 (1582921800010)
+02-28 23:30:00.012  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:30:00.013  1666  1666 D ZenLog  : config: conditionChanged,ZenModeConfig[user=0,allowCalls=true,allowRepeatCallers=false,allowMessages=false,allowCallsFrom=contacts,allowMessagesFrom=contacts,allowReminders=true,allowEvents=true,allowWhenScreenOff=true,allowWhenScreenOn=true,automaticRules={EVENTS_DEFAULT_RULE=ZenRule[enabled=false,snoozing=false,name=Event,zenMode=ZEN_MODE_ALARMS,conditionId=condition://android/event?userId=-10000&calendar=&reply=1,condition=Condition[id=condition://android/event?userId=-10000&calendar=&reply=1,summary=...,line1=...,line2=...,icon=0,state=STATE_FALSE,flags=2],component=ComponentInfo{android/com.android.server.notification.EventConditionProvider},id=EVENTS_DEFAULT_RULE,creationTime=1563054733958,enabler=null], SCHEDULED_DEFAULT_RULE_1=ZenRule[enabled=false,snoozing=false,name=Weeknight,zenMode=ZEN_MODE_ALARMS,conditionId=condition://android/schedule?days=1.2.3.4.5&start=22.0&end=7.0&exitAtAlarm=false,condition=Condition[id=condition://android/schedule?days=1.2.3.4.5&start=22.0&end=7.0&exitAtAlarm=false,summary=...,line1=...,line2=...,icon=0,state=STATE_FALSE,flags=2],component=ComponentInfo{android/com.android.server.notification.ScheduleConditionProvider},id=SCHEDULED_DEFAULT_RULE_1,creationTime=1563054733958,enabler=null], SCHEDULED_DEFAULT_RULE_2=ZenRule[enabled=false,snoozing=false,name=Weekend,zenMode=ZEN_MODE_ALARMS,conditionId=condition://android/schedule?days=6.7&start=23.30&end=10.0&exitAtAlarm=false,condition=Condition[id=condition://android/schedule?days=6.7&start=23.30&end=10.0&exitAtAlarm=false,summary=...,line1=...,line2=...,icon=0,state=STATE_TRUE,flags=2],component=ComponentInfo{android/com.android.server.notification.ScheduleConditionProvider},id=SCHEDULED_DEFAULT_RULE_2,creationTime=1563054733958,enabler=null]},manualRule=null],Diff[automaticRule[SCHEDULED_DEFAULT_RULE_2].condition:Condition[id=condition://android/schedule?days=6.7&start=23.30&end=10.0&exitAtAlarm=false,summary=...,line1=...,line2=...,icon=0,state=STATE_FALSE,flags=2]->Condition[id=condition://android/schedule?days=6.7&start=23.30&end=10.0&exitAtAlarm=false,summary=...,line1=...,line2=...,icon=0,state=STATE_TRUE,flags=2]]
+02-28 23:30:00.023  1666  1666 D ZenLog  : set_zen_mode: off,conditionChanged
+02-28 23:30:00.049  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:30:00.049  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:30:08.998  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:30:08.998  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:30:08.998  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:30:09.045  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:30:09.045  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:30:09.045  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:30:19.062  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 23:30:24.078  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:30:24.078  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:30:24.078  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:30:49.904  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:31:00.003  1666  1666 I ActivityManager: Killing 19524:com.google.android.apps.messaging:rcs/u0a69 (adj 904): empty for 1801s
+02-28 23:31:00.003  1666  1688 W zygote  : kill(-19524, 9) failed: No such process
+02-28 23:31:00.014  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:31:00.014  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:31:00.032  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:31:00.047  1666  1688 W zygote  : kill(-19524, 9) failed: No such process
+02-28 23:31:00.069  1666  4878 W ActivityManager: Scheduling restart of crashed service com.google.android.apps.messaging/com.google.android.ims.service.JibeService in 1000ms
+02-28 23:31:00.086  1666  1688 W zygote  : kill(-19524, 9) failed: No such process
+02-28 23:31:00.087  1666  1688 I zygote  : Successfully killed process cgroup uid 10069 pid 19524 in 83ms
+02-28 23:31:01.080 19962 19962 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+02-28 23:31:01.082  1666  1686 I ActivityManager: Start proc 19962:com.google.android.apps.messaging:rcs/u0a69 for service com.google.android.apps.messaging/com.google.android.ims.service.JibeService
+02-28 23:31:01.103 19962 19962 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 23:31:01.128 19962 19962 I MultiDex: VM with version 2.1.0 has multidex support
+02-28 23:31:01.129 19962 19962 I MultiDex: install
+02-28 23:31:01.129 19962 19962 I MultiDex: VM has multidex support, MultiDex support library is disabled.
+02-28 23:31:01.156 19962 19962 I CarrierServices: [2] a.a: Initializing Carrier Services Library.
+02-28 23:31:01.162 19962 19985 I Bugle   : GServicesValues:
+02-28 23:31:01.162 19962 19985 I Bugle   : bugle_enable_primes_crash_metrics: true
+02-28 23:31:01.162 19962 19985 I Bugle   : bugle_max_telemetry_upload_retries: 10
+02-28 23:31:01.162 19962 19985 I Bugle   : bugle_sticker_set_list_version: 3
+02-28 23:31:01.185 19962 19962 I CarrierServices: [2] a.c: Initializing Carrier Services Logging.
+02-28 23:31:01.192 19962 19962 I com.google.android.ims.util.z: LogSaver new instance with filename: carrier_services
+02-28 23:31:01.218 19962 19962 I CarrierServices: [2] zzbgb$zza.shouldUseCarrierServicesApkForV1Apis: Checking if using CarrierServices.apk is possible. Enabled: true, isAtLeastM: true, runningInsideBugle: true
+02-28 23:31:01.220 19962 19962 W CarrierServices: [2] zzbgb$zza.C: Carrier Services Apk was not found.
+02-28 23:31:01.221 19962 19962 W CarrierServices: [2] zzbgb$zza.a: CarrierServices.apk was not found, not pre-loaded or is disabled.
+02-28 23:31:01.221 19962 19962 I CarrierServices: [2] t.c: Using AndroidNetworkFactory
+02-28 23:31:01.223 19962 19962 I CarrierServices: [2] zzbgb$zza.shouldUseCarrierServicesApkForV1Apis: Checking if using CarrierServices.apk is possible. Enabled: true, isAtLeastM: true, runningInsideBugle: true
+02-28 23:31:01.224 19962 19962 W CarrierServices: [2] zzbgb$zza.C: Carrier Services Apk was not found.
+02-28 23:31:01.224 19962 19962 W CarrierServices: [2] zzbgb$zza.a: CarrierServices.apk was not found, not pre-loaded or is disabled.
+02-28 23:31:01.255 19962 19962 V RcsProvisioning: No legacy config file found, migration not necessary
+02-28 23:31:01.259 19962 19962 W RcsProvisioning: Failed to read configuration: /data/user/0/com.google.android.apps.messaging/files/rcsconfig (No such file or directory)
+02-28 23:31:01.259 19962 19962 D RcsProvisioning: Retrieving backup token
+02-28 23:31:01.364 19962 19962 D RcsProvisioning: No backup token found
+02-28 23:31:01.373 19962 19962 W CarrierServices: [2] zzbgb$zza.av: No config URL. RCS will be disabled!
+02-28 23:31:01.384 19962 19962 W DynamiteModule: Local module descriptor class for com.google.android.gms.googlecertificates not found.
+02-28 23:31:01.404 19962 19962 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 23:31:01.405 19962 19962 I chatty  : uid=10069 com.google.android.apps.messaging:rcs identical 1 line
+02-28 23:31:01.410 19962 19962 I zygote  : The ClassLoaderContext is a special shared library.
+02-28 23:31:01.417 19962 19962 I DynamiteModule: Considering local module com.google.android.gms.googlecertificates:0 and remote module com.google.android.gms.googlecertificates:4
+02-28 23:31:01.417 19962 19962 I DynamiteModule: Selected remote version of com.google.android.gms.googlecertificates, version >= 4
+02-28 23:31:01.430 19962 19962 W zygote  : Unsupported class loader
+02-28 23:31:01.431 19962 19962 W zygote  : Skipping duplicate class check due to unsupported classloader
+02-28 23:31:01.439 19962 19962 D GoogleCertificates: com.google.android.gms.googlecertificates module is loaded
+02-28 23:31:01.465 19962 19962 D CarrierServices: log_saver already enabled
+02-28 23:31:01.483 19962 19962 I CarrierServices: [2] e.onReceive: intent=Intent { act=android.net.conn.CONNECTIVITY_CHANGE flg=0x4000010 (has extras) }, isDeviceIdleMode=false
+02-28 23:31:01.484 19962 19962 W CarrierServices: [2] zzbgb$zza.C: Carrier Services Apk was not found.
+02-28 23:31:01.485 19962 19962 W CarrierServices: [2] zzbgb$zza.a: CarrierServices.apk was not found, not pre-loaded or is disabled.
+02-28 23:31:26.232  1666  4878 I ActivityManager: Killing 19470:com.google.android.apps.messaging/u0a69 (adj 906): empty for 1827s
+02-28 23:31:26.232  1666  1688 W zygote  : kill(-19470, 9) failed: No such process
+02-28 23:31:26.278  1666  1688 W zygote  : kill(-19470, 9) failed: No such process
+02-28 23:31:26.305 19962 19962 I CarrierServices: [2] p.g: RCS provisioning stopped!!
+02-28 23:31:26.316  1666  1688 W zygote  : kill(-19470, 9) failed: No such process
+02-28 23:31:26.317  1666  1688 I zygote  : Successfully killed process cgroup uid 10069 pid 19470 in 84ms
+02-28 23:31:29.197  1666  5955 D WificondControl: Scan result ready event
+02-28 23:31:49.904  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:32:00.003  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:32:00.003  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:32:00.022  1442  1465 D hwcomposer: hw_composer sent 12 syncs in 60s
+02-28 23:32:00.035  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:32:00.035  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:32:00.073  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:32:00.073  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:32:00.103  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:32:00.103  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:32:00.136  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:32:00.136  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:32:49.905  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:33:00.026  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:33:12.127  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 27903711 , only wrote 27903600
+02-28 23:33:15.353  1433  1583 W audio_hw_generic: Not supplying enough data to HAL, expected position 28211275 , only wrote 28058400
+02-28 23:33:49.906  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:34:00.002  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:34:00.002  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:34:00.014  1442  1465 D hwcomposer: hw_composer sent 18 syncs in 60s
+02-28 23:34:09.319  1666  3380 D WificondControl: Scan result ready event
+02-28 23:34:49.907  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:35:00.018  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:35:49.908  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:36:00.003  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:36:00.004  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:36:00.009  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:36:49.317  1666  5955 D WificondControl: Scan result ready event
+02-28 23:36:49.910  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:37:00.011  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:37:49.910  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:38:00.004  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:38:00.004  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:38:00.039  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:38:49.913  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:39:00.002  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:39:00.002  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:39:00.018  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:39:00.047  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:39:00.047  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:39:00.087  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:39:00.087  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:39:00.118  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:39:00.118  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:39:03.949  1666  5955 I WifiService: getConnectionInfo uid=10013
+02-28 23:39:03.959  2116 19873 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+02-28 23:39:03.961  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:39:03.961  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:39:03.961  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:39:03.993  1666  2606 I WifiService: getConnectionInfo uid=10013
+02-28 23:39:18.997  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:39:18.997  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:39:18.997  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:39:29.318  1666  3380 D WificondControl: Scan result ready event
+02-28 23:39:36.857  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:39:36.857  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:39:36.857  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:39:46.881  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 23:39:49.915  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:39:51.878  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:39:51.878  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:39:51.878  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:40:00.005  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:40:00.005  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:40:00.028  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:40:00.093  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:40:00.093  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:40:00.133  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:40:00.133  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:40:00.163  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:40:00.163  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:40:26.361  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:40:26.362  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:40:49.917  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:41:00.020  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:41:49.918  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:42:00.009  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:42:00.009  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:42:00.017  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:42:09.338  1666  5955 D WificondControl: Scan result ready event
+02-28 23:42:49.920  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:43:00.033  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:43:49.922  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:44:00.008  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:44:00.008  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:44:00.013  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:44:49.328  1666  5955 D WificondControl: Scan result ready event
+02-28 23:44:49.925  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:45:00.011  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:45:00.012  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:45:00.044  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:45:49.926  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:46:00.011  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:46:00.011  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:46:00.031  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:46:49.928  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:47:00.011  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:47:00.011  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:47:00.042  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:47:02.493  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:47:02.493  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:47:02.493  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:47:12.537  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 23:47:17.520  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:47:17.521  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:47:17.521  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:47:29.339  1666  2606 D WificondControl: Scan result ready event
+02-28 23:47:49.929  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:48:00.012  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:48:00.013  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:48:00.020  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:48:14.009  1666  2606 I WifiService: getConnectionInfo uid=10013
+02-28 23:48:14.018  2116 19873 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+02-28 23:48:14.026  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:48:14.028  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:48:14.029  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:48:14.078  1666  5955 I WifiService: getConnectionInfo uid=10013
+02-28 23:48:14.244  2187 15992 I EventLogChimeraService: Aggregate from 1582921086462 (log), 1582921086462 (data)
+02-28 23:48:14.245  2116 18734 W zygote  : Long monitor contention with owner netscheduler-queue-handler (2988) at void aaat.a(aaaq, zxr)(:com.google.android.gms@16089022@16.0.89 (040700-239467275):97) waiters=0 in void aaat.b(zxr) for 164ms
+02-28 23:48:14.450  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.stats.service.DropBoxEntryAddedReceiver
+02-28 23:48:14.450  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+02-28 23:48:29.121  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:48:29.122  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:48:29.123  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:48:49.932  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:49:00.025  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:49:49.933  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:49:53.939  1666  1685 I UsageStatsService: User[0] Flushing usage stats to disk
+02-28 23:50:00.009  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:50:00.009  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:50:00.039  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:50:00.099  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:50:00.099  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:50:09.338  1666  7772 D WificondControl: Scan result ready event
+02-28 23:50:49.936  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:51:00.008  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:51:49.938  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:52:00.015  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:52:00.015  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:52:00.023  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:52:49.940  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:53:00.024  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:53:06.417  1666  2606 I WifiService: getConnectionInfo uid=10032
+02-28 23:53:06.432  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:53:06.432  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:53:06.432  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:53:09.359  1666  3380 D WificondControl: Scan result ready event
+02-28 23:53:21.599  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:53:21.599  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:53:21.599  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:53:49.943  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:54:00.003  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:54:00.003  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:54:00.012  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:54:00.051  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:54:00.051  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:54:00.089  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:54:00.089  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:54:00.128  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:54:00.128  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:54:00.158  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:54:00.158  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:54:06.399  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:54:06.399  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:54:49.944  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:55:00.006  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:55:00.007  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:55:00.025  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:55:00.112  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:55:00.112  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:55:00.147  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:55:00.147  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:55:29.340  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:55:29.340  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:55:29.340  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:55:29.344  1666  1689 E BluetoothAdapter: Bluetooth binder is null
+02-28 23:55:29.350  1666  1689 E KernelCpuSpeedReader: Failed to read cpu-freq: /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state (No such file or directory)
+02-28 23:55:29.353  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 23:55:31.741  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:55:31.741  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:55:31.741  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:55:46.758  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:55:46.758  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:55:46.758  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:55:49.946  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:56:00.024  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:56:46.117  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:56:46.117  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:56:46.139  1666  1768 D RecurrenceRule: Resolving using anchor 2020-02-28T23:56:46.139+03:00[Europe/Moscow]
+02-28 23:56:46.141  1666  1768 D RecurrenceRule: Resolving using anchor 2020-02-28T23:56:46.141+03:00[Europe/Moscow]
+02-28 23:56:46.143  1666  1768 D RecurrenceRule: Cycle 13 from 2020-02-13T00:00+03:00[Europe/Moscow] to 2020-03-13T00:00+03:00[Europe/Moscow]
+02-28 23:55:41.773  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 23:56:46.143  1666  1768 D NetworkStats: Resolving plan for NetworkTemplate: matchRule=MOBILE_ALL, subscriberId=310260..., matchSubscriberIds=[310260...]
+02-28 23:56:46.146  1666  1768 D NetworkStats: Found active matching subId 1
+02-28 23:56:46.152  1666  1768 D NetworkStats: Resolved to plan null
+02-28 23:56:49.088  1666  2606 D WificondControl: Scan result ready event
+02-28 23:56:49.947  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:57:00.043  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:57:06.592  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:57:06.594  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:57:06.594  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:57:21.599  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:57:21.600  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:57:21.600  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:57:24.088  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:57:24.088  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:57:24.088  1666  7772 I WifiService: getConnectionInfo uid=10013
+02-28 23:57:24.095  2116 19873 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+02-28 23:57:24.098  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:57:24.098  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:57:24.099  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:57:24.136  1666  7772 I WifiService: getConnectionInfo uid=10013
+02-28 23:57:24.575 17969 17986 I zygote  : android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 0
+02-28 23:57:24.577 17969 17986 D EGL_emulation: eglCreateContext: 0xe8de5ac0: maj 2 min 0 rcv 2
+02-28 23:57:24.581 17969 17986 D EGL_emulation: eglMakeCurrent: 0xe8de5ac0: ver 2 0 (tinfo 0xcb326800)
+02-28 23:57:24.633 17969 17986 I zygote  : android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 0
+02-28 23:57:24.635 17969 17986 D EGL_emulation: eglCreateContext: 0xe0da9bc0: maj 2 min 0 rcv 2
+02-28 23:57:24.638 17969 17986 D EGL_emulation: eglMakeCurrent: 0xe0da9bc0: ver 2 0 (tinfo 0xcb326800)
+02-28 23:57:24.651  2116 19745 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:57:24.652  2116 19745 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:57:24.652  2116 19745 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:57:24.697 17969 17989 W zygote  : Couldn't lock the profile file /data/data/com.google.android.gms/app_dg_cache/B48D3D85073AEB2B4FF9AF85F82475996DEACD02/oat/the.apk.cur.prof: Failed to open file '/data/data/com.google.android.gms/app_dg_cache/B48D3D85073AEB2B4FF9AF85F82475996DEACD02/oat/the.apk.cur.prof': No such file or directory
+02-28 23:57:24.697 17969 17989 W zygote  : Could not forcefully load profile /data/data/com.google.android.gms/app_dg_cache/B48D3D85073AEB2B4FF9AF85F82475996DEACD02/oat/the.apk.cur.prof
+02-28 23:57:24.698 17969 17989 W zygote  : Couldn't lock the profile file /data/data/com.google.android.gms/app_fb/oat/f.apk.cur.prof: Failed to open file '/data/data/com.google.android.gms/app_fb/oat/f.apk.cur.prof': No such file or directory
+02-28 23:57:24.698 17969 17989 W zygote  : Could not forcefully load profile /data/data/com.google.android.gms/app_fb/oat/f.apk.cur.prof
+02-28 23:57:24.717  2116 19745 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:57:24.723  2116 19745 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:57:24.723  2116 19745 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:57:24.833  2116 19745 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:57:24.833  2116 19745 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:57:24.833  2116 19745 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:57:24.858  2116 19745 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:57:24.858  2116 19745 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:57:24.858  2116 19745 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:57:24.886 17969 17986 W SystemServiceRegistry: No service published for: persistent_data_block
+02-28 23:57:24.907  2116  4935 I zygote  : Deoptimizing void braq.c(byte[], int, int) due to JIT inline cache
+02-28 23:57:25.026  2116 20044 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:57:25.026  2116 20044 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:57:25.027  2116 20044 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:57:25.053  2116 20044 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:57:25.053  2116 20044 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:57:25.053  2116 20044 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:57:42.375  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-28 23:57:49.950  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:57:55.397  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:57:55.398  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:57:55.398  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:57:55.429  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:57:55.429  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:57:55.429  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:57:55.453  2116  2664 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:57:55.453  2116  2664 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:57:55.453  2116  2664 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:57:55.514  2116  2664 W Conscrypt: Could not set socket write timeout: java.net.SocketException: Socket closed
+02-28 23:57:55.514  2116  2664 W Conscrypt: 	at com.google.android.gms.org.conscrypt.Platform.setSocketWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:57:55.514  2116  2664 W Conscrypt: 	at com.google.android.gms.org.conscrypt.ConscryptFileDescriptorSocket.setSoWriteTimeout(:com.google.android.gms@16089022@16.0.89 (040700-239467275):2)
+02-28 23:57:55.551  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:57:55.552  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:57:55.560  2116  2664 W GLSUser : [AppCertManager] IOException while requesting key: 
+02-28 23:57:55.560  2116  2664 W GLSUser : java.io.IOException: Invalid device key response.
+02-28 23:57:55.560  2116  2664 W GLSUser : 	at hzz.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):14)
+02-28 23:57:55.560  2116  2664 W GLSUser : 	at hzz.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):115)
+02-28 23:57:55.560  2116  2664 W GLSUser : 	at hzx.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):6)
+02-28 23:57:55.560  2116  2664 W GLSUser : 	at hzt.a(Unknown Source:0)
+02-28 23:57:55.560  2116  2664 W GLSUser : 	at hzs.a(:com.google.android.gms@16089022@16.0.89 (040700-239467275):8)
+02-28 23:57:55.560  2116  2664 W GLSUser : 	at com.google.android.gms.auth.account.be.legacy.AuthCronChimeraService.b(:com.google.android.gms@16089022@16.0.89 (040700-239467275):6)
+02-28 23:57:55.560  2116  2664 W GLSUser : 	at gyi.call(:com.google.android.gms@16089022@16.0.89 (040700-239467275):3)
+02-28 23:57:55.560  2116  2664 W GLSUser : 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+02-28 23:57:55.560  2116  2664 W GLSUser : 	at rrt.b(:com.google.android.gms@16089022@16.0.89 (040700-239467275):32)
+02-28 23:57:55.560  2116  2664 W GLSUser : 	at rrt.run(:com.google.android.gms@16089022@16.0.89 (040700-239467275):21)
+02-28 23:57:55.560  2116  2664 W GLSUser : 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
+02-28 23:57:55.560  2116  2664 W GLSUser : 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
+02-28 23:57:55.560  2116  2664 W GLSUser : 	at rxx.run(Unknown Source:7)
+02-28 23:57:55.560  2116  2664 W GLSUser : 	at java.lang.Thread.run(Thread.java:764)
+02-28 23:58:00.005  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:58:00.005  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:58:00.038  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:58:00.070  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:58:00.070  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:58:00.094  1812  1818 D         : HostConnection::get() New Host Connection established 0xcdcfde80, tid 1818
+02-28 23:58:00.094  1812  1818 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-28 23:58:00.095  1812  1818 D         : HostConnection::get() New Host Connection established 0xcdcfde80, tid 1818
+02-28 23:58:00.096  1812  1818 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-28 23:58:00.100  1812  1819 D         : HostConnection::get() New Host Connection established 0xcc45d7c0, tid 1819
+02-28 23:58:00.100  1812  1819 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-28 23:58:00.101  1812  1819 D         : HostConnection::get() New Host Connection established 0xcc45d7c0, tid 1819
+02-28 23:58:00.101  1812  1819 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-28 23:58:10.600  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:58:10.601  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:58:10.601  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:58:40.213  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:58:40.213  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:58:40.213  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:58:46.163  1666  1685 E memtrack: Couldn't load memtrack module
+02-28 23:58:46.163  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-28 23:58:49.953  1449  1449 I boot-pipe: done populating /dev/random
+02-28 23:59:00.029  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-28 23:59:10.281  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-28 23:59:10.282  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-28 23:59:10.282  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-28 23:59:49.955  1449  1449 I boot-pipe: done populating /dev/random
+02-29 00:00:00.005  1666  1666 D AlarmManagerService: Kernel timezone updated to -180 minutes west of GMT
+02-29 00:00:00.024  1666  1685 E memtrack: Couldn't load memtrack module
+02-29 00:00:00.024  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-29 00:00:00.058  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-29 00:00:00.101  1666  3380 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DATE_CHANGED flg=0x20200010 } to com.google.android.calendar/com.android.calendar.widget.CalendarAppWidgetProvider
+02-29 00:00:00.102  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DATE_CHANGED flg=0x20200010 } to com.google.android.calendar/.widgetmonth.MonthViewWidgetProvider
+02-29 00:00:00.102  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DATE_CHANGED flg=0x20200010 } to com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+02-29 00:00:49.958  1449  1449 I boot-pipe: done populating /dev/random
+02-29 00:00:53.971  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-29 00:00:53.971  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-29 00:00:53.972  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-29 00:01:00.002  1666  1685 E memtrack: Couldn't load memtrack module
+02-29 00:01:00.002  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-29 00:01:00.018  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-29 00:01:03.982  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-29 00:01:08.996 20066 20066 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+02-29 00:01:09.000  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-29 00:01:09.000  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-29 00:01:09.000  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-29 00:01:09.001  1666  1686 I ActivityManager: Start proc 20066:com.google.android.calendar/u0a45 for broadcast com.google.android.calendar/.widgetmonth.MonthViewWidgetProvider
+02-29 00:01:09.052 20066 20066 I zygote  : The ClassLoaderContext is a special shared library.
+02-29 00:01:09.097 20066 20066 I PerformanceMetricCollec: Logging experiments memory-false, lantency-false
+02-29 00:01:09.105  1666  4878 I ActivityManager: Start proc 20092:com.android.providers.calendar/u0a3 for content provider com.android.providers.calendar/.CalendarProvider2
+02-29 00:01:09.106 20092 20092 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+02-29 00:01:09.132 20092 20092 I zygote  : The ClassLoaderContext is a special shared library.
+02-29 00:01:09.132 20092 20092 I chatty  : uid=10003(com.android.providers.calendar) identical 1 line
+02-29 00:01:09.133 20092 20092 I zygote  : The ClassLoaderContext is a special shared library.
+02-29 00:01:09.147 20092 20092 I CalendarProvider2: Created com.android.providers.calendar.CalendarAlarmManager@27a0ea0(com.android.providers.calendar.CalendarProvider2@e2d2a59)
+02-29 00:01:09.157 20066 20066 D PhenotypeJobService: Job scheduled successfully
+02-29 00:01:09.163 20066 20066 E PrefServiceImpl: Primary account is null
+02-29 00:01:09.164 20066 20066 I PerformanceMetricCollec: Logging experiments memory-false, lantency-false
+02-29 00:01:09.212 19777 20127 I ConfigUpdater: Update started
+02-29 00:01:09.225 20066 20066 D PhenotypeManager: Registered: Status{statusCode=SUCCESS, resolution=null}
+02-29 00:01:09.229 19440 19453 V DownloadManager: Deleting /data/data/com.android.providers.downloads/cache/01302020-sms-metadata.txt via provider delete
+02-29 00:01:09.293 20066 20126 I PhenotypeFlagCommitter: Experiment Configs successfully retrieved for com.google.android.calendar
+02-29 00:01:09.295 19440 20130 D DownloadManager: [18] Starting
+02-29 00:01:09.314 19440 20130 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+02-29 00:01:09.319  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-29 00:01:09.319  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-29 00:01:09.319  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-29 00:01:09.476 19440 20130 D DownloadManager: [18] Finished with status SUCCESS
+02-29 00:01:09.564 19440 20136 D DownloadManager: [19] Starting
+02-29 00:01:09.583 19440 20136 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+02-29 00:01:09.714 19440 20136 D DownloadManager: [19] Finished with status SUCCESS
+02-29 00:01:09.763 19777 20138 I ConfigUpdater: Update downloaded, starting installation
+02-29 00:01:09.775 19777 20138 I ConfigUpdater: doneInstall
+02-29 00:01:09.782 19440 19811 V DownloadManager: Deleting /data/data/com.android.providers.downloads/cache/01302020-sms-metadata.txt via provider delete
+02-29 00:01:09.783 19440 19811 V DownloadManager: Deleting /data/data/com.android.providers.downloads/cache/01302020-sms-blacklist.txt via provider delete
+02-29 00:01:09.825  1666 20139 W Binder  : Outgoing transactions from this process must be FLAG_ONEWAY
+02-29 00:01:09.825  1666 20139 W Binder  : java.lang.Throwable
+02-29 00:01:09.825  1666 20139 W Binder  : 	at android.os.BinderProxy.transact(Binder.java:752)
+02-29 00:01:09.825  1666 20139 W Binder  : 	at android.content.ContentProviderProxy.openTypedAssetFile(ContentProviderNative.java:696)
+02-29 00:01:09.825  1666 20139 W Binder  : 	at android.content.ContentResolver.openTypedAssetFileDescriptor(ContentResolver.java:1410)
+02-29 00:01:09.825  1666 20139 W Binder  : 	at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:1247)
+02-29 00:01:09.825  1666 20139 W Binder  : 	at android.content.ContentResolver.openInputStream(ContentResolver.java:967)
+02-29 00:01:09.825  1666 20139 W Binder  : 	at com.android.server.updates.ConfigUpdateInstallReceiver.getAltContent(ConfigUpdateInstallReceiver.java:135)
+02-29 00:01:09.825  1666 20139 W Binder  : 	at com.android.server.updates.ConfigUpdateInstallReceiver.-wrap1(Unknown Source:0)
+02-29 00:01:09.825  1666 20139 W Binder  : 	at com.android.server.updates.ConfigUpdateInstallReceiver$1.run(ConfigUpdateInstallReceiver.java:65)
+02-29 00:01:09.837  1666 20139 I ConfigUpdateInstallReceiver: Found new update, installing...
+02-29 00:01:09.844  1666 20139 I ConfigUpdateInstallReceiver: Installation successful
+02-29 00:01:11.948  1666  2606 D WificondControl: Scan result ready event
+02-29 00:01:14.061 20066 20085 I zygote  : Waiting for a blocking GC ProfileSaver
+02-29 00:01:14.220  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.stats.service.DropBoxEntryAddedReceiver
+02-29 00:01:14.220  1666  1686 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+02-29 00:01:40.281  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-29 00:01:40.282  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-29 00:01:40.282  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-29 00:01:49.961  1449  1449 I boot-pipe: done populating /dev/random
+02-29 00:01:55.556  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-29 00:01:55.556  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-29 00:01:55.556  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-29 00:02:00.015  1666  1666 I ActivityManager: Killing 19879:com.google.android.dialer/u0a21 (adj 906): empty for 2774s
+02-29 00:02:00.020  1666  1666 I ActivityManager: Killing 19634:com.google.process.gapps/u0a13 (adj 906): empty for 3659s
+02-29 00:02:00.020  1666  1688 W zygote  : kill(-19879, 9) failed: No such process
+02-29 00:02:00.025  1666  1685 E memtrack: Couldn't load memtrack module
+02-29 00:02:00.026  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-29 00:02:00.051  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-29 00:02:00.058  1666  1688 W zygote  : kill(-19879, 9) failed: No such process
+02-29 00:02:00.095  1666  1685 E memtrack: Couldn't load memtrack module
+02-29 00:02:00.095  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-29 00:02:00.103  1666  1688 W zygote  : kill(-19879, 9) failed: No such process
+02-29 00:02:00.122  1666  1685 E memtrack: Couldn't load memtrack module
+02-29 00:02:00.122  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-29 00:02:00.147  1666  1688 W zygote  : kill(-19879, 9) failed: No such process
+02-29 00:02:00.147  1666  1688 I zygote  : Successfully killed process cgroup uid 10021 pid 19879 in 127ms
+02-29 00:02:00.147  1666  1688 W zygote  : kill(-19634, 9) failed: No such process
+02-29 00:02:00.147  1666  1688 I zygote  : Successfully killed process cgroup uid 10013 pid 19634 in 0ms
+02-29 00:02:00.151  1666  1685 E memtrack: Couldn't load memtrack module
+02-29 00:02:00.151  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-29 00:02:00.176  1666  1685 E memtrack: Couldn't load memtrack module
+02-29 00:02:00.176  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-29 00:02:10.638  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-29 00:02:10.638  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-29 00:02:10.638  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-29 00:02:24.489  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-29 00:02:24.489  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-29 00:02:24.489  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-29 00:02:40.239  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-29 00:02:40.239  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-29 00:02:40.239  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-29 00:02:49.963  1449  1449 I boot-pipe: done populating /dev/random
+02-29 00:02:55.565  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-29 00:02:55.565  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-29 00:02:55.566  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-29 00:03:00.009  1666  1685 E memtrack: Couldn't load memtrack module
+02-29 00:03:00.009  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-29 00:03:00.039  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-29 00:03:10.600  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-29 00:03:10.600  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-29 00:03:10.600  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-29 00:03:49.965  1449  1449 I boot-pipe: done populating /dev/random
+02-29 00:03:51.949  1666  7772 D WificondControl: Scan result ready event
+02-29 00:04:00.032  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-29 00:04:49.967  1449  1449 I boot-pipe: done populating /dev/random
+02-29 00:05:00.009  1666  1685 E memtrack: Couldn't load memtrack module
+02-29 00:05:00.009  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-29 00:05:00.041  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-29 00:05:49.971  1449  1449 I boot-pipe: done populating /dev/random
+02-29 00:06:00.042  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-29 00:06:31.962  1666  2606 D WificondControl: Scan result ready event
+02-29 00:06:34.149  1666  2606 I WifiService: getConnectionInfo uid=10013
+02-29 00:06:34.155  2116 19873 E WakeLock: GCM_HB_ALARM release without a matched acquire!
+02-29 00:06:34.160  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-29 00:06:34.161  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-29 00:06:34.161  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-29 00:06:34.193  1666  7771 I WifiService: getConnectionInfo uid=10013
+02-29 00:06:49.200  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-29 00:06:49.201  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-29 00:06:49.201  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-29 00:06:49.974  1449  1449 I boot-pipe: done populating /dev/random
+02-29 00:07:00.010  1666  1685 E memtrack: Couldn't load memtrack module
+02-29 00:07:00.011  1666  1685 W android.os.Debug: failed to get memory consumption info: -1
+02-29 00:07:00.047  1442  1465 D hwcomposer: hw_composer sent 6 syncs in 60s
+02-29 00:07:15.714  1666  1672 I zygote  : Debugger is no longer active
+02-29 00:07:15.714 17666 17673 I zygote  : Debugger is no longer active
+02-29 00:07:15.714  2374  2384 I zygote  : Debugger is no longer active
+02-29 00:07:15.714  2249  2259 I zygote  : Debugger is no longer active
+02-29 00:07:15.714  2116  2124 I zygote  : Debugger is no longer active
+02-29 00:07:15.714  2348  2365 I zygote  : Debugger is no longer active
+02-29 00:07:15.714 17932 17939 I zygote  : Debugger is no longer active
+02-29 00:07:15.714 19702 19709 I zygote  : Debugger is no longer active
+02-29 00:07:15.714  1879  1888 I zygote  : Debugger is no longer active
+02-29 00:07:15.715  1797  1804 I zygote  : Debugger is no longer active
+02-29 00:07:15.715 19962 19969 I zygote  : Debugger is no longer active
+02-29 00:07:15.715  1812  1817 I zygote  : Debugger is no longer active
+02-29 00:07:15.715  2187  2195 I zygote  : Debugger is no longer active
+02-29 00:07:15.715  2271  2279 I zygote  : Debugger is no longer active
+02-29 00:07:15.715 20092 20099 I zygote  : Debugger is no longer active
+02-29 00:07:15.715 17969 17979 I zygote  : Debugger is no longer active
+02-29 00:07:15.715 18683 18690 I zygote  : Debugger is no longer active
+02-29 00:07:15.715 19440 19447 I zygote  : Debugger is no longer active
+02-29 00:07:15.715 20066 20074 I zygote  : Debugger is no longer active
+02-29 00:07:15.716 19777 19784 I zygote  : Debugger is no longer active
+02-29 00:07:22.959  1444  1743 W hw-IPCThreadState: All binder threads in pool (2 threads) busy for 215 ms
+02-29 00:07:23.891  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-29 00:07:23.891  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-29 00:07:23.891  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-29 00:07:25.306 20165 20165 D AndroidRuntime: >>>>>> START com.android.internal.os.RuntimeInit uid 2000 <<<<<<
+02-29 00:07:25.311 20165 20165 W app_process: Could not reserve sentinel fault page
+02-29 00:07:25.423 20165 20165 W app_process: Unexpected CPU variant for X86 using defaults: x86
+02-29 00:07:25.425 20165 20165 I app_process: The ClassLoaderContext is a special shared library.
+02-29 00:07:25.465 20165 20165 D AndroidRuntime: Calling main entry com.android.commands.wm.Wm
+02-29 00:07:25.468  1666  7771 W WindowManager: Permission Denial: dismissKeyguard from pid=20165, uid=2000 requires android.permission.CONTROL_KEYGUARD
+02-29 00:07:25.469 20165 20165 D AndroidRuntime: Shutting down VM
+02-29 00:07:31.765  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28058582 , only wrote 28058400
+02-29 00:07:31.803  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28060225 , only wrote 28059840
+02-29 00:07:33.404  1666  1689 E BatteryExternalStatsWorker: modem info is invalid: ModemActivityInfo{ mTimestamp=0 mSleepTimeMs=0 mIdleTimeMs=0 mTxTimeMs[]=[0, 0, 0, 0, 0] mRxTimeMs=0 mEnergyUsed=0}
+02-29 00:07:34.995  1451  1451 D SurfaceFlinger: duplicate layer name: changing name.mlopatkin.shuttle/name.mlopatkin.shuttle.NewMainActivity to name.mlopatkin.shuttle/name.mlopatkin.shuttle.NewMainActivity#1
+02-29 00:07:35.005  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 2527232
+02-29 00:07:35.025 18683 18688 I zygote  : Do partial code cache collection, code=198KB, data=155KB
+02-29 00:07:35.028 18683 18688 I zygote  : After code cache collection, code=198KB, data=155KB
+02-29 00:07:35.028 18683 18688 I zygote  : Increasing code cache capacity to 1024KB
+02-29 00:07:35.028 18683 18688 I zygote  : JIT allocated 71KB for compiled code of void android.widget.TextView.<init>(android.content.Context, android.util.AttributeSet, int, int)
+02-29 00:07:35.028 18683 18688 I zygote  : Compiler allocated 4MB to compile void android.widget.TextView.<init>(android.content.Context, android.util.AttributeSet, int, int)
+02-29 00:07:35.061  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 2527232
+02-29 00:07:35.085  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 2527232
+02-29 00:07:35.136 18683 18708 D EGL_emulation: eglMakeCurrent: 0xe10852a0: ver 2 0 (tinfo 0xe1083350)
+02-29 00:07:36.558 18683 18708 I chatty  : uid=10085(name.mlopatkin.shuttle) identical 2 lines
+02-29 00:07:36.583 18683 18708 D EGL_emulation: eglMakeCurrent: 0xe10852a0: ver 2 0 (tinfo 0xe1083350)
+02-29 00:07:36.585  1451  1628 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:07:36.586  1451  1628 D         : HostConnection::get() New Host Connection established 0xebe53300, tid 1628
+02-29 00:07:36.587  1451  1628 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:07:36.639  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:07:36.640  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+02-29 00:07:36.640  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:07:36.640  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+02-29 00:07:36.641  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:07:36.641  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+02-29 00:07:36.641  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:07:36.647  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+02-29 00:07:36.998  1666  1689 I WifiService: requestActivityInfo uid=1000
+02-29 00:07:36.998  1666  1689 I WifiService: reportActivityInfo uid=1000
+02-29 00:07:36.998  1666  1689 I WifiService: getSupportedFeatures uid=1000
+02-29 00:07:37.455 18683 18708 D EGL_emulation: eglMakeCurrent: 0xe10852a0: ver 2 0 (tinfo 0xe1083350)
+02-29 00:07:37.544  1451  1451 D SurfaceFlinger: duplicate layer name: changing name.mlopatkin.shuttle/name.mlopatkin.shuttle.NewMainActivity to name.mlopatkin.shuttle/name.mlopatkin.shuttle.NewMainActivity#1
+02-29 00:07:37.552  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 2527232
+02-29 00:07:37.560  1441  1441 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 2527232
+02-29 00:07:37.566  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 2527232
+02-29 00:07:37.646 18683 18708 D EGL_emulation: eglMakeCurrent: 0xe10852a0: ver 2 0 (tinfo 0xe1083350)
+02-29 00:07:37.666 18683 18708 I chatty  : uid=10085(name.mlopatkin.shuttle) identical 1 line
+02-29 00:07:37.672 18683 18708 D EGL_emulation: eglMakeCurrent: 0xe10852a0: ver 2 0 (tinfo 0xe1083350)
+02-29 00:07:38.232  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28368184 , only wrote 28368000
+02-29 00:07:38.234  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28368333 , only wrote 28368000
+02-29 00:07:38.249  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28368731 , only wrote 28368720
+02-29 00:07:38.399  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28375932 , only wrote 28375920
+02-29 00:07:38.430  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28377404 , only wrote 28377360
+02-29 00:07:38.432  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28377420 , only wrote 28377360
+02-29 00:07:38.448  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28378145 , only wrote 28378080
+02-29 00:07:38.508  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28380977 , only wrote 28380960
+02-29 00:07:38.513  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28381191 , only wrote 28380960
+02-29 00:07:38.548  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28382628 , only wrote 28381680
+02-29 00:07:38.550  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28381719 , only wrote 28381680
+02-29 00:07:38.808  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28394109 , only wrote 28393920
+02-29 00:07:38.823  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28394660 , only wrote 28394640
+02-29 00:07:38.856  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28396205 , only wrote 28396080
+02-29 00:07:39.756  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28439286 , only wrote 28439280
+02-29 00:07:39.758  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28439363 , only wrote 28439280
+02-29 00:07:39.782  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28440445 , only wrote 28440000
+02-29 00:07:40.623  1433  1583 W audio_hw_generic: Not supplying enough data to HAL, expected position 28519996 , only wrote 28480320
+02-29 00:07:49.976  1449  1449 I boot-pipe: done populating /dev/random
+02-29 00:07:59.059  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28480437 , only wrote 28480320
+02-29 00:07:59.068 18683 18683 I WebViewFactory: Loading com.android.chrome version 69.0.3497.100 (code 349710017)
+02-29 00:07:59.071 18683 18683 I zygote  : The ClassLoaderContext is a special shared library.
+02-29 00:07:59.115 18683 18683 I zygote  : Rejecting re-init on previously-failed class java.lang.Class<uJ>: java.lang.NoClassDefFoundError: Failed resolution of: Landroid/webkit/TracingController;
+02-29 00:07:59.115 18683 18683 I zygote  :   at java.lang.Class java.lang.Class.classForName(java.lang.String, boolean, java.lang.ClassLoader) (Class.java:-2)
+02-29 00:07:59.115 18683 18683 I zygote  :   at java.lang.Class java.lang.Class.forName(java.lang.String, boolean, java.lang.ClassLoader) (Class.java:453)
+02-29 00:07:59.115 18683 18683 I zygote  :   at java.lang.Class android.webkit.WebViewFactory.getWebViewProviderClass(java.lang.ClassLoader) (WebViewFactory.java:128)
+02-29 00:07:59.115 18683 18683 I zygote  :   at java.lang.Class android.webkit.WebViewFactory.getProviderClass() (WebViewFactory.java:402)
+02-29 00:07:59.115 18683 18683 I zygote  :   at android.webkit.WebViewFactoryProvider android.webkit.WebViewFactory.getProvider() (WebViewFactory.java:194)
+02-29 00:07:59.116 18683 18683 I zygote  :   at android.webkit.WebViewFactoryProvider android.webkit.WebView.getFactory() (WebView.java:2530)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void android.webkit.WebView.ensureProviderCreated() (WebView.java:2525)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void android.webkit.WebView.setOverScrollMode(int) (WebView.java:2590)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void android.view.View.<init>(android.content.Context) (View.java:4574)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void android.view.View.<init>(android.content.Context, android.util.AttributeSet, int, int) (View.java:4706)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void android.view.ViewGroup.<init>(android.content.Context, android.util.AttributeSet, int, int) (ViewGroup.java:597)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void android.widget.AbsoluteLayout.<init>(android.content.Context, android.util.AttributeSet, int, int) (AbsoluteLayout.java:55)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int, int, java.util.Map, boolean) (WebView.java:643)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int, int) (WebView.java:588)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int) (WebView.java:571)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet) (WebView.java:558)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context) (WebView.java:548)
+02-29 00:07:59.116 18683 18683 I zygote  :   at android.app.Dialog name.mlopatkin.shuttle.AboutDialogs$ThirdPartyLicensesFragment.onCreateDialog(android.os.Bundle) (AboutDialogs.java:90)
+02-29 00:07:59.116 18683 18683 I zygote  :   at android.view.LayoutInflater androidx.fragment.app.DialogFragment.onGetLayoutInflater(android.os.Bundle) (DialogFragment.java:403)
+02-29 00:07:59.116 18683 18683 I zygote  :   at android.view.LayoutInflater androidx.fragment.app.Fragment.performGetLayoutInflater(android.os.Bundle) (Fragment.java:1484)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentStateManager.createView(androidx.fragment.app.FragmentContainer) (FragmentStateManager.java:320)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(androidx.fragment.app.Fragment, int) (FragmentManager.java:1187)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(androidx.fragment.app.Fragment) (FragmentManager.java:1356)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveFragmentToExpectedState(androidx.fragment.app.Fragment) (FragmentManager.java:1434)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(int, boolean) (FragmentManager.java:1497)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void androidx.fragment.app.BackStackRecord.executeOps() (BackStackRecord.java:447)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.executeOps(java.util.ArrayList, java.util.ArrayList, int, int) (FragmentManager.java:2169)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.executeOpsTogether(java.util.ArrayList, java.util.ArrayList, int, int) (FragmentManager.java:1992)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(java.util.ArrayList, java.util.ArrayList) (FragmentManager.java:1947)
+02-29 00:07:59.116 18683 18683 I zygote  :   at boolean androidx.fragment.app.FragmentManager.execPendingActions(boolean) (FragmentManager.java:1849)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager$4.run() (FragmentManager.java:413)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void android.os.Handler.handleCallback(android.os.Message) (Handler.java:790)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void android.os.Handler.dispatchMessage(android.os.Message) (Handler.java:99)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void android.os.Looper.loop() (Looper.java:164)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+02-29 00:07:59.116 18683 18683 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+02-29 00:07:59.116 18683 18683 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+02-29 00:07:59.116 18683 18683 I zygote  : Caused by: java.lang.ClassNotFoundException: Didn't find class "android.webkit.TracingController" on path: DexPathList[[zip file "/system/app/Chrome/Chrome.apk"],nativeLibraryDirectories=[/system/app/Chrome/lib/x86, /system/app/Chrome/Chrome.apk!/lib/x86, /system/lib, /vendor/lib, /system/lib, /vendor/lib]]
+02-29 00:07:59.117 18683 18683 I zygote  :   at java.lang.Class dalvik.system.BaseDexClassLoader.findClass(java.lang.String) (BaseDexClassLoader.java:125)
+02-29 00:07:59.117 18683 18683 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String, boolean) (ClassLoader.java:379)
+02-29 00:07:59.117 18683 18683 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String) (ClassLoader.java:312)
+02-29 00:07:59.117 18683 18683 I zygote  :   at java.lang.Class java.lang.Class.classForName(java.lang.String, boolean, java.lang.ClassLoader) (Class.java:-2)
+02-29 00:07:59.117 18683 18683 I zygote  :   at java.lang.Class java.lang.Class.forName(java.lang.String, boolean, java.lang.ClassLoader) (Class.java:453)
+02-29 00:07:59.117 18683 18683 I zygote  :   at java.lang.Class android.webkit.WebViewFactory.getWebViewProviderClass(java.lang.ClassLoader) (WebViewFactory.java:128)
+02-29 00:07:59.117 18683 18683 I zygote  :   at java.lang.Class android.webkit.WebViewFactory.getProviderClass() (WebViewFactory.java:402)
+02-29 00:07:59.117 18683 18683 I zygote  :   at android.webkit.WebViewFactoryProvider android.webkit.WebViewFactory.getProvider() (WebViewFactory.java:194)
+02-29 00:07:59.117 18683 18683 I zygote  :   at android.webkit.WebViewFactoryProvider android.webkit.WebView.getFactory() (WebView.java:2530)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void android.webkit.WebView.ensureProviderCreated() (WebView.java:2525)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void android.webkit.WebView.setOverScrollMode(int) (WebView.java:2590)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void android.view.View.<init>(android.content.Context) (View.java:4574)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void android.view.View.<init>(android.content.Context, android.util.AttributeSet, int, int) (View.java:4706)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void android.view.ViewGroup.<init>(android.content.Context, android.util.AttributeSet, int, int) (ViewGroup.java:597)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void android.widget.AbsoluteLayout.<init>(android.content.Context, android.util.AttributeSet, int, int) (AbsoluteLayout.java:55)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int, int, java.util.Map, boolean) (WebView.java:643)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int, int) (WebView.java:588)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int) (WebView.java:571)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet) (WebView.java:558)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context) (WebView.java:548)
+02-29 00:07:59.117 18683 18683 I zygote  :   at android.app.Dialog name.mlopatkin.shuttle.AboutDialogs$ThirdPartyLicensesFragment.onCreateDialog(android.os.Bundle) (AboutDialogs.java:90)
+02-29 00:07:59.117 18683 18683 I zygote  :   at android.view.LayoutInflater androidx.fragment.app.DialogFragment.onGetLayoutInflater(android.os.Bundle) (DialogFragment.java:403)
+02-29 00:07:59.117 18683 18683 I zygote  :   at android.view.LayoutInflater androidx.fragment.app.Fragment.performGetLayoutInflater(android.os.Bundle) (Fragment.java:1484)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentStateManager.createView(androidx.fragment.app.FragmentContainer) (FragmentStateManager.java:320)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(androidx.fragment.app.Fragment, int) (FragmentManager.java:1187)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(androidx.fragment.app.Fragment) (FragmentManager.java:1356)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveFragmentToExpectedState(androidx.fragment.app.Fragment) (FragmentManager.java:1434)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(int, boolean) (FragmentManager.java:1497)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void androidx.fragment.app.BackStackRecord.executeOps() (BackStackRecord.java:447)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.executeOps(java.util.ArrayList, java.util.ArrayList, int, int) (FragmentManager.java:2169)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.executeOpsTogether(java.util.ArrayList, java.util.ArrayList, int, int) (FragmentManager.java:1992)
+02-29 00:07:59.117 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(java.util.ArrayList, java.util.ArrayList) (FragmentManager.java:1947)
+02-29 00:07:59.118 18683 18683 I zygote  :   at boolean androidx.fragment.app.FragmentManager.execPendingActions(boolean) (FragmentManager.java:1849)
+02-29 00:07:59.118 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager$4.run() (FragmentManager.java:413)
+02-29 00:07:59.118 18683 18683 I zygote  :   at void android.os.Handler.handleCallback(android.os.Message) (Handler.java:790)
+02-29 00:07:59.118 18683 18683 I zygote  :   at void android.os.Handler.dispatchMessage(android.os.Message) (Handler.java:99)
+02-29 00:07:59.118 18683 18683 I zygote  :   at void android.os.Looper.loop() (Looper.java:164)
+02-29 00:07:59.118 18683 18683 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+02-29 00:07:59.118 18683 18683 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+02-29 00:07:59.118 18683 18683 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+02-29 00:07:59.118 18683 18683 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+02-29 00:07:59.118 18683 18683 I zygote  : 
+02-29 00:07:59.118 18683 18683 I zygote  : Rejecting re-init on previously-failed class java.lang.Class<uJ>: java.lang.NoClassDefFoundError: Failed resolution of: Landroid/webkit/TracingController;
+02-29 00:07:59.119 18683 18683 I zygote  :   at java.lang.Class java.lang.Class.classForName(java.lang.String, boolean, java.lang.ClassLoader) (Class.java:-2)
+02-29 00:07:59.119 18683 18683 I zygote  :   at java.lang.Class java.lang.Class.forName(java.lang.String, boolean, java.lang.ClassLoader) (Class.java:453)
+02-29 00:07:59.119 18683 18683 I zygote  :   at java.lang.Class android.webkit.WebViewFactory.getWebViewProviderClass(java.lang.ClassLoader) (WebViewFactory.java:128)
+02-29 00:07:59.119 18683 18683 I zygote  :   at java.lang.Class android.webkit.WebViewFactory.getProviderClass() (WebViewFactory.java:402)
+02-29 00:07:59.119 18683 18683 I zygote  :   at android.webkit.WebViewFactoryProvider android.webkit.WebViewFactory.getProvider() (WebViewFactory.java:194)
+02-29 00:07:59.119 18683 18683 I zygote  :   at android.webkit.WebViewFactoryProvider android.webkit.WebView.getFactory() (WebView.java:2530)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void android.webkit.WebView.ensureProviderCreated() (WebView.java:2525)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void android.webkit.WebView.setOverScrollMode(int) (WebView.java:2590)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void android.view.View.<init>(android.content.Context) (View.java:4574)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void android.view.View.<init>(android.content.Context, android.util.AttributeSet, int, int) (View.java:4706)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void android.view.ViewGroup.<init>(android.content.Context, android.util.AttributeSet, int, int) (ViewGroup.java:597)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void android.widget.AbsoluteLayout.<init>(android.content.Context, android.util.AttributeSet, int, int) (AbsoluteLayout.java:55)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int, int, java.util.Map, boolean) (WebView.java:643)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int, int) (WebView.java:588)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int) (WebView.java:571)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet) (WebView.java:558)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context) (WebView.java:548)
+02-29 00:07:59.119 18683 18683 I zygote  :   at android.app.Dialog name.mlopatkin.shuttle.AboutDialogs$ThirdPartyLicensesFragment.onCreateDialog(android.os.Bundle) (AboutDialogs.java:90)
+02-29 00:07:59.119 18683 18683 I zygote  :   at android.view.LayoutInflater androidx.fragment.app.DialogFragment.onGetLayoutInflater(android.os.Bundle) (DialogFragment.java:403)
+02-29 00:07:59.119 18683 18683 I zygote  :   at android.view.LayoutInflater androidx.fragment.app.Fragment.performGetLayoutInflater(android.os.Bundle) (Fragment.java:1484)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentStateManager.createView(androidx.fragment.app.FragmentContainer) (FragmentStateManager.java:320)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(androidx.fragment.app.Fragment, int) (FragmentManager.java:1187)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(androidx.fragment.app.Fragment) (FragmentManager.java:1356)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveFragmentToExpectedState(androidx.fragment.app.Fragment) (FragmentManager.java:1434)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(int, boolean) (FragmentManager.java:1497)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void androidx.fragment.app.BackStackRecord.executeOps() (BackStackRecord.java:447)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.executeOps(java.util.ArrayList, java.util.ArrayList, int, int) (FragmentManager.java:2169)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.executeOpsTogether(java.util.ArrayList, java.util.ArrayList, int, int) (FragmentManager.java:1992)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(java.util.ArrayList, java.util.ArrayList) (FragmentManager.java:1947)
+02-29 00:07:59.119 18683 18683 I zygote  :   at boolean androidx.fragment.app.FragmentManager.execPendingActions(boolean) (FragmentManager.java:1849)
+02-29 00:07:59.119 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager$4.run() (FragmentManager.java:413)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void android.os.Handler.handleCallback(android.os.Message) (Handler.java:790)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void android.os.Handler.dispatchMessage(android.os.Message) (Handler.java:99)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void android.os.Looper.loop() (Looper.java:164)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+02-29 00:07:59.120 18683 18683 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+02-29 00:07:59.120 18683 18683 I zygote  : Caused by: java.lang.ClassNotFoundException: Didn't find class "android.webkit.TracingController" on path: DexPathList[[zip file "/system/app/Chrome/Chrome.apk"],nativeLibraryDirectories=[/system/app/Chrome/lib/x86, /system/app/Chrome/Chrome.apk!/lib/x86, /system/lib, /vendor/lib, /system/lib, /vendor/lib]]
+02-29 00:07:59.120 18683 18683 I zygote  :   at java.lang.Class dalvik.system.BaseDexClassLoader.findClass(java.lang.String) (BaseDexClassLoader.java:125)
+02-29 00:07:59.120 18683 18683 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String, boolean) (ClassLoader.java:379)
+02-29 00:07:59.120 18683 18683 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String) (ClassLoader.java:312)
+02-29 00:07:59.120 18683 18683 I zygote  :   at java.lang.Class java.lang.Class.classForName(java.lang.String, boolean, java.lang.ClassLoader) (Class.java:-2)
+02-29 00:07:59.120 18683 18683 I zygote  :   at java.lang.Class java.lang.Class.forName(java.lang.String, boolean, java.lang.ClassLoader) (Class.java:453)
+02-29 00:07:59.120 18683 18683 I zygote  :   at java.lang.Class android.webkit.WebViewFactory.getWebViewProviderClass(java.lang.ClassLoader) (WebViewFactory.java:128)
+02-29 00:07:59.120 18683 18683 I zygote  :   at java.lang.Class android.webkit.WebViewFactory.getProviderClass() (WebViewFactory.java:402)
+02-29 00:07:59.120 18683 18683 I zygote  :   at android.webkit.WebViewFactoryProvider android.webkit.WebViewFactory.getProvider() (WebViewFactory.java:194)
+02-29 00:07:59.120 18683 18683 I zygote  :   at android.webkit.WebViewFactoryProvider android.webkit.WebView.getFactory() (WebView.java:2530)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void android.webkit.WebView.ensureProviderCreated() (WebView.java:2525)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void android.webkit.WebView.setOverScrollMode(int) (WebView.java:2590)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void android.view.View.<init>(android.content.Context) (View.java:4574)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void android.view.View.<init>(android.content.Context, android.util.AttributeSet, int, int) (View.java:4706)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void android.view.ViewGroup.<init>(android.content.Context, android.util.AttributeSet, int, int) (ViewGroup.java:597)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void android.widget.AbsoluteLayout.<init>(android.content.Context, android.util.AttributeSet, int, int) (AbsoluteLayout.java:55)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int, int, java.util.Map, boolean) (WebView.java:643)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int, int) (WebView.java:588)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int) (WebView.java:571)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet) (WebView.java:558)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context) (WebView.java:548)
+02-29 00:07:59.120 18683 18683 I zygote  :   at android.app.Dialog name.mlopatkin.shuttle.AboutDialogs$ThirdPartyLicensesFragment.onCreateDialog(android.os.Bundle) (AboutDialogs.java:90)
+02-29 00:07:59.120 18683 18683 I zygote  :   at android.view.LayoutInflater androidx.fragment.app.DialogFragment.onGetLayoutInflater(android.os.Bundle) (DialogFragment.java:403)
+02-29 00:07:59.120 18683 18683 I zygote  :   at android.view.LayoutInflater androidx.fragment.app.Fragment.performGetLayoutInflater(android.os.Bundle) (Fragment.java:1484)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentStateManager.createView(androidx.fragment.app.FragmentContainer) (FragmentStateManager.java:320)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(androidx.fragment.app.Fragment, int) (FragmentManager.java:1187)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(androidx.fragment.app.Fragment) (FragmentManager.java:1356)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveFragmentToExpectedState(androidx.fragment.app.Fragment) (FragmentManager.java:1434)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(int, boolean) (FragmentManager.java:1497)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void androidx.fragment.app.BackStackRecord.executeOps() (BackStackRecord.java:447)
+02-29 00:07:59.120 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.executeOps(java.util.ArrayList, java.util.ArrayList, int, int) (FragmentManager.java:2169)
+02-29 00:07:59.121 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.executeOpsTogether(java.util.ArrayList, java.util.ArrayList, int, int) (FragmentManager.java:1992)
+02-29 00:07:59.121 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(java.util.ArrayList, java.util.ArrayList) (FragmentManager.java:1947)
+02-29 00:07:59.121 18683 18683 I zygote  :   at boolean androidx.fragment.app.FragmentManager.execPendingActions(boolean) (FragmentManager.java:1849)
+02-29 00:07:59.121 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager$4.run() (FragmentManager.java:413)
+02-29 00:07:59.121 18683 18683 I zygote  :   at void android.os.Handler.handleCallback(android.os.Message) (Handler.java:790)
+02-29 00:07:59.121 18683 18683 I zygote  :   at void android.os.Handler.dispatchMessage(android.os.Message) (Handler.java:99)
+02-29 00:07:59.121 18683 18683 I zygote  :   at void android.os.Looper.loop() (Looper.java:164)
+02-29 00:07:59.121 18683 18683 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+02-29 00:07:59.121 18683 18683 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+02-29 00:07:59.121 18683 18683 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+02-29 00:07:59.121 18683 18683 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+02-29 00:07:59.121 18683 18683 I zygote  : 
+02-29 00:07:59.122 18683 18683 I zygote  : Rejecting re-init on previously-failed class java.lang.Class<uJ>: java.lang.NoClassDefFoundError: Failed resolution of: Landroid/webkit/TracingController;
+02-29 00:07:59.122 18683 18683 I zygote  :   at java.lang.Class java.lang.Class.classForName(java.lang.String, boolean, java.lang.ClassLoader) (Class.java:-2)
+02-29 00:07:59.122 18683 18683 I zygote  :   at java.lang.Class java.lang.Class.forName(java.lang.String, boolean, java.lang.ClassLoader) (Class.java:453)
+02-29 00:07:59.122 18683 18683 I zygote  :   at java.lang.Class android.webkit.WebViewFactory.getWebViewProviderClass(java.lang.ClassLoader) (WebViewFactory.java:128)
+02-29 00:07:59.122 18683 18683 I zygote  :   at java.lang.Class android.webkit.WebViewFactory.getProviderClass() (WebViewFactory.java:402)
+02-29 00:07:59.122 18683 18683 I zygote  :   at android.webkit.WebViewFactoryProvider android.webkit.WebViewFactory.getProvider() (WebViewFactory.java:194)
+02-29 00:07:59.122 18683 18683 I zygote  :   at android.webkit.WebViewFactoryProvider android.webkit.WebView.getFactory() (WebView.java:2530)
+02-29 00:07:59.122 18683 18683 I zygote  :   at void android.webkit.WebView.ensureProviderCreated() (WebView.java:2525)
+02-29 00:07:59.122 18683 18683 I zygote  :   at void android.webkit.WebView.setOverScrollMode(int) (WebView.java:2590)
+02-29 00:07:59.122 18683 18683 I zygote  :   at void android.view.View.<init>(android.content.Context) (View.java:4574)
+02-29 00:07:59.122 18683 18683 I zygote  :   at void android.view.View.<init>(android.content.Context, android.util.AttributeSet, int, int) (View.java:4706)
+02-29 00:07:59.122 18683 18683 I zygote  :   at void android.view.ViewGroup.<init>(android.content.Context, android.util.AttributeSet, int, int) (ViewGroup.java:597)
+02-29 00:07:59.122 18683 18683 I zygote  :   at void android.widget.AbsoluteLayout.<init>(android.content.Context, android.util.AttributeSet, int, int) (AbsoluteLayout.java:55)
+02-29 00:07:59.122 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int, int, java.util.Map, boolean) (WebView.java:643)
+02-29 00:07:59.122 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int, int) (WebView.java:588)
+02-29 00:07:59.122 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int) (WebView.java:571)
+02-29 00:07:59.122 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet) (WebView.java:558)
+02-29 00:07:59.122 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context) (WebView.java:548)
+02-29 00:07:59.122 18683 18683 I zygote  :   at android.app.Dialog name.mlopatkin.shuttle.AboutDialogs$ThirdPartyLicensesFragment.onCreateDialog(android.os.Bundle) (AboutDialogs.java:90)
+02-29 00:07:59.122 18683 18683 I zygote  :   at android.view.LayoutInflater androidx.fragment.app.DialogFragment.onGetLayoutInflater(android.os.Bundle) (DialogFragment.java:403)
+02-29 00:07:59.122 18683 18683 I zygote  :   at android.view.LayoutInflater androidx.fragment.app.Fragment.performGetLayoutInflater(android.os.Bundle) (Fragment.java:1484)
+02-29 00:07:59.122 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentStateManager.createView(androidx.fragment.app.FragmentContainer) (FragmentStateManager.java:320)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(androidx.fragment.app.Fragment, int) (FragmentManager.java:1187)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(androidx.fragment.app.Fragment) (FragmentManager.java:1356)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveFragmentToExpectedState(androidx.fragment.app.Fragment) (FragmentManager.java:1434)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(int, boolean) (FragmentManager.java:1497)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void androidx.fragment.app.BackStackRecord.executeOps() (BackStackRecord.java:447)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.executeOps(java.util.ArrayList, java.util.ArrayList, int, int) (FragmentManager.java:2169)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.executeOpsTogether(java.util.ArrayList, java.util.ArrayList, int, int) (FragmentManager.java:1992)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(java.util.ArrayList, java.util.ArrayList) (FragmentManager.java:1947)
+02-29 00:07:59.123 18683 18683 I zygote  :   at boolean androidx.fragment.app.FragmentManager.execPendingActions(boolean) (FragmentManager.java:1849)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager$4.run() (FragmentManager.java:413)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void android.os.Handler.handleCallback(android.os.Message) (Handler.java:790)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void android.os.Handler.dispatchMessage(android.os.Message) (Handler.java:99)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void android.os.Looper.loop() (Looper.java:164)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+02-29 00:07:59.123 18683 18683 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+02-29 00:07:59.123 18683 18683 I zygote  : Caused by: java.lang.ClassNotFoundException: Didn't find class "android.webkit.TracingController" on path: DexPathList[[zip file "/system/app/Chrome/Chrome.apk"],nativeLibraryDirectories=[/system/app/Chrome/lib/x86, /system/app/Chrome/Chrome.apk!/lib/x86, /system/lib, /vendor/lib, /system/lib, /vendor/lib]]
+02-29 00:07:59.123 18683 18683 I zygote  :   at java.lang.Class dalvik.system.BaseDexClassLoader.findClass(java.lang.String) (BaseDexClassLoader.java:125)
+02-29 00:07:59.123 18683 18683 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String, boolean) (ClassLoader.java:379)
+02-29 00:07:59.123 18683 18683 I zygote  :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String) (ClassLoader.java:312)
+02-29 00:07:59.123 18683 18683 I zygote  :   at java.lang.Class java.lang.Class.classForName(java.lang.String, boolean, java.lang.ClassLoader) (Class.java:-2)
+02-29 00:07:59.123 18683 18683 I zygote  :   at java.lang.Class java.lang.Class.forName(java.lang.String, boolean, java.lang.ClassLoader) (Class.java:453)
+02-29 00:07:59.123 18683 18683 I zygote  :   at java.lang.Class android.webkit.WebViewFactory.getWebViewProviderClass(java.lang.ClassLoader) (WebViewFactory.java:128)
+02-29 00:07:59.123 18683 18683 I zygote  :   at java.lang.Class android.webkit.WebViewFactory.getProviderClass() (WebViewFactory.java:402)
+02-29 00:07:59.123 18683 18683 I zygote  :   at android.webkit.WebViewFactoryProvider android.webkit.WebViewFactory.getProvider() (WebViewFactory.java:194)
+02-29 00:07:59.123 18683 18683 I zygote  :   at android.webkit.WebViewFactoryProvider android.webkit.WebView.getFactory() (WebView.java:2530)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void android.webkit.WebView.ensureProviderCreated() (WebView.java:2525)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void android.webkit.WebView.setOverScrollMode(int) (WebView.java:2590)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void android.view.View.<init>(android.content.Context) (View.java:4574)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void android.view.View.<init>(android.content.Context, android.util.AttributeSet, int, int) (View.java:4706)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void android.view.ViewGroup.<init>(android.content.Context, android.util.AttributeSet, int, int) (ViewGroup.java:597)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void android.widget.AbsoluteLayout.<init>(android.content.Context, android.util.AttributeSet, int, int) (AbsoluteLayout.java:55)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int, int, java.util.Map, boolean) (WebView.java:643)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int, int) (WebView.java:588)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet, int) (WebView.java:571)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context, android.util.AttributeSet) (WebView.java:558)
+02-29 00:07:59.123 18683 18683 I zygote  :   at void android.webkit.WebView.<init>(android.content.Context) (WebView.java:548)
+02-29 00:07:59.123 18683 18683 I zygote  :   at android.app.Dialog name.mlopatkin.shuttle.AboutDialogs$ThirdPartyLicensesFragment.onCreateDialog(android.os.Bundle) (AboutDialogs.java:90)
+02-29 00:07:59.124 18683 18683 I zygote  :   at android.view.LayoutInflater androidx.fragment.app.DialogFragment.onGetLayoutInflater(android.os.Bundle) (DialogFragment.java:403)
+02-29 00:07:59.124 18683 18683 I zygote  :   at android.view.LayoutInflater androidx.fragment.app.Fragment.performGetLayoutInflater(android.os.Bundle) (Fragment.java:1484)
+02-29 00:07:59.124 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentStateManager.createView(androidx.fragment.app.FragmentContainer) (FragmentStateManager.java:320)
+02-29 00:07:59.124 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(androidx.fragment.app.Fragment, int) (FragmentManager.java:1187)
+02-29 00:07:59.124 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(androidx.fragment.app.Fragment) (FragmentManager.java:1356)
+02-29 00:07:59.124 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveFragmentToExpectedState(androidx.fragment.app.Fragment) (FragmentManager.java:1434)
+02-29 00:07:59.124 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.moveToState(int, boolean) (FragmentManager.java:1497)
+02-29 00:07:59.124 18683 18683 I zygote  :   at void androidx.fragment.app.BackStackRecord.executeOps() (BackStackRecord.java:447)
+02-29 00:07:59.124 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.executeOps(java.util.ArrayList, java.util.ArrayList, int, int) (FragmentManager.java:2169)
+02-29 00:07:59.124 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.executeOpsTogether(java.util.ArrayList, java.util.ArrayList, int, int) (FragmentManager.java:1992)
+02-29 00:07:59.124 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(java.util.ArrayList, java.util.ArrayList) (FragmentManager.java:1947)
+02-29 00:07:59.124 18683 18683 I zygote  :   at boolean androidx.fragment.app.FragmentManager.execPendingActions(boolean) (FragmentManager.java:1849)
+02-29 00:07:59.124 18683 18683 I zygote  :   at void androidx.fragment.app.FragmentManager$4.run() (FragmentManager.java:413)
+02-29 00:07:59.124 18683 18683 I zygote  :   at void android.os.Handler.handleCallback(android.os.Message) (Handler.java:790)
+02-29 00:07:59.124 18683 18683 I zygote  :   at void android.os.Handler.dispatchMessage(android.os.Message) (Handler.java:99)
+02-29 00:07:59.124 18683 18683 I zygote  :   at void android.os.Looper.loop() (Looper.java:164)
+02-29 00:07:59.124 18683 18683 I zygote  :   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6494)
+02-29 00:07:59.124 18683 18683 I zygote  :   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
+02-29 00:07:59.124 18683 18683 I zygote  :   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:438)
+02-29 00:07:59.124 18683 18683 I zygote  :   at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:807)
+02-29 00:07:59.124 18683 18683 I zygote  : 
+02-29 00:07:59.159 18683 18683 I cr_LibraryLoader: Time to load native libraries: 23 ms (timestamps 9849-9872)
+02-29 00:07:59.168 18683 20341 E cr_VariationsUtils: Failed reading seed file "/data/user/0/name.mlopatkin.shuttle/app_webview/variations_seed": /data/user/0/name.mlopatkin.shuttle/app_webview/variations_seed (No such file or directory)
+02-29 00:07:59.174 18683 18683 I chromium: [INFO:library_loader_hooks.cc(36)] Chromium logging enabled: level = 0, default verbosity = 0
+02-29 00:07:59.174 18683 18683 I cr_LibraryLoader: Expected native library version number "69.0.3497.100", actual native library version number "69.0.3497.100"
+02-29 00:07:59.181 18683 20342 W cr_ChildProcLH: Create a new ChildConnectionAllocator with package name = com.android.chrome, sandboxed = true
+02-29 00:07:59.184 20343 20343 W zygote  : Unexpected CPU variant for X86 using defaults: x86
+02-29 00:07:59.186  1666  2606 I ActivityManager: Start proc 20343:com.android.chrome:webview_service/u0a48 for service com.android.chrome/org.chromium.android_webview.services.VariationsSeedServer
+02-29 00:07:59.192 18683 18683 I cr_BrowserStartup: Initializing chromium process, singleProcess=false
+02-29 00:07:59.198 18683 18683 W ResourceType: Failure getting entry for 0x7f1204b0 (t=17 e=1200) (error -2147483647)
+02-29 00:07:59.204  1666  3380 I ActivityManager: Start proc 20357:com.android.chrome:sandboxed_process0/u0i5 for webview_service name.mlopatkin.shuttle/org.chromium.content.app.SandboxedProcessService0
+02-29 00:07:59.205 20357 20357 E /system/bin/webview_zygote32: Failed to make and chown /acct/uid_99005: Permission denied
+02-29 00:07:59.205 20357 20357 E Zygote  : createProcessGroup(99005, 0) failed: Permission denied
+02-29 00:07:59.208 20357 20357 W /system/bin/webview_zygote32: Unexpected CPU variant for X86 using defaults: x86
+02-29 00:07:59.230 20380 20380 E asset   : setgid: Operation not permitted
+02-29 00:07:59.262 20357 20357 I cr_ChildProcessService: Creating new ChildProcessService pid=20357
+02-29 00:07:59.276 20343 20343 I zygote  : The ClassLoaderContext is a special shared library.
+02-29 00:07:59.330 18683 20402 D         : HostConnection::get() New Host Connection established 0xe10bbf40, tid 20402
+02-29 00:07:59.330 18683 20378 W cr_media: Requires BLUETOOTH permission
+02-29 00:07:59.330 18683 20402 E chromium: [ERROR:gl_surface_egl.cc(335)] eglChooseConfig failed with error EGL_SUCCESS
+02-29 00:07:59.372 18683 20402 D EGL_emulation: eglCreateContext: 0xe10867a0: maj 2 min 0 rcv 2
+02-29 00:07:59.374 18683 20402 D EGL_emulation: eglMakeCurrent: 0xe10867a0: ver 2 0 (tinfo 0xcd5f5510)
+02-29 00:07:59.389  1442  1465 D hwcomposer: hw_composer sent 36 syncs in 60s
+02-29 00:07:59.418  1666  7771 I ActivityManager: Killing 19702:com.google.android.apps.photos/u0a70 (adj 906): empty for 2915s
+02-29 00:07:59.418 20357 20391 I cr_LibraryLoader: Time to load native libraries: 0 ms (timestamps 132-132)
+02-29 00:07:59.419  1450  1450 E lowmemorykiller: Error writing /proc/19702/oom_score_adj; errno=22
+02-29 00:07:59.419 20357 20391 I chromium: [INFO:library_loader_hooks.cc(36)] Chromium logging enabled: level = 0, default verbosity = 0
+02-29 00:07:59.419 20357 20391 I cr_LibraryLoader: Expected native library version number "69.0.3497.100", actual native library version number "69.0.3497.100"
+02-29 00:07:59.419 20343 20398 E cr_VariationsUtils: Failed reading seed file "/data/user/0/com.android.chrome/app_webview/variations_seed": /data/user/0/com.android.chrome/app_webview/variations_seed (No such file or directory)
+02-29 00:07:59.426  1666  1688 W zygote  : kill(-19702, 9) failed: No such process
+02-29 00:07:59.467  1666  1688 I chatty  : uid=1000(system) ActivityManager identical 1 line
+02-29 00:07:59.506  1666  1688 W zygote  : kill(-19702, 9) failed: No such process
+02-29 00:07:59.506  1666  1688 I zygote  : Successfully killed process cgroup uid 10070 pid 19702 in 80ms
+02-29 00:07:59.513  1451  1451 D SurfaceFlinger: duplicate layer name: changing name.mlopatkin.shuttle/name.mlopatkin.shuttle.NewMainActivity to name.mlopatkin.shuttle/name.mlopatkin.shuttle.NewMainActivity#2
+02-29 00:07:59.526  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 1593344
+02-29 00:07:59.546 18683 20402 I VideoCapabilities: Unsupported profile 4 for video/mp4v-es
+02-29 00:07:59.552  1451  2135 D         : HostConnection::get() New Host Connection established 0xf1cf2b80, tid 2135
+02-29 00:07:59.553  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 1593344
+02-29 00:07:59.559 18683 20402 W cr_MediaCodecUtil: HW encoder for video/avc is not available on this device.
+02-29 00:07:59.562  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 1593344
+02-29 00:07:59.663 18683 18708 D EGL_emulation: eglMakeCurrent: 0xe10852a0: ver 2 0 (tinfo 0xe1083350)
+02-29 00:08:00.110  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28530765 , only wrote 28530720
+02-29 00:08:00.112  1666  1693 W zygote  : Long monitor contention with owner android.anim (1740) at void com.android.server.wm.WindowSurfacePlacer.lambda$-com_android_server_wm_WindowSurfacePlacer_5337()(WindowSurfacePlacer.java:107) waiters=0 in void com.android.server.wm.WindowManagerService$H.handleMessage(android.os.Message) for 414ms
+02-29 00:08:00.114  1666  3380 W zygote  : Long monitor contention with owner android.anim (1740) at void com.android.server.wm.WindowSurfacePlacer.lambda$-com_android_server_wm_WindowSurfacePlacer_5337()(WindowSurfacePlacer.java:107) waiters=1 in void com.android.server.wm.WindowManagerService.finishDrawingWindow(com.android.server.wm.Session, android.view.IWindow) for 401ms
+02-29 00:08:00.157  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28532976 , only wrote 28532160
+02-29 00:08:00.258  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28536979 , only wrote 28536480
+02-29 00:08:00.258  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28536499 , only wrote 28536480
+02-29 00:08:00.279 18683 20425 W cr_CrashFileManager: /data/user/0/name.mlopatkin.shuttle/cache/WebView/Crash Reports does not exist or is not a directory
+02-29 00:08:00.282  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28537604 , only wrote 28537200
+02-29 00:08:00.298  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28537990 , only wrote 28537920
+02-29 00:08:00.306  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28538290 , only wrote 28537920
+02-29 00:08:00.337  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28539427 , only wrote 28538640
+02-29 00:08:00.368  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28540098 , only wrote 28539360
+02-29 00:08:00.463  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28543936 , only wrote 28540080
+02-29 00:08:00.525  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28543069 , only wrote 28541520
+02-29 00:08:00.542  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28542308 , only wrote 28542240
+02-29 00:08:00.597  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28544904 , only wrote 28542240
+02-29 00:08:00.675  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28545987 , only wrote 28542960
+02-29 00:08:00.691  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28543738 , only wrote 28542960
+02-29 00:08:00.716  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28544158 , only wrote 28543680
+02-29 00:08:00.767  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28546101 , only wrote 28545840
+02-29 00:08:00.782 18683 20402 E chromium: [ERROR:gl_surface_egl.cc(335)] eglChooseConfig failed with error EGL_SUCCESS
+02-29 00:08:00.793 18683 20402 D EGL_emulation: eglCreateContext: 0xe1086c80: maj 2 min 0 rcv 2
+02-29 00:08:00.801 18683 20402 D EGL_emulation: eglMakeCurrent: 0xe1086c80: ver 2 0 (tinfo 0xcd5f5510)
+02-29 00:08:01.007 18683 18708 D EGL_emulation: eglMakeCurrent: 0xe10852a0: ver 2 0 (tinfo 0xe1083350)
+02-29 00:08:01.012  1451  1628 D         : HostConnection::get() New Host Connection established 0xf1cf2a80, tid 1628
+02-29 00:08:01.012  1451  1628 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:01.013  1451  1628 D         : HostConnection::get() New Host Connection established 0xf1cf2a80, tid 1628
+02-29 00:08:01.014  1451  1628 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:01.015  1451  1628 D         : HostConnection::get() New Host Connection established 0xebe53880, tid 1628
+02-29 00:08:01.015  1451  1628 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:01.015  1451  1628 D         : HostConnection::get() New Host Connection established 0xebe53880, tid 1628
+02-29 00:08:01.016  1451  1628 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:01.017  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 4288512
+02-29 00:08:01.030  1451  1628 D         : HostConnection::get() New Host Connection established 0xebe53880, tid 1628
+02-29 00:08:01.048 18683 18708 D EGL_emulation: eglMakeCurrent: 0xe10852a0: ver 2 0 (tinfo 0xe1083350)
+02-29 00:08:01.182 18683 18708 E eglCodecCommon: glUtilsParamSize: unknow param 0x000085b5
+02-29 00:08:01.182 18683 18708 E eglCodecCommon: glUtilsParamSize: unknow param 0x000085b5
+02-29 00:08:01.240  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 4288512
+02-29 00:08:01.268  1451  1478 D         : HostConnection::get() New Host Connection established 0xebe535c0, tid 1478
+02-29 00:08:01.317 18683 18708 E eglCodecCommon: glUtilsParamSize: unknow param 0x000085b5
+02-29 00:08:01.317 18683 18708 E eglCodecCommon: glUtilsParamSize: unknow param 0x000085b5
+02-29 00:08:01.391  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28575818 , only wrote 28574640
+02-29 00:08:01.392  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28574656 , only wrote 28574640
+02-29 00:08:01.393  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 4288512
+02-29 00:08:01.410  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28575517 , only wrote 28575360
+02-29 00:08:01.413  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:01.414  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+02-29 00:08:01.415  1442  1498 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:01.434  1442  1498 D         : HostConnection::get() New Host Connection established 0xecc32080, tid 1498
+02-29 00:08:01.680  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28588305 , only wrote 28587600
+02-29 00:08:01.680  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28587616 , only wrote 28587600
+02-29 00:08:01.699  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28588511 , only wrote 28588320
+02-29 00:08:01.715 18683 18708 E eglCodecCommon: glUtilsParamSize: unknow param 0x000085b5
+02-29 00:08:02.020 18683 18708 I chatty  : uid=10085(name.mlopatkin.shuttle) identical 6 lines
+02-29 00:08:02.020 18683 18708 E eglCodecCommon: glUtilsParamSize: unknow param 0x000085b5
+02-29 00:08:02.271  1433  1583 W audio_hw_generic: Not supplying enough data to HAL, expected position 28642014 , only wrote 28615680
+02-29 00:08:02.995 18683 18708 E eglCodecCommon: glUtilsParamSize: unknow param 0x000085b5
+02-29 00:08:06.514 18683 18708 I chatty  : uid=10085(name.mlopatkin.shuttle) identical 76 lines
+02-29 00:08:06.515 18683 18708 E eglCodecCommon: glUtilsParamSize: unknow param 0x000085b5
+02-29 00:08:06.740  1433  5262 W audio_hw_generic: Not supplying enough data to HAL, expected position 28616029 , only wrote 28615680
+02-29 00:08:06.741 18683 18708 D EGL_emulation: eglMakeCurrent: 0xe10852a0: ver 2 0 (tinfo 0xe1083350)
+02-29 00:08:06.800  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:06.800  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+02-29 00:08:06.801  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:06.801  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+02-29 00:08:06.801  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:06.802  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+02-29 00:08:06.802  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:06.802  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+02-29 00:08:06.802  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:06.803  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+02-29 00:08:06.803  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:06.812  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+02-29 00:08:06.835 18683 18708 E eglCodecCommon: glUtilsParamSize: unknow param 0x000085b5
+02-29 00:08:07.700  1666  7771 I ActivityManager: Force stopping name.mlopatkin.shuttle appid=10085 user=0: from pid 20428
+02-29 00:08:07.700  1666  7771 I ActivityManager: Killing 18683:name.mlopatkin.shuttle/u0a85 (adj 0): stop name.mlopatkin.shuttle
+02-29 00:08:06.951 18683 18708 I chatty  : uid=10085(name.mlopatkin.shuttle) identical 2 lines
+02-29 00:08:06.952 18683 18708 E eglCodecCommon: glUtilsParamSize: unknow param 0x000085b5
+02-29 00:08:07.701  1666  1688 W zygote  : kill(-18683, 9) failed: No such process
+02-29 00:08:07.702  1666  7771 W ActivityManager: Force removing ActivityRecord{8313238 u0 name.mlopatkin.shuttle/.NewMainActivity t339}: app died, no saved state
+02-29 00:08:07.705 20357 20357 I cr_ChildProcessService: Destroying ChildProcessService pid=20357
+02-29 00:08:07.732  1441  1501 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 3690496
+02-29 00:08:07.740  1666  7771 D         : HostConnection::get() New Host Connection established 0xc64b1740, tid 7771
+02-29 00:08:07.746  1666  1688 W zygote  : kill(-18683, 9) failed: No such process
+02-29 00:08:07.760  1451  1451 E EGL_emulation: tid 1451: eglCreateSyncKHR(2017): error 0x3004 (EGL_BAD_ATTRIBUTE)
+02-29 00:08:07.764  1451  1478 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:07.765  1451  1478 D         : HostConnection::get() New Host Connection established 0xebe535c0, tid 1478
+02-29 00:08:07.766  1451  1478 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:07.771  1666  1759 W InputDispatcher: channel 'e719968 name.mlopatkin.shuttle/name.mlopatkin.shuttle.NewMainActivity (server)' ~ Consumer closed input channel or an error occurred.  events=0x9
+02-29 00:08:07.771  1666  1759 E InputDispatcher: channel 'e719968 name.mlopatkin.shuttle/name.mlopatkin.shuttle.NewMainActivity (server)' ~ Channel is unrecoverably broken and will be disposed!
+02-29 00:08:07.771  1666  1759 W InputDispatcher: channel '396b86d name.mlopatkin.shuttle/name.mlopatkin.shuttle.NewMainActivity (server)' ~ Consumer closed input channel or an error occurred.  events=0x9
+02-29 00:08:07.771  1666  1759 E InputDispatcher: channel '396b86d name.mlopatkin.shuttle/name.mlopatkin.shuttle.NewMainActivity (server)' ~ Channel is unrecoverably broken and will be disposed!
+02-29 00:08:07.772  1666  7778 I WindowManager: WIN DEATH: Window{e719968 u0 name.mlopatkin.shuttle/name.mlopatkin.shuttle.NewMainActivity}
+02-29 00:08:07.772  1666  7778 W InputDispatcher: Attempted to unregister already unregistered input channel 'e719968 name.mlopatkin.shuttle/name.mlopatkin.shuttle.NewMainActivity (server)'
+02-29 00:08:07.781  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:07.782  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+02-29 00:08:07.783  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:07.783  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+02-29 00:08:07.784  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:07.784  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+02-29 00:08:07.787  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:07.787  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+02-29 00:08:07.794  1666  1688 W zygote  : kill(-18683, 9) failed: No such process
+02-29 00:08:07.794  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:07.794  1666  1688 I zygote  : Successfully killed process cgroup uid 10085 pid 18683 in 93ms
+02-29 00:08:07.794  1442  5514 D         : HostConnection::get() New Host Connection established 0xed023600, tid 5514
+02-29 00:08:07.819  1442  5514 D gralloc_ranchu: gralloc_unregister_buffer: exiting HostConnection (is buffer-handling thread)
+02-29 00:08:07.831  1666  7572 I WindowManager: WIN DEATH: Window{396b86d u0 name.mlopatkin.shuttle/name.mlopatkin.shuttle.NewMainActivity}
+02-29 00:08:07.831  1666  7572 W InputDispatcher: Attempted to unregister already unregistered input channel '396b86d name.mlopatkin.shuttle/name.mlopatkin.shuttle.NewMainActivity (server)'
+02-29 00:08:07.943  1666  5180 I zygote  : android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 0
+02-29 00:08:07.943  1666  5180 I OpenGLRenderer: Initialized EGL, version 1.4

--- a/base/src/main/java/name/mlopatkin/andlogview/base/io/LineReader.java
+++ b/base/src/main/java/name/mlopatkin/andlogview/base/io/LineReader.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2023 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.base.io;
+
+import com.google.common.base.Preconditions;
+import com.google.common.io.CharSource;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Reader;
+
+/**
+ * This class functions similarly to {@link BufferedReader}, but only provides the ability to read whole lines.
+ * In addition, it includes line-terminating characters in the read lines, similar to Python's {@code lines} method.
+ */
+public class LineReader implements Closeable {
+    // Beware, this class is optimized for performance. All changes to it should be verified with LineReaderPerfTest.
+    // Currently, it beats BufferedReader by about 5% in "\n" case.
+
+    private static final int DEFAULT_BUFFER_SIZE = 8192;
+    private static final int EXPECTED_LINE_LENGTH = 150;
+
+    private final Reader input;
+
+    private final char[] buffer;
+    private int bufStart = 0;
+    private int bufEnd = 0;
+
+    private boolean shouldConsumeNextLf;
+
+    /**
+     * Creates the new line reader that uses {@code input} as the source of char data.
+     *
+     * @param source the source of the data
+     * @param bufferSize the size of the internal buffer
+     * @throws IOException if opening the stream out of the source fails
+     */
+    public LineReader(CharSource source, int bufferSize) throws IOException {
+        this(source.openStream(), bufferSize);
+    }
+
+    /**
+     * Creates the new line reader that uses {@code input} as the source of char data and with the default buffer size.
+     *
+     * @param source the source of the data
+     * @throws IOException if opening the stream out of the source fails
+     */
+    public LineReader(CharSource source) throws IOException {
+        this(source, DEFAULT_BUFFER_SIZE);
+    }
+
+    /**
+     * Creates the new line reader that uses {@code input} as the source of char data and the default buffer size. The
+     * line reader takes ownership of the provided reader and closes it upon calling {@link #close()}. If something else
+     * reads from the provided input, the behavior is undefined.
+     *
+     * @param input the reader to provide data
+     */
+    public LineReader(Reader input) {
+        this(input, DEFAULT_BUFFER_SIZE);
+    }
+
+    /**
+     * Creates the new line reader that uses {@code input} as the source of char data. The line reader takes ownership
+     * of the provided reader and closes it upon calling {@link #close()}. If something else reads from the provided
+     * input, the behavior is undefined.
+     *
+     * @param input the reader to provide data
+     * @param bufferSize the size of the internal buffer
+     */
+    public LineReader(Reader input, int bufferSize) {
+        Preconditions.checkArgument(bufferSize > 0, "Buffer size %s is too small, must be positive", bufferSize);
+
+        this.input = input;
+        this.buffer = new char[bufferSize];
+
+    }
+
+    /**
+     * Returns the next line of the input, or {@code null} if there is no more data in it. Unlike
+     * {@link BufferedReader#readLine()}, this method includes line-terminating character in the result.
+     * Line endings are normalized, so only {@code \n} is used, even if the source reader has {@code \r} or
+     * {@code \r\n}.
+     *
+     * @return the next line of the input or {@code null} if the input is exhausted.
+     * @throws IOException if reading the input fails
+     */
+    @Nullable
+    @SuppressWarnings("NullAway")
+    // NullAway cannot figure out that (result != null || resultBuffer != null) is the do-while cycle's post-condition.
+    // It can be probably fixed with assert, but I don't want to add new bytecodes to this optimized method.
+    public String readLine() throws IOException {
+        consumeLfTailIfNeeded();
+        if (!ensureBuffer()) {
+            return null;
+        }
+
+        String result = null;
+        StringBuilder resultBuffer = null;
+
+        do {
+            int eolnPos = eolnPosInBuffer();
+            if (eolnPos >= 0) {
+                if (buffer[eolnPos] == '\r') {
+                    shouldConsumeNextLf = true;
+                    // Convert the EOLN, so we can copy it into result.
+                    buffer[eolnPos] = '\n';
+                }
+                int start = bufStart;
+                int len = eolnPos - start + 1;
+                // Copy the buffer until EOLN, inclusive.
+                if (resultBuffer == null) {
+                    result = new String(buffer, start, len);
+                } else {
+                    result = resultBuffer.append(buffer, start, len).toString();
+                }
+                // Don't move this up, for whatever reason JIT loves having this update at the end.
+                bufStart = eolnPos + 1;
+                break;
+            } else {
+                int len = bufEnd - bufStart;
+                if (resultBuffer == null) {
+                    resultBuffer = new StringBuilder(EXPECTED_LINE_LENGTH);
+                }
+                // No EOLN in the buffer, append the whole buffer, fill it and start again.
+                resultBuffer.append(buffer, bufStart, len);
+                // the buffer is now empty.
+                bufStart = bufEnd;
+            }
+        } while (fillBuffer());
+        return result != null ? result : resultBuffer.toString();
+    }
+
+    /**
+     * Looks up the position of the leftmost end-of-line (EOLN) character in the buffer. The EOLN chars are {@code \n}
+     * or {@code \r}. This method doesn't touch the input source.
+     *
+     * @return the position of the EOLN character in the buffer or -1 if there is no such character.
+     */
+    private int eolnPosInBuffer() {
+        for (int pos = bufStart, last = bufEnd; pos < last; ++pos) {
+            char c = buffer[pos];
+            if (c == '\r' || c == '\n') {
+                return pos;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Checks if the previous line ended in {@code \r}, so there's a potential trailing {@code \n} remaining, then
+     * consumes the trailing {@code \n}. May fill the buffer is it empty.
+     *
+     * @throws IOException if filling the buffer failed
+     */
+    private void consumeLfTailIfNeeded() throws IOException {
+        if (shouldConsumeNextLf && ensureBuffer()) {
+            if (buffer[bufStart] == '\n') {
+                // Discard the '\n' suffix of a previously read '\r\n'
+                ++bufStart;
+            }
+            shouldConsumeNextLf = false;
+        }
+    }
+
+    /**
+     * Ensures that the buffer is not empty, filling it from the input if necessary. Calling this method when the buffer
+     * is not empty has no effect.
+     *
+     * @return {@code true} if the buffer is not empty, {@code false} if the buffer cannot be filled because the input
+     *         is also empty
+     * @throws IOException if reading from the input fails
+     */
+    private boolean ensureBuffer() throws IOException {
+        return hasSomeInBuffer() || fillBuffer();
+    }
+
+    /**
+     * Checks if the buffer is not empty.
+     *
+     * @return {@code true} if the buffer is not empty
+     */
+    private boolean hasSomeInBuffer() {
+        return bufStart < bufEnd;
+    }
+
+    /**
+     * Fills the buffer from the input, discarding existing buffer contents.
+     *
+     * @return {@code true} if the buffer was filled, {@code false} if the input is empty
+     * @throws IOException if reading from the input fails
+     */
+    private boolean fillBuffer() throws IOException {
+        bufStart = 0;
+        bufEnd = input.read(buffer);
+        return bufEnd >= 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Closes the reader provided as an argument too.
+     */
+    @Override
+    public void close() throws IOException {
+        input.close();
+    }
+}

--- a/base/src/main/java/name/mlopatkin/andlogview/base/io/package-info.java
+++ b/base/src/main/java/name/mlopatkin/andlogview/base/io/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Common input-output utilities.
+ */
+package name.mlopatkin.andlogview.base.io;

--- a/base/src/test/java/name/mlopatkin/andlogview/base/io/LineReaderTest.java
+++ b/base/src/test/java/name/mlopatkin/andlogview/base/io/LineReaderTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2023 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.base.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.io.CharSource;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+class LineReaderTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "Line without EOL",
+            "Line with LF\n",
+            "Line with CRLF\r\n",
+            "Line with CR\r",
+            "\r",
+            "\r\n",
+            "\n",
+    })
+    void canReadSingleLine(String line) throws Exception {
+        assertThat(lines(line)).singleElement().isEqualTo(normalizeLine(line));
+    }
+
+    @Test
+    void emptySourceProducesNoLines() throws Exception {
+        assertThat(lines("")).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "\n",
+            "\r",
+            "\r\n"
+    })
+    void canReadSeveralLines(String eol) throws Exception {
+        String input = convertEols("""
+                First line
+                Second line
+                Third line
+                """, eol);
+
+        assertThat(lines(input)).containsExactly(
+                "First line\n",
+                "Second line\n",
+                "Third line\n"
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "\n",
+            "\r",
+            "\r\n"
+    })
+    void canReadSeveralLinesWhereLastHasNoEol(String eol) throws Exception {
+        String input = convertEols("""
+                First line
+                Second line
+                Third line""", eol);
+
+        assertThat(lines(input)).containsExactly(
+                "First line\n",
+                "Second line\n",
+                "Third line"
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "\n",
+            "\r",
+            "\r\n"
+    })
+    void canReadSeveralLinesWhereLastIsBlank(String eol) throws Exception {
+        String input = convertEols("""
+                First line
+                Second line
+
+                """, eol);
+
+        assertThat(lines(input)).containsExactly(
+                "First line\n",
+                "Second line\n",
+                "\n"
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "\n",
+            "\r",
+            "\r\n"
+    })
+    void canReadSeveralLinesWhereAllAreBlank(String eol) throws Exception {
+        String input = convertEols("""
+
+
+
+                """, eol);
+
+        assertThat(lines(input)).containsExactly(
+                "\n",
+                "\n",
+                "\n"
+        );
+    }
+
+    @Test
+    void canReadMixedEols() throws Exception {
+        String input = "\n\r\r\r\n\n\n\r\n";
+        assertThat(lines(input)).allMatch("\n"::equals).hasSize(7);
+    }
+
+    private List<String> lines(String source) throws IOException {
+        List<String> result = new ArrayList<>();
+        try (var reader = createReader(source)) {
+            var line = reader.readLine();
+            while (line != null) {
+                result.add(line);
+                line = reader.readLine();
+            }
+        }
+        return result;
+    }
+
+    private LineReader createReader(String source) throws IOException {
+        // Use small buffer size to ensure that all funny behaviors triggered by characters split between chunks
+        // happen in tests.
+        return new LineReader(CharSource.wrap(source), 1);
+    }
+
+    private String normalizeLine(String line) {
+        return line.replaceAll("\\r\\n?", "\n");
+    }
+
+    private String convertEols(String line, String newEol) {
+        return line.replace("\n", newEol);
+    }
+}

--- a/config/idea/run/Open Dump.run.xml
+++ b/config/idea/run/Open Dump.run.xml
@@ -4,7 +4,7 @@
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="name.mlopatkin.andlogview.Main" />
     <module name="andlogview.main" />
-    <option name="PROGRAM_PARAMETERS" value="-d test_resources\name\mlopatkin\andlogview\liblogcat\file\galaxy_nexus_jbmr2.minimized.dump" />
+    <option name="PROGRAM_PARAMETERS" value="-d test_resources/name/mlopatkin/andlogview/liblogcat/file/galaxy_nexus_jbmr2.minimized.dump" />
     <option name="VM_PARAMETERS" value="-ea" />
     <extension name="coverage">
       <pattern>

--- a/device/src/main/java/name/mlopatkin/andlogview/device/CommandImpl.java
+++ b/device/src/main/java/name/mlopatkin/andlogview/device/CommandImpl.java
@@ -81,6 +81,10 @@ class CommandImpl implements Command {
         // makes it impossible to discard stdout while keeping stderr.
         ForStderr stderr = getRedirectWithDefault(this.configuredStderr, OutputTarget.noRedirection());
 
+        // IDEA's null checker seems to be unable to figure out that getRedirectWithDefault is NonNull, even if I
+        // explicitly annotate it with @NonNull.
+        assert stdout != null;
+        assert stderr != null;
         try (OutputTarget.OutputHandle tempStdout = stdout.openOutput(device);
                 OutputTarget.OutputHandle tempStderr = stderr.openOutput(device)) {
             // TODO(mlopatkin) Try to implement shell api v2 on top of ddmlib. Shell v2 allows to get stdout and stderr

--- a/logmodel/src/main/java/name/mlopatkin/andlogview/logmodel/Field.java
+++ b/logmodel/src/main/java/name/mlopatkin/andlogview/logmodel/Field.java
@@ -18,6 +18,9 @@ package name.mlopatkin.andlogview.logmodel;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.Comparator;
+import java.util.Objects;
+
 /**
  * Fields in the log record.
  */
@@ -101,5 +104,32 @@ public enum Field {
      * @param record the record to get the value from
      * @return the value of the field of the record
      */
-    public abstract @Nullable Object getValue(LogRecord record);
+    public abstract @Nullable Comparable<?> getValue(LogRecord record);
+    // Ideally we'd have Field<T extends Comparable<T>> and T getValue(), then each enum constant would be
+    // Field<String>, Field<Integer>, etc. Unfortunately, this is not possible to express with Java enums.
+    // At most, we can restrict constants to be comparables.
+
+    /**
+     * Creates a comparator that can be used to compare records by the value of the field. The returned comparator
+     * doesn't accept {@code null} records, or records with {@code null} values of the field.
+     *
+     * @return the comparator
+     */
+    public Comparator<LogRecord> createComparator() {
+        return new Comparator<>() {
+            @SuppressWarnings({"unchecked", "rawtypes"})
+            @Override
+            public int compare(LogRecord o1, LogRecord o2) {
+                // Enums cannot be generic, so we have to erase the type of comparable here.
+                var value1 = (Comparable) Objects.requireNonNull(getValue(o1));
+                var value2 = (Comparable) Objects.requireNonNull(getValue(o2));
+                return value1.compareTo(value2);
+            }
+
+            @Override
+            public String toString() {
+                return "Comparator<LogRecord>{" + name() + "}";
+            }
+        };
+    }
 }

--- a/logmodel/src/main/java/name/mlopatkin/andlogview/logmodel/LogRecord.java
+++ b/logmodel/src/main/java/name/mlopatkin/andlogview/logmodel/LogRecord.java
@@ -48,6 +48,16 @@ public class LogRecord {
         ERROR,
         FATAL;
 
+        public static Priority fromChar(String next) {
+            next = next.trim();
+            for (Priority val : values()) {
+                if (val.getLetter().equalsIgnoreCase(next)) {
+                    return val;
+                }
+            }
+            throw new IllegalArgumentException("Symbol '" + next + "' doesn't correspond to valid priority value");
+        }
+
         public String getLetter() {
             return toString().substring(0, 1);
         }

--- a/logmodel/src/testFixtures/java/name/mlopatkin/andlogview/logmodel/LogRecordBuilder.java
+++ b/logmodel/src/testFixtures/java/name/mlopatkin/andlogview/logmodel/LogRecordBuilder.java
@@ -34,6 +34,30 @@ public class LogRecordBuilder {
         return this;
     }
 
+    public LogRecordBuilder withPid(int pid) {
+        record = record.withPid(pid);
+        return this;
+    }
+
+    public LogRecordBuilder withTid(int tid) {
+        record = record.withTid(tid);
+        return this;
+    }
+
+    public LogRecordBuilder withPriority(String priorityChar) {
+        return withPriority(LogRecord.Priority.fromChar(priorityChar));
+    }
+
+    public LogRecordBuilder withPriority(LogRecord.Priority priority) {
+        record = record.withPriority(priority);
+        return this;
+    }
+
+    public LogRecordBuilder withTag(String tag) {
+        record = record.withTag(tag);
+        return this;
+    }
+
     public LogRecord build() {
         return record;
     }

--- a/parsers/build.gradle.kts
+++ b/parsers/build.gradle.kts
@@ -26,9 +26,15 @@ dependencies {
     implementation(libs.guava)
     implementation(libs.log4j)
 
+    testFixturesApi(platform(libs.test.junit5.bom))
+    testFixturesApi(libs.test.junit5.jupiter)
+
+    testFixturesImplementation(project(":base"))
+    testFixturesImplementation(testFixtures(project(":logmodel")))
+    testFixturesImplementation(libs.gson)
     testFixturesImplementation(libs.guava)
 
     testImplementation(project(":device"))
     testImplementation(testFixtures(project(":logmodel")))
-
+    testImplementation(libs.gson)
 }

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/BasePushParser.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/BasePushParser.java
@@ -21,8 +21,8 @@ package name.mlopatkin.andlogview.parsers;
  */
 public interface BasePushParser extends AutoCloseable {
     /**
-     * Passes the line to the parser to process. The line should have the trailing EOL trimmed. The parser can signal
-     * that it no longer intends to process the input by returning {@code false} from this method.
+     * Passes the line to the parser to process. The parser can signal that it no longer intends to process the input by
+     * returning {@code false} from this method.
      *
      * @param line the next line of input
      * @return {@code true} if the parser can process more lines or {@code false} if the parser cannot process the input

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/dumpstate/BaseDumpstatePushParser.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/dumpstate/BaseDumpstatePushParser.java
@@ -21,6 +21,8 @@ import name.mlopatkin.andlogview.parsers.PushParser;
 import name.mlopatkin.andlogview.utils.LineParser;
 import name.mlopatkin.andlogview.utils.LineParser.State;
 
+import com.google.common.base.CharMatcher;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -56,7 +58,7 @@ class BaseDumpstatePushParser<H extends BaseDumpstateParseEventsHandler> impleme
             return false;
         }
 
-        lineParser.nextLine(line);
+        lineParser.nextLine(CharMatcher.whitespace().trimFrom(line));
         return !shouldStop;
     }
 

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateBrief.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateBrief.java
@@ -35,7 +35,7 @@ class DelegateBrief extends SingleLineRegexLogcatParserDelegate {
 
     @Override
     protected ParserControl fromGroups(Matcher m) {
-        LogRecord.Priority priority = getPriorityFromChar(m.group(1));
+        LogRecord.Priority priority = LogRecord.Priority.fromChar(m.group(1));
         String tag = m.group(2);
         int pid = Integer.parseInt(m.group(3));
         String message = m.group(4);

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateProcess.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateProcess.java
@@ -35,7 +35,7 @@ class DelegateProcess extends SingleLineRegexLogcatParserDelegate {
 
     @Override
     protected ParserControl fromGroups(Matcher m) {
-        LogRecord.Priority priority = getPriorityFromChar(m.group(1));
+        LogRecord.Priority priority = LogRecord.Priority.fromChar(m.group(1));
         int pid = Integer.parseInt(m.group(2));
         String message = m.group(3);
         String tag = m.group(4);

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateStudio.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateStudio.java
@@ -50,7 +50,7 @@ class DelegateStudio extends SingleLineRegexLogcatParserDelegate {
         int tid = Integer.parseInt(m.group(3));
         String rawAppName = m.group(4);
         @Nullable String appName = "?".equals(rawAppName) ? null : rawAppName;
-        LogRecord.Priority priority = getPriorityFromChar(m.group(5));
+        LogRecord.Priority priority = LogRecord.Priority.fromChar(m.group(5));
         String tag = m.group(6);
         String message = m.group(7);
         return eventsHandler.logRecord(dateTime, pid, tid, priority, tag, message, appName);

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateTag.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateTag.java
@@ -33,7 +33,7 @@ class DelegateTag extends SingleLineRegexLogcatParserDelegate {
 
     @Override
     protected ParserControl fromGroups(Matcher m) {
-        LogRecord.Priority priority = getPriorityFromChar(m.group(1));
+        LogRecord.Priority priority = LogRecord.Priority.fromChar(m.group(1));
         String tag = m.group(2);
         String message = m.group(3);
         eventsHandler.logRecord(priority, tag, message);

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateTag.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateTag.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 
 class DelegateTag extends SingleLineRegexLogcatParserDelegate {
     private static final Pattern PATTERN =
-            Patterns.compileFromParts(PRIORITY_REGEX, "/", TAG_REGEX, ": ", MESSAGE_REGEX);
+            Patterns.compileFromParts(PRIORITY_REGEX, "/", TAG_REGEX, "\\s*: ", MESSAGE_REGEX);
 
     public DelegateTag(LogcatParseEventsHandler eventsHandler) {
         super(eventsHandler, PATTERN);

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateThreadTime.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateThreadTime.java
@@ -48,7 +48,7 @@ class DelegateThreadTime extends SingleLineRegexLogcatParserDelegate {
         Timestamp dateTime = TimeFormatUtils.getTimeFromString(m.group(1));
         int pid = Integer.parseInt(m.group(2));
         int tid = Integer.parseInt(m.group(3));
-        LogRecord.Priority priority = getPriorityFromChar(m.group(4));
+        LogRecord.Priority priority = LogRecord.Priority.fromChar(m.group(4));
         String tag = m.group(5);
         String message = m.group(6);
         return eventsHandler.logRecord(dateTime, pid, tid, priority, tag, message);

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateTime.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateTime.java
@@ -42,7 +42,7 @@ class DelegateTime extends SingleLineRegexLogcatParserDelegate {
     @Override
     protected ParserControl fromGroups(Matcher m) throws ParseException {
         Timestamp dateTime = TimeFormatUtils.getTimeFromString(m.group(1));
-        LogRecord.Priority priority = getPriorityFromChar(m.group(2));
+        LogRecord.Priority priority = LogRecord.Priority.fromChar(m.group(2));
         String tag = m.group(3);
         int pid = Integer.parseInt(m.group(4));
         String message = m.group(5);

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/Format.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/Format.java
@@ -17,12 +17,14 @@
 package name.mlopatkin.andlogview.parsers.logcat;
 
 import name.mlopatkin.andlogview.logmodel.Field;
+import name.mlopatkin.andlogview.logmodel.LogRecord;
 
 import com.google.common.collect.ImmutableSet;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.function.Function;
@@ -71,5 +73,17 @@ public enum Format {
             return parserFactory.apply(eventsHandler);
         }
         throw new IllegalArgumentException("Unsupported format " + name());
+    }
+
+    /**
+     * Creates a log record comparator, that only compares fields present in this format.
+     *
+     * @return the comparator
+     */
+    final Comparator<LogRecord> createComparator() {
+        return getAvailableFields().stream()
+                .map(Field::createComparator)
+                .reduce(Comparator::thenComparing)
+                .orElseThrow(() -> new AssertionError("Number of fields in " + this + " is empty, cannot reduce"));
     }
 }

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/Format.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/Format.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
 /**
  * Metadata about the supported log formats.
  */
-enum Format {
+public enum Format {
     BRIEF(DelegateBrief::new, Field.PRIORITY, Field.TAG, Field.PID, Field.MESSAGE),
     LONG(Field.TIME, Field.PID, Field.TID, Field.PRIORITY, Field.TAG, Field.MESSAGE),
     PROCESS(DelegateProcess::new, Field.PRIORITY, Field.PID, Field.MESSAGE, Field.TAG),
@@ -66,7 +66,7 @@ enum Format {
         return parserFactory != null;
     }
 
-    public final RegexLogcatParserDelegate createParser(LogcatParseEventsHandler eventsHandler) {
+    final RegexLogcatParserDelegate createParser(LogcatParseEventsHandler eventsHandler) {
         if (parserFactory != null) {
             return parserFactory.apply(eventsHandler);
         }

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/LogcatPushParser.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/LogcatPushParser.java
@@ -23,6 +23,8 @@ import java.util.Set;
 
 /**
  * The push parser for the logcat log. Use {@link LogcatParsers} to obtain the instance for the desired format.
+ * <p>
+ * Logcat push parsers are tolerant to input lines with trailing EOLN characters.
  */
 public class LogcatPushParser<H extends LogcatParseEventsHandler> implements PushParser<H> {
     private final Format format;

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/RegexLogcatParserDelegate.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/RegexLogcatParserDelegate.java
@@ -16,7 +16,6 @@
 
 package name.mlopatkin.andlogview.parsers.logcat;
 
-import name.mlopatkin.andlogview.logmodel.LogRecord;
 import name.mlopatkin.andlogview.parsers.ParserControl;
 
 abstract class RegexLogcatParserDelegate {
@@ -40,14 +39,4 @@ abstract class RegexLogcatParserDelegate {
     }
 
     public abstract ParserControl parseLine(CharSequence line);
-
-    static LogRecord.Priority getPriorityFromChar(String next) {
-        next = next.trim();
-        for (LogRecord.Priority val : LogRecord.Priority.values()) {
-            if (val.getLetter().equalsIgnoreCase(next)) {
-                return val;
-            }
-        }
-        throw new IllegalArgumentException("Symbol '" + next + "' doesn't correspond to valid priority value");
-    }
 }

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/SingleLineRegexLogcatParserDelegate.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/SingleLineRegexLogcatParserDelegate.java
@@ -18,6 +18,8 @@ package name.mlopatkin.andlogview.parsers.logcat;
 
 import name.mlopatkin.andlogview.parsers.ParserControl;
 
+import com.google.common.base.CharMatcher;
+
 import java.text.ParseException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -41,9 +43,10 @@ abstract class SingleLineRegexLogcatParserDelegate extends RegexLogcatParserDele
 
     @Override
     public final ParserControl parseLine(CharSequence line) {
-        Matcher matcher = pattern.matcher(line);
+        String trimmed = CharMatcher.whitespace().trimFrom(line);
+        Matcher matcher = pattern.matcher(trimmed);
         if (!matcher.matches()) {
-            return eventsHandler.unparseableLine(line);
+            return eventsHandler.unparseableLine(trimmed);
         }
         try {
             return fromGroups(matcher);

--- a/parsers/src/test/java/name/mlopatkin/andlogview/parsers/logcat/LogcatFormatSnifferTest.java
+++ b/parsers/src/test/java/name/mlopatkin/andlogview/parsers/logcat/LogcatFormatSnifferTest.java
@@ -19,9 +19,14 @@ package name.mlopatkin.andlogview.parsers.logcat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import name.mlopatkin.andlogview.logmodel.LogRecord;
+import name.mlopatkin.andlogview.parsers.ParserUtils;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
 import java.util.Arrays;
+import java.util.List;
 
 class LogcatFormatSnifferTest {
     @Test
@@ -115,6 +120,19 @@ class LogcatFormatSnifferTest {
 
             assertThatThrownBy(() -> sniffer.createParser(new ListCollectingHandler())).isInstanceOf(
                     IllegalStateException.class);
+        }
+    }
+
+    @ParameterizedTest(name = "{0} with Eoln.{2}")
+    @LogcatCompatSource(
+            path = "parsers/logcat/golden.json",
+            formats = {Format.BRIEF, Format.THREADTIME},
+            eolns = {Eoln.NONE})
+    void canDetectFormat(Format ignoredFormat, List<LogRecord> ignoredRecords, Eoln ignoredEoln, List<String> lines) {
+        try (var sniffer = LogcatParsers.detectFormat()) {
+            ParserUtils.readInto(sniffer, lines.stream());
+
+            assertThat(sniffer.isFormatDetected()).isTrue();
         }
     }
 

--- a/parsers/src/test/java/name/mlopatkin/andlogview/parsers/logcat/LogcatTestJsonModelTest.java
+++ b/parsers/src/test/java/name/mlopatkin/andlogview/parsers/logcat/LogcatTestJsonModelTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.parsers.logcat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import name.mlopatkin.andlogview.base.AppResources;
+
+import com.google.gson.Gson;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+public class LogcatTestJsonModelTest {
+    @Test
+    void jsonModelCanBeParsed() throws Exception {
+        var gson = new Gson();
+
+        try (var input = AppResources.getResource("parsers/logcat/golden.json")
+                .asCharSource(StandardCharsets.UTF_8)
+                .openBufferedStream()) {
+            var model = gson.fromJson(input, LogcatTestJsonModel.class);
+
+            assertThat(model.getResourceForFormat("parsers/logcat", Format.TIME)).isPresent();
+            assertThat(model.getResourceForFormat("parsers/logcat", Format.STUDIO)).isNotPresent();
+            assertThat(model.getRecords(Format.THREADTIME)).isNotEmpty();
+        }
+    }
+}

--- a/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/brief.txt
+++ b/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/brief.txt
@@ -1,0 +1,4 @@
+--------- beginning of main
+I/lowmemorykiller(  188): Using psi monitors for memory pressure detection
+I/lowmemorykiller(  188): Process polling is supported
+W/auditd  (  187): type=2000 audit(0.0:1): state=initialized audit_enabled=0 res=1

--- a/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/golden.json
+++ b/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/golden.json
@@ -1,0 +1,38 @@
+{
+  "entries": [
+    {
+      "time": "09-11 12:52:56.962",
+      "pid": "188",
+      "tid": "188",
+      "prio": "I",
+      "tag": "lowmemorykiller",
+      "message": "Using psi monitors for memory pressure detection"
+    },
+    {
+      "time": "09-11 12:52:56.963",
+      "pid": "188",
+      "tid": "188",
+      "prio": "I",
+      "tag": "lowmemorykiller",
+      "message": "Process polling is supported"
+    },
+    {
+      "time": "09-11 12:52:53.169",
+      "pid": "187",
+      "tid": "187",
+      "prio": "W",
+      "tag": "auditd",
+      "message": "type=2000 audit(0.0:1): state=initialized audit_enabled=0 res=1"
+    }
+  ],
+  "formats": {
+    "BRIEF": "brief.txt",
+    "LONG": "long.txt",
+    "PROCESS": "process.txt",
+    "RAW": "raw.txt",
+    "TAG": "tag.txt",
+    "THREAD": "thread.txt",
+    "THREADTIME": "threadtime.txt",
+    "TIME": "time.txt"
+  }
+}

--- a/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/long.txt
+++ b/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/long.txt
@@ -1,0 +1,10 @@
+--------- beginning of main
+[ 09-11 12:52:56.962   188:  188 I/lowmemorykiller ]
+Using psi monitors for memory pressure detection
+
+[ 09-11 12:52:56.963   188:  188 I/lowmemorykiller ]
+Process polling is supported
+
+[ 09-11 12:52:53.169   187:  187 W/auditd   ]
+type=2000 audit(0.0:1): state=initialized audit_enabled=0 res=1
+

--- a/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/process.txt
+++ b/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/process.txt
@@ -1,0 +1,4 @@
+--------- beginning of main
+I(  188) Using psi monitors for memory pressure detection  (lowmemorykiller)
+I(  188) Process polling is supported  (lowmemorykiller)
+W(  187) type=2000 audit(0.0:1): state=initialized audit_enabled=0 res=1  (auditd)

--- a/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/raw.txt
+++ b/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/raw.txt
@@ -1,0 +1,4 @@
+--------- beginning of main
+Using psi monitors for memory pressure detection
+Process polling is supported
+type=2000 audit(0.0:1): state=initialized audit_enabled=0 res=1

--- a/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/tag.txt
+++ b/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/tag.txt
@@ -1,0 +1,4 @@
+--------- beginning of main
+I/lowmemorykiller: Using psi monitors for memory pressure detection
+I/lowmemorykiller: Process polling is supported
+W/auditd  : type=2000 audit(0.0:1): state=initialized audit_enabled=0 res=1

--- a/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/thread.txt
+++ b/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/thread.txt
@@ -1,0 +1,4 @@
+--------- beginning of main
+I(  188:  188) Using psi monitors for memory pressure detection
+I(  188:  188) Process polling is supported
+W(  187:  187) type=2000 audit(0.0:1): state=initialized audit_enabled=0 res=1

--- a/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/threadtime.txt
+++ b/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/threadtime.txt
@@ -1,0 +1,4 @@
+--------- beginning of main
+09-11 12:52:56.962   188   188 I lowmemorykiller: Using psi monitors for memory pressure detection
+09-11 12:52:56.963   188   188 I lowmemorykiller: Process polling is supported
+09-11 12:52:53.169   187   187 W auditd  : type=2000 audit(0.0:1): state=initialized audit_enabled=0 res=1

--- a/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/time.txt
+++ b/parsers/src/test/resources/name/mlopatkin/andlogview/parsers/logcat/time.txt
@@ -1,0 +1,4 @@
+--------- beginning of main
+09-11 12:52:56.962 I/lowmemorykiller(  188): Using psi monitors for memory pressure detection
+09-11 12:52:56.963 I/lowmemorykiller(  188): Process polling is supported
+09-11 12:52:53.169 W/auditd  (  187): type=2000 audit(0.0:1): state=initialized audit_enabled=0 res=1

--- a/parsers/src/testFixtures/java/name/mlopatkin/andlogview/parsers/logcat/Eoln.java
+++ b/parsers/src/testFixtures/java/name/mlopatkin/andlogview/parsers/logcat/Eoln.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.parsers.logcat;
+
+/**
+ * End-of-line character sequence
+ */
+public enum Eoln {
+    NONE(""),
+    CR("\r"),
+    LF("\n"),
+    CRLF("\r\n");
+
+    private final String chars;
+
+    Eoln(String chars) {
+        this.chars = chars;
+    }
+
+    /**
+     * Returns the string representation of this EOLN sequence.
+     *
+     * @return the EOLN as a String
+     */
+    public String getChars() {
+        return chars;
+    }
+}

--- a/parsers/src/testFixtures/java/name/mlopatkin/andlogview/parsers/logcat/LogcatCompatProvider.java
+++ b/parsers/src/testFixtures/java/name/mlopatkin/andlogview/parsers/logcat/LogcatCompatProvider.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.parsers.logcat;
+
+
+import name.mlopatkin.andlogview.base.AppResources;
+import name.mlopatkin.andlogview.logmodel.LogRecord;
+
+import com.google.common.io.CharSource;
+import com.google.gson.Gson;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class LogcatCompatProvider implements ArgumentsProvider, AnnotationConsumer<LogcatCompatSource> {
+    private static final Gson GSON = new Gson();
+
+    private @Nullable String resourcePath;
+    private final Set<Format> formats = EnumSet.noneOf(Format.class);
+    private final Set<Eoln> eolns = EnumSet.of(Eoln.NONE);
+
+    @Override
+    public void accept(LogcatCompatSource logcatCompatSource) {
+        resourcePath = Objects.requireNonNull(logcatCompatSource.path());
+        updateSetWithEnumArray(logcatCompatSource.formats(), formats);
+        updateSetWithEnumArray(logcatCompatSource.eolns(), eolns);
+    }
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+        var resourcePath = Objects.requireNonNull(this.resourcePath);
+        var model = loadModel(resourcePath);
+        if (formats.isEmpty()) {
+            formats.addAll(model.getFormats());
+        }
+        var basePath = new File(resourcePath).getParent();
+        return formats.stream()
+                .map(format -> {
+                    var source = model.getResourceForFormat(basePath, format)
+                            .orElseThrow(() -> new IllegalArgumentException("Don't have a source for " + format));
+                    var records = model.getRecords(format);
+                    return new PartialArgs(format, records, source);
+                }).flatMap(args ->
+                        eolns.stream().map(eoln ->
+                                arguments(args.format, args.records, eoln, loadLinesWithEoln(args.lines, eoln))
+                        )
+                );
+    }
+
+    private static <T extends Enum<T>> void updateSetWithEnumArray(@Nullable T[] input, Set<T> output) {
+        if (input != null && input.length > 0) {
+            output.clear();
+            output.addAll(Arrays.asList(input));
+        }
+    }
+
+    private static LogcatTestJsonModel loadModel(String basePath) throws IOException {
+        try (var reader = AppResources.getResource(Objects.requireNonNull(basePath))
+                .asCharSource(StandardCharsets.UTF_8)
+                .openBufferedStream()) {
+            return GSON.fromJson(reader, LogcatTestJsonModel.class);
+        }
+    }
+
+    private static List<String> loadLinesWithEoln(CharSource source, Eoln eoln) {
+        try {
+            try (var lines = source.lines()) {
+                return lines.map(s -> s + eoln.getChars()).collect(Collectors.toList());
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static class PartialArgs {
+        final Format format;
+        final List<LogRecord> records;
+        final CharSource lines;
+
+        private PartialArgs(Format format, List<LogRecord> records, CharSource lines) {
+            this.format = format;
+            this.records = records;
+            this.lines = lines;
+        }
+    }
+
+    private static Arguments arguments(Format format, List<LogRecord> records, Eoln eoln, List<String> lines) {
+        return Arguments.of(format, records, eoln, lines);
+    }
+}

--- a/parsers/src/testFixtures/java/name/mlopatkin/andlogview/parsers/logcat/LogcatCompatSource.java
+++ b/parsers/src/testFixtures/java/name/mlopatkin/andlogview/parsers/logcat/LogcatCompatSource.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.parsers.logcat;
+
+import name.mlopatkin.andlogview.logmodel.LogRecord;
+
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation for the logcat parser compatibility testing. A parameterized test is expected to have the parameters:
+ * <ol>
+ *     <li>{@link Format} - the format of the log lines</li>
+ *     <li>List&lt;{@linkplain LogRecord }> - the log records that the lines contain</li>
+ *     <li>{@link Eoln} - the end of line char sequence used in lines</li>
+ *     <li>List&lt;String> - the log records as a sequence of lines, each ending with the given Eoln</li>
+ * </ol>
+ */
+@ArgumentsSource(LogcatCompatProvider.class)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogcatCompatSource {
+    /**
+     * The path to the JSON resource describing the test suite.
+     */
+    String path();
+
+    /**
+     * The list of the formats to test on. Defaults to all available in the suite.
+     */
+    Format[] formats() default {};
+
+    /**
+     * The list of all EOLN sequences to test with. Defaults to only NONE.
+     */
+    Eoln[] eolns() default { Eoln.NONE };
+}

--- a/parsers/src/testFixtures/java/name/mlopatkin/andlogview/parsers/logcat/LogcatEntryJsonModel.java
+++ b/parsers/src/testFixtures/java/name/mlopatkin/andlogview/parsers/logcat/LogcatEntryJsonModel.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.parsers.logcat;
+
+import name.mlopatkin.andlogview.logmodel.Field;
+import name.mlopatkin.andlogview.logmodel.LogRecord;
+import name.mlopatkin.andlogview.logmodel.LogRecordBuilder;
+import name.mlopatkin.andlogview.logmodel.LogRecordUtils;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Collection;
+import java.util.Objects;
+
+/**
+ * A JSON-serializable representation of a logcat log entry.
+ */
+@SuppressWarnings({"UseCorrectAssertInTests", "unused"})
+public class LogcatEntryJsonModel {
+    private @Nullable String time;
+    private @Nullable String pid;
+    private @Nullable String tid;
+    private @Nullable String prio;
+    private @Nullable String tag;
+    private @Nullable String message;
+
+    public LogRecord buildRecord(Collection<Field> fields) {
+        assert fields.contains(Field.MESSAGE);
+        LogRecordBuilder record = LogRecordUtils.logRecord(Objects.requireNonNull(message));
+        if (fields.contains(Field.TIME)) {
+            record.withTime(Objects.requireNonNull(time));
+        }
+        if (fields.contains(Field.PID)) {
+            record.withPid(Integer.parseInt(Objects.requireNonNull(pid)));
+        }
+        if (fields.contains(Field.TID)) {
+            record.withTid(Integer.parseInt(Objects.requireNonNull(tid)));
+        }
+        if (fields.contains(Field.PRIORITY)) {
+            record.withPriority(Objects.requireNonNull(prio));
+        }
+        if (fields.contains(Field.TAG)) {
+            record.withTag(Objects.requireNonNull(tag));
+        }
+        return record.build();
+    }
+}

--- a/parsers/src/testFixtures/java/name/mlopatkin/andlogview/parsers/logcat/LogcatTestJsonModel.java
+++ b/parsers/src/testFixtures/java/name/mlopatkin/andlogview/parsers/logcat/LogcatTestJsonModel.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.parsers.logcat;
+
+import name.mlopatkin.andlogview.base.AppResources;
+import name.mlopatkin.andlogview.logmodel.Field;
+import name.mlopatkin.andlogview.logmodel.LogRecord;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.CharSource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A JSON-serializable representation of a logcat log in different formats. The JSON file contains a list of "golden"
+ * entries in a parsed form, and a set of filenames pointing to logs in different formats.
+ */
+public class LogcatTestJsonModel {
+    private final List<LogcatEntryJsonModel> entries = Collections.emptyList();
+    private final Map<Format, String> formats = Collections.emptyMap();
+
+    /**
+     * Returns a text resource for the provided format if it is available.
+     *
+     * @param basePath the base path to resources
+     * @param format the desired format
+     * @return the resource or empty optional if there is no resource for this format
+     */
+    public Optional<CharSource> getResourceForFormat(String basePath, Format format) {
+        return Optional.ofNullable(formats.get(format)).map(relPath ->
+                AppResources.getResource(basePath + "/" + relPath).asCharSource(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Returns the "golden" list of records. The available fields are limited to what is available in the format.
+     *
+     * @param format the format of the record
+     * @return the list of records in this test model
+     */
+    public List<LogRecord> getRecords(Format format) {
+        var requestedFields = format.getAvailableFields();
+        Preconditions.checkArgument(requestedFields.contains(Field.MESSAGE), "Message field is mandatory");
+        Preconditions.checkArgument(!requestedFields.contains(Field.APP_NAME), "App name is not yet supported");
+        Preconditions.checkArgument(!requestedFields.contains(Field.BUFFER), "Buffer is not yet supported");
+        return entries.stream()
+                .map(entry -> entry.buildRecord(requestedFields))
+                .collect(Collectors.toList());
+    }
+
+    public Set<Format> getFormats() {
+        return ImmutableSet.copyOf(formats.keySet());
+    }
+}

--- a/src/name/mlopatkin/andlogview/liblogcat/file/DumpstateFileDataSource.java
+++ b/src/name/mlopatkin/andlogview/liblogcat/file/DumpstateFileDataSource.java
@@ -15,6 +15,7 @@
  */
 package name.mlopatkin.andlogview.liblogcat.file;
 
+import name.mlopatkin.andlogview.base.io.LineReader;
 import name.mlopatkin.andlogview.logmodel.DataSource;
 import name.mlopatkin.andlogview.logmodel.Field;
 import name.mlopatkin.andlogview.logmodel.LogRecord;
@@ -33,7 +34,6 @@ import name.mlopatkin.andlogview.parsers.ps.PsParseEventsHandler;
 import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -176,7 +176,7 @@ public final class DumpstateFileDataSource implements DataSource {
             return this;
         }
 
-        public ImportResult readFrom(BufferedReader in) throws IOException, UnrecognizedFormatException {
+        public ImportResult readFrom(LineReader in) throws IOException, UnrecognizedFormatException {
             ParserUtils.readInto(Objects.requireNonNull(pushParser), in::readLine);
 
             if (availableBuffers.isEmpty()) {

--- a/src/name/mlopatkin/andlogview/liblogcat/file/LogfileDataSource.java
+++ b/src/name/mlopatkin/andlogview/liblogcat/file/LogfileDataSource.java
@@ -15,6 +15,7 @@
  */
 package name.mlopatkin.andlogview.liblogcat.file;
 
+import name.mlopatkin.andlogview.base.io.LineReader;
 import name.mlopatkin.andlogview.logmodel.DataSource;
 import name.mlopatkin.andlogview.logmodel.Field;
 import name.mlopatkin.andlogview.logmodel.LogRecord;
@@ -30,7 +31,6 @@ import name.mlopatkin.andlogview.parsers.logcat.LogcatPushParser;
 import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -125,7 +125,7 @@ public class LogfileDataSource implements DataSource {
             return this;
         }
 
-        public ImportResult readFrom(BufferedReader in) throws IOException {
+        public ImportResult readFrom(LineReader in) throws IOException {
             assert pushParser != null;
             ParserUtils.readInto(pushParser, in::readLine);
             return new ImportResult(new LogfileDataSource(fileName, pushParser.getAvailableFields(), records));


### PR DESCRIPTION
End-of-line (EOLN) symbols are important when parsing logs in LONG format, so we have to make them available to the logcat parser. This PR introduces LineReader - the replacement for the Java's BufferedReader that keeps EOLN characters in its output, and uses it to parse logs. We adjust the rest of the parsing infrastructure to either trim EOLN early (for dumpstate files), or to be tolerant to them (logcat parsers).

Part of #169 