### PR TITLE
Don't keep EOLNs when reading logs

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,9 @@
+version 0.22
+    [+] Support parsing long logcat format
+    [+] Show warnings when dumpstate cannot be imported properly, but try to still be useful
+
+    [*] Offline and not-fully-connected devices can no longer be selected in the dialog
+
 version 0.21
     [!] The tool is now renamed to AndLogView and the development moved to Github
 

--- a/base/src/jmh/java/name/mlopatkin/andlogview/base/io/LineReaderPerfTest.java
+++ b/base/src/jmh/java/name/mlopatkin/andlogview/base/io/LineReaderPerfTest.java
@@ -95,7 +95,7 @@ public class LineReaderPerfTest {
     @Benchmark
     public void parseWithLineReader(Blackhole bh) throws IOException {
         try (var in = new LineReader(input, 8192)) {
-            String line = in.readLine();
+            var line = in.readLine();
             while (line != null) {
                 bh.consume(line);
                 line = in.readLine();

--- a/base/src/main/java/name/mlopatkin/andlogview/base/io/LineReader.java
+++ b/base/src/main/java/name/mlopatkin/andlogview/base/io/LineReader.java
@@ -133,7 +133,8 @@ public class LineReader implements Closeable {
                 if (resultBuilder == null) {
                     result = new String(buffer, start, len);
                 } else {
-                    result = resultBuilder.append(buffer, start, len).toString();
+                    // Here result should be null.
+                    resultBuilder.append(buffer, start, len);
                 }
                 // Don't move this up, for whatever reason JIT loves having this update at the end.
                 bufStart = eolnPos + 1;

--- a/base/src/main/java/name/mlopatkin/andlogview/utils/MyStringUtils.java
+++ b/base/src/main/java/name/mlopatkin/andlogview/utils/MyStringUtils.java
@@ -118,6 +118,9 @@ public class MyStringUtils {
      * @return the stream of strings
      */
     public static Stream<String> lines(CharSequence sequence) {
-        return EOL_SPLITTER.splitToStream(sequence);
+        if (isEmpty(sequence)) {
+            return Stream.empty();
+        }
+        return EOL_SPLITTER.splitToStream(sequence).map(s -> s.endsWith("\n") ? s.substring(0, s.length() - 1) : s);
     }
 }

--- a/base/src/test/java/name/mlopatkin/andlogview/base/io/LineReaderTest.java
+++ b/base/src/test/java/name/mlopatkin/andlogview/base/io/LineReaderTest.java
@@ -63,9 +63,9 @@ class LineReaderTest {
                 """, eol);
 
         assertThat(lines(input)).containsExactly(
-                "First line\n",
-                "Second line\n",
-                "Third line\n"
+                "First line",
+                "Second line",
+                "Third line"
         );
     }
 
@@ -82,8 +82,8 @@ class LineReaderTest {
                 Third line""", eol);
 
         assertThat(lines(input)).containsExactly(
-                "First line\n",
-                "Second line\n",
+                "First line",
+                "Second line",
                 "Third line"
         );
     }
@@ -102,9 +102,9 @@ class LineReaderTest {
                 """, eol);
 
         assertThat(lines(input)).containsExactly(
-                "First line\n",
-                "Second line\n",
-                "\n"
+                "First line",
+                "Second line",
+                ""
         );
     }
 
@@ -122,16 +122,16 @@ class LineReaderTest {
                 """, eol);
 
         assertThat(lines(input)).containsExactly(
-                "\n",
-                "\n",
-                "\n"
+                "",
+                "",
+                ""
         );
     }
 
     @Test
     void canReadMixedEols() throws Exception {
         String input = "\n\r\r\r\n\n\n\r\n";
-        assertThat(lines(input)).allMatch("\n"::equals).hasSize(7);
+        assertThat(lines(input)).allMatch(""::equals).hasSize(7);
     }
 
     private List<String> lines(String source) throws IOException {
@@ -139,7 +139,7 @@ class LineReaderTest {
         try (var reader = createReader(source)) {
             var line = reader.readLine();
             while (line != null) {
-                result.add(line);
+                result.add(line.toString());
                 line = reader.readLine();
             }
         }
@@ -153,7 +153,7 @@ class LineReaderTest {
     }
 
     private String normalizeLine(String line) {
-        return line.replaceAll("\\r\\n?", "\n");
+        return line.replaceAll("[\\r\\n]", "");
     }
 
     private String convertEols(String line, String newEol) {

--- a/base/src/test/java/name/mlopatkin/andlogview/utils/MyStringUtilsLinesTest.java
+++ b/base/src/test/java/name/mlopatkin/andlogview/utils/MyStringUtilsLinesTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class MyStringUtilsLinesTest {
+
+    @Test
+    void emptyStringHasNoLines() {
+        assertThat(MyStringUtils.lines("")).isEmpty();
+    }
+
+    @Test
+    void singleEolnIsOneLine() {
+        assertThat(MyStringUtils.lines("\n")).hasSize(1).contains("");
+    }
+}

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/dumpstate/BaseDumpstatePushParser.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/dumpstate/BaseDumpstatePushParser.java
@@ -21,8 +21,6 @@ import name.mlopatkin.andlogview.parsers.PushParser;
 import name.mlopatkin.andlogview.utils.LineParser;
 import name.mlopatkin.andlogview.utils.LineParser.State;
 
-import com.google.common.base.CharMatcher;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -58,7 +56,7 @@ class BaseDumpstatePushParser<H extends BaseDumpstateParseEventsHandler> impleme
             return false;
         }
 
-        lineParser.nextLine(CharMatcher.whitespace().trimFrom(line));
+        lineParser.nextLine(line);
         return !shouldStop;
     }
 

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateLong.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateLong.java
@@ -46,6 +46,8 @@ import java.util.regex.Pattern;
  * </pre>
  * It consists of a header (first line), and the rest of the message. The message is finalized with double EOLN
  * {@code \n\n}.
+ * <p>
+ * Even though the paragraph above talks about EOLNs, this delegate only expects lines without end-of-line characters.
  */
 class DelegateLong extends RegexLogcatParserDelegate {
     private static final Pattern HEADER_PATTERN = Patterns.compileFromParts(
@@ -59,7 +61,7 @@ class DelegateLong extends RegexLogcatParserDelegate {
             // priority and left-aligned tag. Tag has to be trimmed before feeding it upstream.
             PRIORITY_REGEX, "/", TAG_REGEX,
             " ",
-            "\\]\\n?"
+            "\\]"
     );
 
     private @Nullable CurrentMessage currentMessage;
@@ -142,7 +144,7 @@ class DelegateLong extends RegexLogcatParserDelegate {
     }
 
     private static boolean isBlank(CharSequence sequence) {
-        return MyStringUtils.isEmpty(sequence) || MyStringUtils.first(sequence) == '\n';
+        return MyStringUtils.isEmpty(sequence);
     }
 
     @Override
@@ -177,9 +179,6 @@ class DelegateLong extends RegexLogcatParserDelegate {
         }
 
         public void addMessageLine(CharSequence line) {
-            if (!MyStringUtils.isEmpty(line) && MyStringUtils.last(line) == '\n') {
-                line = line.subSequence(0, line.length() - 1);
-            }
             messageLines.add(line);
         }
 

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/LogcatPushParser.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/LogcatPushParser.java
@@ -23,8 +23,6 @@ import java.util.Set;
 
 /**
  * The push parser for the logcat log. Use {@link LogcatParsers} to obtain the instance for the desired format.
- * <p>
- * Logcat push parsers are tolerant to input lines with trailing EOLN characters.
  */
 public class LogcatPushParser<H extends LogcatParseEventsHandler> implements PushParser<H> {
     private final Format format;

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/SingleLineRegexLogcatParserDelegate.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/SingleLineRegexLogcatParserDelegate.java
@@ -18,8 +18,6 @@ package name.mlopatkin.andlogview.parsers.logcat;
 
 import name.mlopatkin.andlogview.parsers.ParserControl;
 
-import com.google.common.base.CharMatcher;
-
 import java.text.ParseException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -43,10 +41,9 @@ abstract class SingleLineRegexLogcatParserDelegate extends RegexLogcatParserDele
 
     @Override
     public final ParserControl parseLine(CharSequence line) {
-        String trimmed = CharMatcher.whitespace().trimFrom(line);
-        Matcher matcher = pattern.matcher(trimmed);
+        Matcher matcher = pattern.matcher(line);
         if (!matcher.matches()) {
-            return eventsHandler.unparseableLine(trimmed);
+            return eventsHandler.unparseableLine(line);
         }
         try {
             return fromGroups(matcher);

--- a/parsers/src/test/java/name/mlopatkin/andlogview/parsers/logcat/DelegateLongTest.java
+++ b/parsers/src/test/java/name/mlopatkin/andlogview/parsers/logcat/DelegateLongTest.java
@@ -36,6 +36,38 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 public class DelegateLongTest {
     @Test
+    void parsesEmptyMessage() {
+        assertOnlyParsedRecord(LogcatParsers::logcatLong, lines("""
+                [ 01-02 03:04:05.678  1234: 4321 E/sometag ]
+
+
+                """))
+                .hasDate(1, 2)
+                .hasTime(3, 4, 5, 678)
+                .hasPid(1234)
+                .hasTid(4321)
+                .hasPriority(LogRecord.Priority.ERROR)
+                .hasTag("sometag")
+                .hasMessage("");
+    }
+
+    @Test
+    void parsesBlankMessage() {
+        assertOnlyParsedRecord(LogcatParsers::logcatLong, lines("""
+                [ 01-02 03:04:05.678  1234: 4321 E/sometag ]
+                \s\s\s\t
+
+                """))
+                .hasDate(1, 2)
+                .hasTime(3, 4, 5, 678)
+                .hasPid(1234)
+                .hasTid(4321)
+                .hasPriority(LogRecord.Priority.ERROR)
+                .hasTag("sometag")
+                .hasMessage("\s\s\s\t");
+    }
+
+    @Test
     void parsesSingleLineMessage() {
         assertOnlyParsedRecord(LogcatParsers::logcatLong, lines("""
                 [ 01-02 03:04:05.678  1234: 4321 E/sometag ]

--- a/parsers/src/test/java/name/mlopatkin/andlogview/parsers/logcat/LogcatParsersTest.java
+++ b/parsers/src/test/java/name/mlopatkin/andlogview/parsers/logcat/LogcatParsersTest.java
@@ -214,7 +214,7 @@ public class LogcatParsersTest {
                     Format.THREADTIME,
                     Format.TIME
             },
-            eolns = {Eoln.NONE, Eoln.LF, Eoln.CRLF}
+            eolns = {Eoln.NONE}
     )
     void compatibilityTest(Format format, List<LogRecord> expectedRecords, Eoln ignoredEoln, List<String> lines) {
         ListCollectingHandler handler = new ListCollectingHandler();

--- a/src/name/mlopatkin/andlogview/liblogcat/file/FileDataSourceFactory.java
+++ b/src/name/mlopatkin/andlogview/liblogcat/file/FileDataSourceFactory.java
@@ -52,7 +52,7 @@ public class FileDataSourceFactory {
             try (var parser = new ReplayParser<>(
                     MAX_LOOKAHEAD_LINES,
                     new MultiplexParser<>(dumpstateSniffer, logcatSniffer))) {
-                String line;
+                CharSequence line;
                 while ((line = in.readLine()) != null) {
                     boolean parserStopped = !parser.nextLine(line);
                     if (dumpstateSniffer.isFormatDetected()) {


### PR DESCRIPTION
I forgot what I had in mind when I was introducing this `\n`-preserving code. It looks like `LONG` logs can be parsed just fine without looking at `\n`.

It might be important when combining multiple entries into one but we don't do that yet. When parsing the last line of the file, it also doesn't matter much.

Issue: #169 