### PR TITLE
Post-process log records of dumpstate to assign process names

### DIFF
--- a/logmodel/src/main/java/name/mlopatkin/andlogview/logmodel/LogRecord.java
+++ b/logmodel/src/main/java/name/mlopatkin/andlogview/logmodel/LogRecord.java
@@ -17,7 +17,6 @@ package name.mlopatkin.andlogview.logmodel;
 
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.common.collect.ComparisonChain;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -94,7 +93,7 @@ public class LogRecord {
     private final String tag;
     private final String message;
     private final @Nullable Buffer buffer;
-    private final String appName;
+    private final @Nullable String appName;
 
     LogRecord(
             SequenceNumber seqNo,
@@ -110,7 +109,7 @@ public class LogRecord {
         this.time = time;
         this.pid = pid;
         this.tid = tid;
-        this.appName = CharMatcher.whitespace().trimFrom(Strings.nullToEmpty(appName));
+        this.appName = appName != null ? CharMatcher.whitespace().trimFrom(appName) : null;
         this.priority = priority;
         this.tag = tag;
         this.message = message;
@@ -149,8 +148,12 @@ public class LogRecord {
         return buffer;
     }
 
+    public boolean hasAppName() {
+        return appName != null;
+    }
+
     public String getAppName() {
-        return appName;
+        return appName != null ? appName : "";
     }
 
     @Override

--- a/test_resources/name/mlopatkin/andlogview/liblogcat/file/emulator_api34.minimized.dump
+++ b/test_resources/name/mlopatkin/andlogview/liblogcat/file/emulator_api34.minimized.dump
@@ -1,0 +1,6211 @@
+========================================================
+== dumpstate: 2023-12-26 16:19:21
+========================================================
+
+Build: UE1A.230829.036
+Build fingerprint: 'google/sdk_gphone64_x86_64/emu64xa:14/UE1A.230829.036/11036701:user/release-keys'
+Bootloader: unknown
+Radio: 1.0.0.0
+Network: T-Mobile
+Module Metadata version: 340724004
+Android SDK version: 34
+SDK extensions: [ad_services=7, r=7, s=7, t=7, u=7]
+Kernel: Linux version 6.1.23-android14-4-00257-g7e35917775b8-ab9964412 (build-user@build-host) (Android (9796371, based on r487747) clang version 17.0.0 (https://android.googlesource.com/toolchain/llvm-project d9f89f4d16663d5012e5c09495f3b30ece3d2362), LLD 17.0.0) #1 SMP PREEMPT Mon Apr 17 20:50:58 UTC 2023
+Command line: console=ttynull stack_depot_disable=on cgroup_disable=pressure bootconfig no_timer_check 8250.nr_uarts=1 clocksource=pit console=0 cma=288M@0-4G loop.max_part=7 ramoops.mem_address=0xff018000 ramoops.mem_size=0x10000 memmap=0x10000$0xff018000 printk.devkmsg=on bootconfig mac80211_hwsim.radios=0
+Bootconfig: androidboot.qemu = "1"
+androidboot.qemu.cpuvulkan.version = "4202496"
+androidboot.qemu.settings.system.screen_off_timeout = "2147483647"
+androidboot.qemu.vsync = "60"
+androidboot.qemu.gltransport.name = "pipe"
+androidboot.qemu.gltransport.drawFlushInterval = "800"
+androidboot.qemu.adb.pubkey = "QAAAAEXd5gVz0iihhprOFStHSeHgmhCWzuPtCbxx4J8xyZ85J9P0qGGaatcyJfZgnWhmdgJmyMSPcEkQXLG2o93VJdj+bEwJ0v0Bc3ZX7pMxhoFaZ6taa5hbc9LRcKJrAsP3dPLQH9RhfnisiJvnbwdeDWr0/pb3N+C3Z+kjv9vN1s/WQsZqrL81JB5U04hZcK7vMWakzClgH3Ho8Ho09BWZLbgCHaBo/BcOzGVDR3KC0ENly0JM8Z7qkx/5Q7gLrPmipnCuogxISZcw+FXgA9Y03Uj/6whCmviPJuTsC2gTc1ppEaK4Zhr7B8Bxk6+hWBpZmdshp7ChR2n7j2HuBC1y5d8Mcm+vlvxCRSrlhWitR2ZFZdgVQplvJlMUYYNxRnc3xDRsLcU3E9gHfJbTpnFMKdCyXRllf3G+hDh+7xIFf9up5kTokovN2HD26mwq6Tst1kffa/9Ii74suzAG1V2/2/pZt9hHxy5hdJn53292tS2W4sY6vkG4fa+MCP01CbZRPzhGkmBDS+IXRxVbT73yIzSSEBj2ufT56YmT3U4/B6gI/cvUPzLBakFEt3rxRvFsonCoGmTvPd6lXR2FwfZpiQ+JG2kJg+ggShH2FKYe30zLA9POOVnaPIHWjTFItsV/DxMgt+BfpkY+9sOfd1xKh3JIArElxJr+GILN/zu4YjM0xJC9bgEAAQA= @unknown"
+androidboot.qemu.camera_protocol_ver = "1"
+androidboot.qemu.camera_hq_edge_processing = "0"
+androidboot.qemu.virtiowifi = "1"
+androidboot.qemu.hwcodec.avcdec = "2"
+androidboot.qemu.hwcodec.hevcdec = "2"
+androidboot.qemu.hwcodec.vpxdec = "2"
+androidboot.qemu.avd_name = "Pixel_2_API_34"
+androidboot.hardware = "ranchu"
+androidboot.serialno = "EMULATOR33X1X23X0"
+androidboot.veritymode = "enforcing"
+androidboot.opengles.version = "196608"
+androidboot.debug.hwui.renderer = "skiagl"
+androidboot.logcat = "*:V"
+androidboot.dalvik.vm.heapsize = "512m"
+androidboot.vbmeta.size = "6656"
+androidboot.vbmeta.hash_alg = "sha256"
+androidboot.vbmeta.digest = "72a95aa8f64fd107a11153e33ae83e0e3b5922474455eac90582d01951349e33"
+androidboot.boot_devices = "pci0000:00/0000:00:03.0"
+Uptime: up 0 weeks, 0 days, 0 hours, 1 minute,  load average: 18.04, 5.75, 2.01
+Bugreport format version: 2.0
+Dumpstate info: id=1 pid=5088 dry_run=0 parallel_run=1 args=/system/bin/dumpstate -S bugreport_mode=
+
+------ SYSTEM LOG (logcat -v threadtime -v printable -v uid -d *:v) ------
+--------- beginning of main
+12-26 16:18:03.038  lmkd   155   155 I lowmemorykiller: Using psi monitors for memory pressure detection
+12-26 16:18:03.040  lmkd   155   155 I lowmemorykiller: Process polling is supported
+12-26 16:18:03.041  lmkd   155   155 I lowmemorykiller: Process reaper initialized with 2 threads in the pool
+12-26 16:18:03.046  1000   156   156 W linker  : Warning: failed to find generated linker configuration from "/linkerconfig/ld.config.txt"
+12-26 16:18:03.049  1000   161   161 W linker  : Warning: failed to find generated linker configuration from "/linkerconfig/ld.config.txt"
+12-26 16:17:57.544  logd   153   153 W auditd  : type=2000 audit(0.0:1): state=initialized audit_enabled=0 res=1
+12-26 16:18:02.072  logd   153   153 W auditd  : type=1403 audit(0.0:2): auid=4294967295 ses=4294967295 lsm=selinux res=1
+12-26 16:18:02.076  logd   153   153 W auditd  : type=1404 audit(0.0:3): enforcing=1 old_enforcing=0 auid=4294967295 ses=4294967295 enabled=1 old-enabled=1 lsm=selinux res=1
+12-26 16:18:03.085  1000   161   161 I hwservicemanager: getFrameworkHalManifest: Reading VINTF information.
+12-26 16:18:03.100  1000   161   161 I hwservicemanager: getDeviceHalManifest: Reading VINTF information.
+12-26 16:18:03.122  1000   161   161 I hwservicemanager: getDeviceHalManifest: Successfully processed VINTF information
+12-26 16:18:03.122  1000   161   161 I hwservicemanager: getFrameworkHalManifest: Successfully processed VINTF information
+12-26 16:18:03.124  1000   161   161 I hwservicemanager: hwservicemanager is ready now.
+12-26 16:18:03.126  root   167   167 I qemu-props: successfully set property 'vendor.qemu.sf.fake_camera' to 'front'
+12-26 16:18:03.127  root   167   167 I qemu-props: successfully set property 'qemu.hw.mainkeys' to '0'
+12-26 16:18:03.127  root   167   167 I qemu-props: successfully set property 'qemu.sf.lcd_density' to '420'
+12-26 16:18:03.129  root   167   167 I qemu-props: successfully set property 'vendor.net.wifi_mac_prefix' to '5554'
+12-26 16:18:03.130  root   167   167 I qemu-props: successfully set property 'vendor.qemu.timezone' to 'Unknown/Unknown'
+12-26 16:18:03.131  root   167   167 I qemu-props: successfully set property 'vendor.qemu.vport.bluetooth' to '/dev/vport8p2'
+12-26 16:18:03.131  root   167   167 W qemu-props: could not open '/sys/class/virtio-ports/vport8p0/name'
+12-26 16:18:03.132  root   167   167 I qemu-props: successfully set property 'vendor.qemu.vport.modem' to '/dev/vport9p1'
+12-26 16:18:03.132  root   167   167 W qemu-props: could not open '/sys/class/virtio-ports/vport8p1/name'
+--------- beginning of system
+12-26 16:18:03.247  root   168   168 I vold    : Vold 3.0 (the awakening) firing up
+12-26 16:18:03.247  root   168   168 D vold    : Detected support for: ext4 f2fs vfat
+12-26 16:18:03.257  root   168   168 D vold    : VoldNativeService::start() completed OK
+12-26 16:18:03.266  root   168   173 I vold    : Found disk at /devices/pci0000:00/0000:00:08.0/virtio6/block/vdf but delaying scan due to secure keyguard
+------ 1.122s was the duration of 'SYSTEM LOG' ------
+------ BLOCKED PROCESS WAIT-CHANNELS ------
+1       /system/bin/init                 0
+91         init                          0
+2       [kthreadd]                       0
+3       [rcu_gp]                         0
+4       [slub_flushwq]                   0
+5       [netns]                          0
+6       [kworker/0:0-virtio_vsock]       0
+7       [kworker/0:0H-kverityd]          0
+8       [kworker/u8:0-events_unbound]    0
+9       [mm_percpu_wq]                   0
+10      [kworker/u8:1-events_unbound]    0
+11      [rcu_tasks_kthread]              0
+12      [rcu_tasks_trace_kthread]        0
+13      [ksoftirqd/0]                    0
+14      [rcu_preempt]                    0
+15      [rcub/0]                         0
+16      [rcu_exp_gp_kthread_worker]      0
+17      [rcu_exp_par_gp_kthread_worker]  0
+18      [migration/0]                    0
+19      [kworker/0:1-cgroup_destroy]     0
+20      [cpuhp/0]                        0
+21      [cpuhp/1]                        0
+22      [migration/1]                    0
+23      [ksoftirqd/1]                    0
+24      [kworker/1:0-events]             0
+25      [kworker/1:0H-kverityd]          0
+26      [cpuhp/2]                        0
+27      [migration/2]                    0
+28      [ksoftirqd/2]                    0
+29      [kworker/2:0-slub_flushwq]       0
+30      [kworker/2:0H-kverityd]          0
+31      [cpuhp/3]                        0
+32      [migration/3]                    0
+33      [ksoftirqd/3]                    0
+34      [kworker/3:0-events]             0
+35      [kworker/3:0H-kblockd]           0
+36      [inet_frag_wq]                   0
+37      [kauditd]                        0
+38      [khungtaskd]                     0
+39      [oom_reaper]                     0
+40      [writeback]                      0
+41      [kcompactd0]                     0
+42      [khugepaged]                     0
+43      [cryptd]                         0
+44      [kblockd]                        0
+45      [blkcg_punt_bio]                 0
+46      [kworker/2:1-virtio_vsock]       0
+47      [edac-poller]                    0
+48      [devfreq_wq]                     0
+49      [watchdogd]                      0
+50      [kworker/0:1H-kblockd]           0
+51      [kswapd0]                        0
+52      [kworker/u9:0-fscrypt_read_queue] 0
+53      [erofs_worker/0]                 0
+54      [erofs_worker/1]                 0
+55      [erofs_worker/2]                 0
+56      [erofs_worker/3]                 0
+57      [kthrotld]                       0
+58      [kworker/1:1-kdmflush/254:40]    0
+59      [dmabuf-deferred-free-worker]    0
+60      [uas]                            0
+61      [dm_bufio_cache]                 0
+62      [kworker/1:1H-kverityd]          0
+63      [mld]                            0
+64      [ipv6_addrconf]                  0
+66      [kworker/u8:2-ext4-rsv-conversion] 0
+67      [kworker/3:1-cgroup_destroy]     0
+68      [kworker/1:2-events]             0
+69      [khvcd]                          0
+70      [hwrng]                          0
+71      [kworker/2:2-virtio_vsock]       0
+72      [kworker/2:1H-kblockd]           0
+73      [kworker/3:1H-kblockd]           0
+77      [jbd2/vdd1-8]                    0
+78      [ext4-rsv-conver]                0
+79      [kdmflush/254:0]                 0
+80      [kdmflush/254:1]                 0
+81      [kdmflush/254:2]                 0
+82      [kdmflush/254:3]                 0
+83      [kdmflush/254:4]                 0
+84      [kdmflush/254:5]                 0
+85      [kverityd]                       0
+86      [ext4-rsv-conver]                0
+87      [ext4-rsv-conver]                0
+88      [ext4-rsv-conver]                0
+89      [ext4-rsv-conver]                0
+90      [kworker/3:2H-kverityd]          0
+92      /system/bin/init                 0
+93      /system/bin/ueventd              0
+100     [kdmflush/254:6]                 0
+102     [kdmflush/254:8]                 0
+103     [kdmflush/254:9]                 0
+104     [kdmflush/254:10]                0
+105     [kdmflush/254:11]                0
+107     [kdmflush/254:13]                0
+109     [kdmflush/254:15]                0
+110     [kdmflush/254:16]                0
+111     [kdmflush/254:17]                0
+112     [kdmflush/254:18]                0
+113     [kdmflush/254:19]                0
+114     [kdmflush/254:20]                0
+115     [kdmflush/254:21]                0
+117     [kdmflush/254:23]                0
+118     [kdmflush/254:24]                0
+119     [kdmflush/254:25]                0
+121     [kdmflush/254:27]                0
+123     [kdmflush/254:29]                0
+124     [kdmflush/254:30]                0
+128     [kdmflush/254:34]                0
+130     [kdmflush/254:36]                0
+131     [kdmflush/254:37]                0
+132     [kdmflush/254:38]                0
+133     [kdmflush/254:39]                0
+138     [ext4-rsv-conver]                0
+139     [ext4-rsv-conver]                0
+140     [ext4-rsv-conver]                0
+141     [ext4-rsv-conver]                0
+146     /system/bin/prng_seeder          0
+148     [sugov:0]                        0
+149     [sugov:1]                        0
+150     [sugov:2]                        0
+151     [sugov:3]                        0
+152     [irq/18-goldfish_pipe_dprctd]    0
+153     /system/bin/logd                 0
+162        logd.reader                   0
+163        logd.writer                   0
+164        logd.control                  0
+166        logd.auditd                   0
+3019       logd.reader.per               0
+3096       logd.reader.per               0
+3110       logd.reader.per               0
+3126       logd.reader.per               0
+3134       logd.reader.per               0
+3149       logd.reader.per               0
+5245       logd.pkglist                  0
+154     [cfg80211]                       0
+155     /system/bin/lmkd                 0
+158        lmkd_reaper0                  0
+159        lmkd_reaper1                  0
+160        lmkd_watchdog                 0
+156     /system/bin/servicemanager       0
+157     [psimon]                         0
+161     /system/bin/hwservicemanager     0
+167     /vendor/bin/qemu-props           0
+168     /system/bin/vold                 0
+171        binder:168_1                  0
+172        binder:168_3                  0
+173        binder:168_2                  0
+197        binder:168_4                  0
+319        binder:168_5                  0
+170     [kdmflush/254:40]                0
+175     /system/bin/hw/android.system.suspend-service 0
+178        binder:175_1                  0
+179        binder:175_2                  0
+499        binder:175_3                  0
+715        binder:175_4                  0
+716        binder:175_5                  0
+176     /system/bin/keystore2            0
+186        binder:176_1                  0
+187        binder:176_3                  0
+3698       binder:176_4                  0
+3699       binder:176_5                  0
+3722       binder:176_3                  0
+177     /vendor/bin/hw/android.hardware.atrace@1.0-service 0
+180     [usbip_event]                    0
+181     [kworker/1:3-events]             0
+182     /vendor/bin/hw/android.hardware.security.keymint-service 0
+190     [blk_crypto_wq]                  0
+192     [kworker/u9:1-fscrypt_read_queue] 0
+193     [kworker/u9:2-blk_crypto_wq]     0
+198     [jbd2/dm-40-8]                   0
+199     [ext4-rsv-conver]                0
+205     /system/bin/tombstoned           0
+206     [kworker/3:2-sock_diag_events]   0
+235     [ext4-rsv-conver]                0
+236     [ext4-rsv-conver]                0
+243     [ext4-rsv-conver]                0
+244     [ext4-rsv-conver]                0
+245     [ext4-rsv-conver]                0
+246     [kworker/u8:3-events_unbound]    0
+255     [kverityd]                       0
+256     [ext4-rsv-conver]                0
+257     [ext4-rsv-conver]                0
+258     [ext4-rsv-conver]                0
+259     [kverityd]                       0
+260     [ext4-rsv-conver]                0
+261     [kverityd]                       0
+262     [kverityd]                       0
+263     [kverityd]                       0
+264     [ext4-rsv-conver]                0
+265     [ext4-rsv-conver]                0
+266     [kverityd]                       0
+267     [kverityd]                       0
+268     [kverityd]                       0
+269     [kverityd]                       0
+270     [kverityd]                       0
+271     [ext4-rsv-conver]                0
+272     [ext4-rsv-conver]                0
+273     [kverityd]                       0
+274     [kworker/1:2H-kverityd]          0
+275     [ext4-rsv-conver]                0
+276     [kverityd]                       0
+277     [ext4-rsv-conver]                0
+278     [kverityd]                       0
+279     [kverityd]                       0
+280     [ext4-rsv-conver]                0
+281     [kverityd]                       0
+282     [kverityd]                       0
+283     [ext4-rsv-conver]                0
+284     [kverityd]                       0
+285     [ext4-rsv-conver]                0
+286     [ext4-rsv-conver]                0
+287     [kworker/1:3H-kverityd]          0
+288     [kverityd]                       0
+289     [kworker/0:2H-kblockd]           0
+290     [ext4-rsv-conver]                0
+291     [ext4-rsv-conver]                0
+292     [ext4-rsv-conver]                0
+293     [kworker/2:2H-kverityd]          0
+294     [kworker/u8:4]                   0
+295     [kverityd]                       0
+296     [kverityd]                       0
+297     [kverityd]                       0
+298     [ext4-rsv-conver]                0
+299     [ext4-rsv-conver]                0
+300     [ext4-rsv-conver]                0
+301     [ext4-rsv-conver]                0
+302     [kverityd]                       0
+303     [ext4-rsv-conver]                0
+304     [kverityd]                       0
+305     [ext4-rsv-conver]                0
+306     [kverityd]                       0
+307     [ext4-rsv-conver]                0
+308     [ext4-rsv-conver]                0
+309     [ext4-rsv-conver]                0
+310     [ext4-rsv-conver]                0
+311     [ext4-rsv-conver]                0
+312     [ext4-rsv-conver]                0
+327     [kworker/0:2-events]             0
+335     /vendor/bin/dhcpclient           0
+350     /apex/com.android.os.statsd/bin/statsd 0
+353        binder:350_1                  0
+354        binder:350_2                  0
+355        binder:350_3                  0
+606        statsd.writer                 0
+607        binder:350_2                  0
+735        binder:350_4                  0
+853        binder:350_5                  0
+1333       binder:350_4                  0
+351     /system/bin/netd                 0
+376        netd                          0
+379        netd                          0
+380        netd                          0
+381        netd                          0
+382        netd                          0
+383        NFLogListener                 0
+389        doh-handler                   0
+390        netd                          0
+391        binder:351_1                  0
+392        binder:351_2                  0
+393        MDnsSdMonitor                 0
+394        binder:351_3                  0
+395        HwBinder:351_1                0
+352     zygote64                         0
+356     /system/bin/hw/android.hidl.allocator@1.0-service 0
+357     /vendor/bin/hw/android.hardware.audio.service 0
+365        binder:357_1                  0
+366        binder:357_3                  0
+406        HwBinder:357_1                0
+407        HwBinder:357_2                0
+4543       HwBinder:357_2                0
+358     /vendor/bin/hw/android.hardware.authsecret-service.example 0
+359     /vendor/bin/hw/android.hardware.camera.provider.ranchu 0
+387        binder:359_1                  0
+388        binder:359_3                  0
+360     /vendor/bin/hw/android.hardware.camera.provider@2.7-service-google 0
+400        binder:360_1                  0
+401        binder:360_3                  0
+361     /vendor/bin/hw/android.hardware.gatekeeper@1.0-service.software 0
+362     /vendor/bin/hw/android.hardware.graphics.allocator@3.0-service.ranchu 0
+404        HwBinder:362_1                0
+405        HwBinder:362_2                0
+363     /vendor/bin/hw/android.hardware.health-service.example 0
+364     /vendor/bin/hw/android.hardware.media.c2@1.0-service-goldfish 0
+412        HwBinder:364_1                0
+414        HwBinder:364_2                0
+755        HwBinder:364_2                0
+756        HwBinder:364_2                0
+1613       c2@1.0-service-               0
+367     /vendor/bin/hw/android.hardware.neuralnetworks-service-sample-all 0
+368     /vendor/bin/hw/android.hardware.neuralnetworks-service-sample-limited 0
+369     /vendor/bin/hw/android.hardware.neuralnetworks-shim-service-sample 0
+370     /vendor/bin/hw/android.hardware.sensors-service.multihal 0
+385        android.hardwar               0
+386        android.hardwar               0
+624        android.hardwar               0
+625        android.hardwar               0
+371     /vendor/bin/hw/android.hardware.thermal@2.0-service.mock 0
+372     /vendor/bin/hw/android.hardware.usb-service.example 0
+710        android.hardwar               0
+373     /vendor/bin/hw/android.hardware.wifi-service 0
+399        binder:373_1                  0
+744        binder:373_1                  0
+374     /system/bin/iptables-restore     0
+375     /system/bin/ip6tables-restore    0
+377     /vendor/bin/hw/android.hardware.bluetooth-service.default 0
+1039       android.hardwar               0
+378     /vendor/bin/hw/android.hardware.cas-service.example 0
+384     /vendor/bin/hw/android.hardware.contexthub-service.example 0
+396     /vendor/bin/hw/android.hardware.biometrics.face-service.example 0
+973        android.hardwar               0
+397     /vendor/bin/hw/android.hardware.graphics.composer3-service.ranchu 0
+418        binder:397_1                  0
+460        binder:397_3                  0
+473        binder:397_2                  0
+398     /vendor/bin/hw/android.hardware.identity-service.example 0
+402     /vendor/bin/hw/android.hardware.lights-service.example 0
+403     /vendor/bin/hw/android.hardware.power-service.example 0
+408     /vendor/bin/hw/android.hardware.power.stats-service.example 0
+409     /vendor/bin/hw/android.hardware.rebootescrow-service.default 0
+410     /vendor/bin/hw/android.hardware.vibrator-service.example 0
+411     /apex/com.google.android.widevine/bin/hw/android.hardware.drm-service.widevine 0
+5781       wvcdm::Timer::I               0
+413     /system/bin/audioserver          0
+430        binder:413_1                  0
+431        binder:413_2                  0
+432        AudioFlinger_Pa               0
+436        HwBinder:413_1                0
+437        HwBinder:413_2                0
+481        ApmAudio                      0
+482        ApmOutput                     0
+490        TimerThread                   0
+498        AudioOut_D                    0
+501        AudioOut_15                   0
+702        binder:413_3                  0
+1239       binder:413_4                  0
+1429       binder:413_5                  0
+2678       binder:413_6                  0
+5353       binder:413_7                  0
+5354       HwBinder:413_3                0
+415     /system/bin/credstore            0
+421        binder:415_1                  0
+416     /system/bin/gpuservice           0
+424        binder:416_1                  0
+425        TracingMuxer                  0
+428        gpuservice                    0
+417     /system/bin/surfaceflinger       0
+426        binder:417_1                  0
+427        binder:417_2                  0
+433        RenderEngine                  0
+483        HwcAsyncWorker                0
+488        TimerDispatch                 0
+489        app                           0
+491        appSf                         0
+492        RegionSampling                0
+493        RegSampIdle                   0
+494        surfaceflinger                0
+497        surfaceflinger                0
+542        binder:417_3                  0
+543        binder:417_4                  0
+861        binder:417_5                  0
+1322       TracingMuxer                  0
+429     /apex/com.android.adbd/bin/adbd  0
+442        adbd                          0
+443        adbd                          0
+444        adbd auth                     0
+446        server socket                 0
+447        server socket                 0
+448        jdwp control                  0
+505        adbd                          0
+506        adbd                          0
+1699       adbd                          0
+1700       adbd                          0
+3015       shell svc 3014                0
+3084       shell svc 3081                0
+3105       shell svc 3103                0
+3119       shell svc 3116                0
+3132       shell svc 3130                0
+3140       shell svc 3139                0
+5086       shell svc 5085                0
+5792       shell svc 5791                0
+435     /system/bin/drmserver            0
+441        DrmManagerMetri               0
+449        binder:435_1                  0
+5381       binder:435_2                  0
+439     /system/bin/traced_probes        0
+450        traced_probes                 0
+453        traced_probes                 0
+440     /system/bin/traced               0
+452        traced                        0
+451     /system/bin/mdnsd                0
+457     /vendor/bin/bt_vhci_forwarder    0
+458     /system/bin/cameraserver         0
+529        HwBinder:458_1                0
+530        HwBinder:458_2                0
+533        binder:458_1                  0
+534        binder:458_3                  0
+535        binder:458_4                  0
+3777       binder:458_5                  0
+5397       binder:458_6                  0
+461     /system/bin/incidentd            0
+466        binder:461_1                  0
+467        binder:461_3                  0
+462     /system/bin/installd             0
+472        binder:462_1                  0
+463     media.extractor                  0
+487        binder:463_1                  0
+763        binder:463_2                  0
+764        binder:463_3                  0
+3426       binder:463_4                  0
+465     media.metrics                    0
+476        mediametrics                  0
+477        binder:465_1                  0
+612        binder:465_2                  0
+613        binder:465_3                  0
+614        binder:465_4                  0
+1098       binder:465_5                  0
+1099       binder:465_6                  0
+468     /system/bin/mediaserver          0
+486        binder:468_1                  0
+812        binder:468_2                  0
+813        binder:468_3                  0
+3300       binder:468_4                  0
+3301       binder:468_5                  0
+3318       binder:468_6                  0
+4523       HwBinder:468_1                0
+4524       HwBinder:468_2                0
+4534       CCodecWatchdog                0
+4535       NPDecoder-CL                  0
+4536       NPDecoder-CL                  0
+4538       HwBinder:468_3                0
+4539       HwBinder:468_4                0
+4540       HwBinder:468_5                0
+4554       HwBinder:468_6                0
+469     /system/bin/storaged             0
+615        storaged                      0
+616        binder:469_1                  0
+617        binder:469_2                  0
+470     /system/bin/wificond             0
+480        HwBinder:470_1                0
+471     /vendor/bin/hw/libgoldfish-rild  0
+500        libgoldfish-ril               0
+502        libgoldfish-ril               0
+503        libgoldfish-ril               0
+504        libgoldfish-ril               0
+474     media.swcodec                    0
+509        HwBinder:474_1                0
+757        HwBinder:474_1                0
+758        HwBinder:474_1                0
+803        HwBinder:474_2                0
+806        HwBinder:474_3                0
+822        HwBinder:474_4                0
+824        HwBinder:474_5                0
+825        HwBinder:474_2                0
+475     /system/bin/gatekeeperd          0
+552     system_server                    0
+559        Signal Catcher                0
+560        perfetto_hprof_               0
+561        Jit thread pool               0
+562        HeapTaskDaemon                0
+563        ReferenceQueueD               0
+564        FinalizerDaemon               0
+565        FinalizerWatchd               0
+566        binder:552_1                  0
+567        binder:552_2                  0
+568        atchdog.monitor               0
+569        android.fg                    0
+570        android.ui                    0
+571        android.io                    0
+572        android.display               0
+573        android.anim                  0
+574        android.anim.lf               0
+575        watchdog                      0
+579        PowerStatsServi               0
+580        android.bg                    0
+581        ActivityManager               0
+582        ActivityManager               0
+583        ActivityManager               0
+584        ActivityManager               0
+585        Thread-2                      0
+586        OomAdjuster                   0
+587        batterystats-ha               0
+588        batterystats-wo               0
+589        bgres-controlle               0
+590        FileObserver                  0
+592        CpuTracker                    0
+593        CriticalEventLo               0
+594        DataLoaderManag               0
+595        Thread-3                      0
+596        Thread-4                      0
+597        Thread-5                      0
+598        Thread-6                      0
+599        PowerManagerSer               0
+600        BatteryStats_wa               0
+602        PackageManagerB               0
+603        PermissionManag               0
+604        DefaultPermGran               0
+605        PackageManager                0
+619        PackageInstalle               0
+620        binder:552_3                  0
+621        OverlayManager                0
+626        SensorEventAckR               0
+627        SensorService                 0
+628        HealthServiceBi               0
+629        eduling.default               0
+630        RollbackPackage               0
+631        RollbackManager               0
+632        NativeTombstone               0
+634        AccountManagerS               0
+635        SettingsProvide               0
+636        CachedAppOptimi               0
+637        oregroundThread               0
+638        Thread-7                      0
+639        tare                          0
+640        AlarmManager                  0
+642        pool-2-thread-1               0
+643        CameraService_p               0
+644        LazyTaskWriterT               0
+645        AccessibilityTr               0
+646        InputDispatcher               0
+647        InputReader                   0
+648        HwBinder:552_1                0
+649        HwBinder:552_2                0
+650        BluetoothManage               0
+651        NetworkWatchlis               0
+652        AppIntegrityMan               0
+653        android.imms                  0
+654        FlashNotificati               0
+655        FlashNotifContr               0
+656        StorageManagerS               0
+658        LocaleManagerSe               0
+661        binder:552_4                  0
+662        LockSettingsSer               0
+678        NetworkStats                  0
+679        NetworkPolicy                 0
+680        tworkPolicy.uid               0
+681        WifiHandlerThre               0
+682        WifiDiagnostics               0
+683        WifiP2pService                0
+684        PasspointProvis               0
+685        WifiScanningSer               0
+686        WifiManagerThre               0
+687        pacproxyservice               0
+688        ConnectivitySer               0
+689        CarrierPrivileg               0
+690        ackgroundThread               0
+691        NsdService                    0
+692        oregroundThread               0
+693        VpnManagerServi               0
+694        VcnManagementSe               0
+695        ranker                        0
+696        onProviders.ECP               0
+697        DeviceStorageMo               0
+698        AS.SfxWorker                  0
+699        AudioService                  0
+700        AudioDeviceBrok               0
+701        AudioPortEventH               0
+703        backActivityMon               0
+704        MediaFocusContr               0
+705        Thread-8                      0
+706        pool-16-thread-               0
+707        SoundTriggerHal               0
+709        UEventObserver                0
+711        ConnectivityThr               0
+712        backup                        0
+713        AppWidgetServic               0
+714        ackgroundThread               0
+717        NetworkTimeUpda               0
+718        BlobStore                     0
+719        GraphicsStats-d               0
+721        SessionRecordTh               0
+726        BackgroundInsta               0
+727        SliceManagerSer               0
+728        StatsCompanionS               0
+730        SdkSandboxManag               0
+731        SdkSandboxManag               0
+732        ackgroundThread               0
+733        AdServicesManag               0
+737        Thread-10                     0
+738        ClipboardServic               0
+739        PhotonicModulat               0
+742        HealthServiceBi               0
+743        TaskSnapshotPer               0
+745        android.perm                  0
+749        GameManagerServ               0
+750        binder:552_5                  0
+751        pool-22-thread-               0
+753        ackgroundThread               0
+754        SyncManager                   0
+759        NetworkStatsObs               0
+782        Thread-13                     0
+801        nearbyfg                      0
+816        CCodecWatchdog                0
+817        NDK MediaCodec_               0
+818        NDK MediaCodec_               0
+826        binder:552_6                  0
+827        HwBinder:552_3                0
+828        HwBinder:552_4                0
+830        EmergencyAfford               0
+833        HwBinder:552_5                0
+834        binder:552_7                  0
+835        binder:552_8                  0
+841        binder:552_9                  0
+842        binder:552_A                  0
+944        DeviceLockContr               0
+1067       BluetoothRouteM               0
+1071       uteStateMachine               0
+1072       CallAudioModeSt               0
+1073       ConnectionSvrFo               0
+1077       binder:552_B                  0
+1079       binder:552_C                  0
+1080       VoipCallMonitor               0
+1209       pool-25-thread-               0
+1277       AsyncTask #2                  0
+1328       PowerStatsServi               0
+1329       pool-7-thread-1               0
+1331       RedirectListene               0
+1332       AdbDebuggingMan               0
+1351       OsuServerHandle               0
+1413       StorageUserConn               0
+1412       queued-work-loo               0
+1471       backup-0                      0
+1523       binder:552_D                  0
+1526       binder:552_E                  0
+1527       binder:552_F                  0
+1531       binder:552_10                 0
+1533       pool-63-thread-               0
+1538       pool-65-thread-               0
+1597       LazyTaskWriterT               0
+1614       pool-21-thread-               0
+1617       pool-70-thread-               0
+1745       binder:552_11                 0
+1747       binder:552_12                 0
+1937       binder:552_13                 0
+1938       binder:552_14                 0
+1977       binder:552_15                 0
+1987       binder:552_16                 0
+1995       binder:552_17                 0
+1996       binder:552_18                 0
+2018       binder:552_19                 0
+2019       binder:552_1A                 0
+2020       binder:552_1B                 0
+2021       binder:552_1C                 0
+2023       binder:552_1D                 0
+2024       binder:552_1E                 0
+2027       binder:552_1F                 0
+2034       binder:552_20                 0
+2156       pool-61-thread-               0
+2195       pool-50-thread-               0
+2315       pool-56-thread-               0
+2353       pool-57-thread-               0
+3259       pool-38-thread-               0
+4063       pool-9-thread-1               0
+4066       AsyncQueryWorke               0
+4482       pool-164-thread               0
+5032       pool-174-thread               0
+5149       pool-175-thread               0
+5213       pool-176-thread               0
+5223       pool-177-thread               0
+5273       pool-178-thread               0
+5460       pool-179-thread               0
+5471       pool-6-thread-1               0
+5483       pool-180-thread               0
+5484       pool-181-thread               0
+558     [kworker/1:4H-kblockd]           0
+725     /vendor/bin/hw/android.hardware.biometrics.fingerprint-service.ranchu 0
+734        binder:725_1                  0
+736        binder:725_3                  0
+978        binder:725_2                  0
+747     /vendor/bin/hw/wpa_supplicant    0
+760     com.android.systemui             0
+770        Signal Catcher                0
+771        perfetto_hprof_               0
+772        ADB-JDWP Connec               0
+773        Jit thread pool               0
+774        HeapTaskDaemon                0
+775        ReferenceQueueD               0
+776        FinalizerDaemon               0
+777        FinalizerWatchd               0
+779        binder:760_1                  0
+780        binder:760_2                  0
+781        binder:760_3                  0
+795        Profile Saver                 0
+802        wmshell.main                  0
+808        InteractionJank               0
+810        hell.background               0
+811        wmshell.anim                  0
+814        ll.splashscreen               0
+815        ll.splashworker               0
+829        SysUiBg                       0
+831        BroadcastRunnin               0
+837        RenderThread                  0
+845        android.bg                    0
+846        pool-2-thread-1               0
+862        binder:760_4                  0
+867        biometrics                    0
+886        plugin                        0
+892        pool-4-thread-1               0
+895        async_sensor                  0
+897        AsyncTask #1                  0
+905        DefaultDispatch               0
+922        SysUiLng                      0
+923        DefaultWallpape               0
+924        ImageWallpaper                0
+942        binder:760_5                  0
+954        ScreenDecoratio               0
+999        WifiManagerThre               0
+1035       ConnectivityThr               0
+1081       VolumeDialogCon               0
+1091       queued-work-loo               0
+1092       binder:760_5                  0
+1094       TimeTick                      0
+1102       Keyboard                      0
+1127       CCodecWatchdog                0
+1129       DefaultDispatch               0
+1130       DefaultDispatch               0
+1131       NDK MediaCodec_               0
+1133       NDK MediaCodec_               0
+1134       HwBinder:760_1                0
+1142       DefaultDispatch               0
+1158       CameraManagerGl               0
+1162       MTViewCapture                 0
+1165       pool-5-thread-1               0
+1208       AsyncLayoutInfl               0
+1214       ndroid.systemui               0
+1215       ndroid.systemui               0
+1216       ndroid.systemui               0
+1217       ndroid.systemui               0
+1218       RSMessageThread               0
+1238       binder:760_6                  0
+1258       binder:760_7                  0
+1270       binder:760_8                  0
+1286       SurfaceSyncGrou               0
+1290       hwuiTask0                     0
+1291       hwuiTask1                     0
+1462       GrallocUploadTh               0
+1657       binder:760_9                  0
+1667       binder:760_A                  0
+2822       pool-7-thread-1               0
+4542       AudioPortEventH               0
+809     /vendor/bin/hw/android.hardware.gnss-service.ranchu 0
+819        binder:809_1                  0
+820        binder:809_3                  0
+855     webview_zygote                   0
+863        HeapTaskDaemon                0
+864        ReferenceQueueD               0
+865        FinalizerDaemon               0
+866        FinalizerWatchd               0
+868     com.android.networkstack.process 0
+874        Signal Catcher                0
+875        perfetto_hprof_               0
+876        Jit thread pool               0
+877        HeapTaskDaemon                0
+878        ReferenceQueueD               0
+879        FinalizerDaemon               0
+880        FinalizerWatchd               0
+881        binder:868_1                  0
+883        binder:868_2                  0
+885        binder:868_3                  0
+896        Profile Saver                 0
+946        NetworkStackNot               0
+980        droid.tethering               0
+1017       WifiManagerThre               0
+1064       IpClient.wlan0                0
+1096       binder:868_4                  0
+1330       pool-2-thread-1               0
+2114       binder:868_5                  0
+2136       NetworkMonitor/               0
+2142       Thread-2                      0
+2310       binder:868_6                  0
+2453       OkHttp Connecti               0
+2464       Okio Watchdog                 0
+3424       NetworkMonitor/               0
+3430       binder:868_7                  0
+3485       OkHttp Connecti               0
+5051       AsyncTask #1                  0
+900     com.google.android.bluetooth     0
+912        Signal Catcher                0
+913        perfetto_hprof_               0
+914        Jit thread pool               0
+915        HeapTaskDaemon                0
+916        ReferenceQueueD               0
+917        FinalizerDaemon               0
+918        FinalizerWatchd               0
+920        binder:900_1                  0
+921        binder:900_2                  0
+925        binder:900_3                  0
+941        Profile Saver                 0
+983        ackgroundThread               0
+1013       AdapterState                  0
+1022       android.bg                    0
+1025       bt_stack_manage               0
+1026       bt_main_thread                0
+1027       POSIX timer 0                 0
+1028       POSIX timer 1                 0
+1029       alarm_default_c               0
+1030       alarm_dispatche               0
+1033       bt_stack_manage               0
+1034       bt_stack_manage               0
+1050       BT Service Call               0
+1051       Thread-4                      0
+1052       Thread-5                      0
+1053       BluetoothDataba               0
+1055       BluetoothActive               0
+1057       AudioPortEventH               0
+1062       AsyncTask #1                  0
+1122       BondStateMachin               0
+1135       BluetoothAdvert               0
+1147       BluetoothScanMa               0
+1151       DistanceMeasure               0
+1152       queued-work-loo               0
+1156       bt_main_thread                0
+1157       btif_sock                     0
+1160       bt_stack_manage               0
+1163       e.StateMachines               0
+1164       bt_a2dp_source_               0
+1173       e.StateMachines               0
+1174       e.StateMachines               0
+1175       BluetoothMapHan               0
+1179       Thread-6                      0
+1180       Thread-7                      0
+1181       PbapHandlerThre               0
+1190       binder:900_4                  0
+1191       Thread-9                      0
+1192       Thread-10                     0
+1197       Thread-11                     0
+1198       Thread-12                     0
+1246       binder:900_5                  0
+1641       binder:900_6                  0
+927     com.android.se                   0
+932        Signal Catcher                0
+933        perfetto_hprof_               0
+934        Jit thread pool               0
+935        HeapTaskDaemon                0
+936        ReferenceQueueD               0
+937        FinalizerDaemon               0
+938        FinalizerWatchd               0
+939        binder:927_1                  0
+943        binder:927_2                  0
+979        Profile Saver                 0
+993        queued-work-loo               0
+945     com.android.phone                0
+952        Signal Catcher                0
+953        perfetto_hprof_               0
+955        Jit thread pool               0
+956        HeapTaskDaemon                0
+957        ReferenceQueueD               0
+958        FinalizerDaemon               0
+959        FinalizerWatchd               0
+960        binder:945_1                  0
+976        binder:945_2                  0
+984        Profile Saver                 0
+1069       queued-work-loo               0
+1074       PersistAtomsThr               0
+1075       DeviceStateHelp               0
+1076       binder:945_3                  0
+1078       binder:945_4                  0
+1088       RHC                           0
+1093       SMSVC                         0
+1095       SMSVC                         0
+1100       binder:945_5                  0
+1101       CellBroadcastCo               0
+1167       ConnectivityThr               0
+1196       pool-2-thread-1               0
+1199       ImsResolver                   0
+1200       RcsProvisioning               0
+1201       SatelliteContro               0
+1203       ImsStateCallbac               0
+1204       ImsProvisioning               0
+1206       android.bg                    0
+1210       binder:945_6                  0
+1211       binder:945_7                  0
+1212       binder:945_8                  0
+1220       binder:945_9                  0
+1221       DataService                   0
+1262       binder:945_A                  0
+1266       binder:945_B                  0
+1267       binder:945_C                  0
+1268       binder:945_D                  0
+1269       binder:945_E                  0
+1271       CatServiceThrea               0
+1272       RilMessageDecod               0
+1274       Cat Icon Loader               0
+1276       NetworkService                0
+1321       Stk App Service               0
+1407       binder:945_F                  0
+1426       binder:945_10                 0
+1749       Thread-2                      0
+1753       ONSNetworkScanC               0
+1782       ONSProfileSelec               0
+947     com.android.settings             0
+965        Signal Catcher                0
+966        perfetto_hprof_               0
+967        Jit thread pool               0
+968        HeapTaskDaemon                0
+969        ReferenceQueueD               0
+970        FinalizerDaemon               0
+971        FinalizerWatchd               0
+972        binder:947_1                  0
+975        binder:947_2                  0
+1021       Profile Saver                 0
+1040       RenderThread                  0
+1046       AsyncTask #1                  0
+1059       binder:947_3                  0
+1061       SurfaceSyncGrou               0
+1086       hwuiTask0                     0
+1087       hwuiTask1                     0
+1259       binder:947_3                  0
+1383       binder:947_4                  0
+1600       binder:947_5                  0
+2626       queued-work-loo               0
+4605       binder:947_6                  0
+4613       binder:947_7                  0
+4616       SettingsIntelli               0
+4617       SettingsIntelli               0
+4618       binder:947_8                  0
+4621       WifiManagerThre               0
+4667       onsState.Loader               0
+4673       InteractionJank               0
+4677       pool-6-thread-1               0
+4684       pool-7-thread-1               0
+4696       pool-8-thread-1               0
+4700       pool-9-thread-1               0
+4708       pool-10-thread-               0
+4714       pool-11-thread-               0
+4719       pool-12-thread-               0
+4720       pool-13-thread-               0
+4723       pool-6-thread-2               0
+4724       pool-6-thread-3               0
+4729       CameraManagerGl               0
+4734       pool-6-thread-4               0
+5433       NotifySliceChan               0
+5434       pool-19-thread-               0
+5435       WifiPickerTrack               0
+5670       pool-28-thread-               0
+5673       pool-29-thread-               0
+5677       pool-30-thread-               0
+5678       pool-31-thread-               0
+5679       pool-32-thread-               0
+5680       pool-33-thread-               0
+982     com.google.android.ext.services  0
+989        Signal Catcher                0
+991        perfetto_hprof_               0
+994        Jit thread pool               0
+995        HeapTaskDaemon                0
+996        ReferenceQueueD               0
+997        FinalizerDaemon               0
+998        FinalizerWatchd               0
+1005       binder:982_1                  0
+1009       binder:982_2                  0
+1018       binder:982_3                  0
+1024       Profile Saver                 0
+1124       queued-work-loo               0
+1247       binder:982_4                  0
+5182       binder:982_5                  0
+5705       binder:982_6                  0
+992     com.google.android.apps.nexuslauncher 0
+1004       Signal Catcher                0
+1006       perfetto_hprof_               0
+1007       Jit thread pool               0
+1008       HeapTaskDaemon                0
+1010       ReferenceQueueD               0
+1011       FinalizerDaemon               0
+1012       FinalizerWatchd               0
+1014       binder:992_1                  0
+1023       binder:992_2                  0
+1038       Profile Saver                 0
+1056       UiThreadHelper                0
+1058       launcher-loader               0
+1237       binder:992_3                  0
+1257       binder:992_4                  0
+1593       InteractionJank               0
+1644       RenderThread                  0
+1668       pool-2-thread-1               0
+1734       equicksearchbox               0
+1751       pool-2-thread-2               0
+1836       android.bg                    0
+1899       GrallocUploadTh               0
+1992       SAViewCapture                 0
+2118       queued-work-loo               0
+2191       grpc-timer-0                  0
+2577       llpaper.recents               0
+2586       SurfaceSyncGrou               0
+2587       hwuiTask0                     0
+2588       hwuiTask1                     0
+2608       WellbeingHandle               0
+2610       binder:992_1                  0
+2619       binder:992_5                  0
+1097    com.google.android.cellbroadcastreceiver 0
+1111       Signal Catcher                0
+1112       perfetto_hprof_               0
+1113       Jit thread pool               0
+1114       HeapTaskDaemon                0
+1115       ReferenceQueueD               0
+1116       FinalizerDaemon               0
+1117       FinalizerWatchd               0
+1121       binder:1097_1                 0
+1123       binder:1097_2                 0
+1138       binder:1097_3                 0
+1159       Profile Saver                 0
+1188       queued-work-loo               0
+1312       binder:1097_4                 0
+4142       AsyncTask #1                  0
+1219    com.google.android.gms.persistent 0
+1227       Signal Catcher                0
+1228       perfetto_hprof_               0
+1229       Jit thread pool               0
+1230       HeapTaskDaemon                0
+1231       ReferenceQueueD               0
+1232       FinalizerDaemon               0
+1233       FinalizerWatchd               0
+1234       binder:1219_1                 0
+1235       binder:1219_2                 0
+1279       Profile Saver                 0
+1288       FileObserver                  0
+1304       GlobalDispatchi               0
+1307       GlobalScheduler               0
+1311       GoogleApiHandle               0
+1313       highpool[3]                   0
+1316       binder:1219_3                 0
+1317       binder:1219_4                 0
+1318       ice] processing               0
+1319       queued-work-loo               0
+1320       peration loader               0
+1545       FlpThread                     0
+1595       OkHttpClientTra               0
+1618       WifiManagerThre               0
+1619       binder:1219_5                 0
+1704       lowpool[2]                    0
+1730       highpool[4]                   0
+1767       android.bg                    0
+2047       binder:1219_6                 0
+2080       binder:1219_7                 0
+2112       GoogleLocationS               0
+2654       binder:1219_8                 0
+2655       binder:1219_9                 0
+2862       binder:1219_A                 0
+2876       binder:1219_B                 0
+2917       binder:1219_C                 0
+2930       DG                            0
+3150       lowpool[6]                    0
+3175       highpool[5]                   0
+3201       binder:1219_D                 0
+3210       lowpool[8]                    0
+3234       ConnectivityThr               0
+3283       netscheduler-qu               0
+3507       OkHttp Connecti               0
+3510       OkHttpClientTra               0
+3511       lowpool[12]                   0
+3513       Okio Watchdog                 0
+3520       grpc-timer-0                  0
+3521       grpc-default-ex               0
+3602       OkHttp Connecti               0
+3643       binder:1219_E                 0
+3711       NearbyDiscovery               0
+3728       NearbyMessages                0
+3759       NearbyDirectMai               0
+3784       eevt                          0
+3833       binder:1219_F                 0
+3856       GoogleApiHandle               0
+3857       TFLiteCounters-               0
+4143       CronetInit                    0
+4144       ThreadPoolServi               0
+4145       ThreadPoolForeg               0
+4146       ChromiumNet                   0
+4155       ThreadPoolForeg               0
+4156       ThreadPoolForeg               0
+4177       Network File Th               0
+4454       -Executor] idle               0
+4455       -Executor] idle               0
+4456       -Executor] idle               0
+4457       -Executor] idle               0
+4492       binder:1219_10                0
+4650       ProcessStablePh               0
+4653       GoogleApiHandle               0
+4716       -Executor] idle               0
+5004       -Executor] idle               0
+5028       lowpool[16]                   0
+5041       pool-464-thread               0
+5045       highpool[6]                   0
+1240    com.google.android.permissioncontroller 0
+1245       Signal Catcher                0
+1248       perfetto_hprof_               0
+1249       Jit thread pool               0
+1250       HeapTaskDaemon                0
+1251       ReferenceQueueD               0
+1252       FinalizerDaemon               0
+1253       FinalizerWatchd               0
+1255       binder:1240_1                 0
+1256       binder:1240_2                 0
+1260       binder:1240_3                 0
+1283       Profile Saver                 0
+1292       queued-work-loo               0
+1293       DefaultDispatch               0
+1294       DefaultDispatch               0
+1295       DefaultDispatch               0
+1303       pool-2-thread-1               0
+1314       pool-2-thread-2               0
+1399       pool-2-thread-3               0
+1401       pool-2-thread-4               0
+1402       pool-2-thread-5               0
+1405       pool-2-thread-6               0
+1409       pool-2-thread-7               0
+1410       pool-2-thread-8               0
+1666       binder:1240_4                 0
+4399       DefaultDispatch               0
+4670       RoleControllerS               0
+5009       binder:1240_5                 0
+1263    [kworker/u9:3-blk_crypto_wq]     0
+1264    [kworker/u9:4-fscrypt_read_queue] 0
+1335    com.google.android.apps.wellbeing 0
+1340       Signal Catcher                0
+1345       perfetto_hprof_               0
+1346       Jit thread pool               0
+1347       HeapTaskDaemon                0
+1348       ReferenceQueueD               0
+1349       FinalizerDaemon               0
+1350       FinalizerWatchd               0
+1354       binder:1335_1                 0
+1355       binder:1335_2                 0
+1357       binder:1335_3                 0
+1359       Profile Saver                 0
+1378       Blocking Thread               0
+1381       Scheduler Threa               0
+1382       BG Thread #0                  0
+1384       BG Thread #1                  0
+1386       GoogleApiHandle               0
+1388       Lite Thread #0                0
+1389       BG Thread #2                  0
+1390       BG Thread #3                  0
+1394       Blocking Thread               0
+1400       Lite Thread #1                0
+1397       Blocking Thread               0
+1582       Lite Thread #0                0
+1770       ConnectivityThr               0
+1876       android.bg                    0
+1986       GmsDynamite                   0
+1989       Blocking Thread               0
+2737       binder:1335_4                 0
+2740       queued-work-loo               0
+3122       binder:1335_5                 0
+3269       binder:1335_6                 0
+3851       binder:1335_7                 0
+1356    com.google.android.inputmethod.latin 0
+1364       Signal Catcher                0
+1365       perfetto_hprof_               0
+1366       Jit thread pool               0
+1367       HeapTaskDaemon                0
+1368       ReferenceQueueD               0
+1369       FinalizerDaemon               0
+1370       FinalizerWatchd               0
+1371       binder:1356_1                 0
+1372       binder:1356_2                 0
+1373       binder:1356_3                 0
+1376       Profile Saver                 0
+1398       queued-work-loo               0
+1404       ImeScheduler-0                0
+1500       ExeSeq-P10-1                  0
+1505       ExeSeq-P10-1                  0
+1522       Light-P0-1                    0
+1525       Light-P0-2                    0
+1598       Block-P11-1                   0
+1609       Block-P11-2                   0
+1612       RenderThread                  0
+1817       Back-P10-1                    0
+1820       GoogleApiHandle               0
+1821       Back-P10-2                    0
+1824       sp-control-1                  0
+1825       DFacilitator-1                0
+1830       Back-P10-3                    0
+1832       Primes-1                      0
+1833       Primes-nativecr               0
+1845       Back-P10-4                    0
+1851       ExeSeq-P11-1                  0
+1865       Block-P11-3                   0
+1866       Block-P11-4                   0
+1867       Block-P11-5                   0
+1868       Block-P11-6                   0
+1869       Block-P11-7                   0
+1870       Block-P11-8                   0
+1871       Block-P11-9                   0
+1872       Block-P11-10                  0
+1873       Block-P11-11                  0
+1874       Block-P11-12                  0
+1891       Block-P11-13                  0
+1892       Block-P11-14                  0
+1893       Block-P11-15                  0
+1894       Block-P11-16                  0
+1895       Block-P11-17                  0
+1896       Block-P11-18                  0
+1929       GmsDynamite                   0
+1994       CronetInit                    0
+2002       ThreadPoolServi               0
+2003       ThreadPoolForeg               0
+2016       ChromiumNet                   0
+2044       ThreadPoolForeg               0
+2045       ThreadPoolForeg               0
+2084       Network File Th               0
+2106       AutoCloseableTr               0
+2107       UserFeatureCach               0
+2110       UFCache-1                     0
+2127       SplitInstallSer               0
+2564       binder:1356_4                 0
+2683       Primes-2                      0
+2685       ProcessStablePh               0
+2986       DecoderWrapper-               0
+1396    com.google.android.devicelockcontroller 0
+1418       Signal Catcher                0
+1419       perfetto_hprof_               0
+1420       Jit thread pool               0
+1421       HeapTaskDaemon                0
+1422       ReferenceQueueD               0
+1423       FinalizerDaemon               0
+1424       FinalizerWatchd               0
+1425       binder:1396_1                 0
+1427       binder:1396_2                 0
+1446       Profile Saver                 0
+1461       binder:1396_3                 0
+4211       binder:1396_4                 0
+4243       pool-3-thread-1               0
+4257       WM.task-1                     0
+4280       WM.task-2                     0
+4289       ConnectivityThr               0
+4293       WM.task-3                     0
+4306       androidx.work-1               0
+4310       GoogleApiHandle               0
+4428       grpc-timer-0                  0
+4431       grpc-default-ex               0
+4433       grpc-okhttp-0                 0
+4434       grpc-okhttp-1                 0
+4442       queued-work-loo               0
+4491       binder:1396_5                 0
+1428    com.google.android.providers.media.module 0
+1434       Signal Catcher                0
+1436       perfetto_hprof_               0
+1437       Jit thread pool               0
+1438       HeapTaskDaemon                0
+1439       ReferenceQueueD               0
+1440       FinalizerDaemon               0
+1441       FinalizerWatchd               0
+1442       binder:1428_1                 0
+1443       binder:1428_2                 0
+1460       binder:1428_3                 0
+1506       Profile Saver                 0
+1532       ent.InfoHandler               0
+1539       nt.EventHandler               0
+1558       ackgroundThread               0
+1594       queued-work-loo               0
+1604       CCodecWatchdog                0
+1605       CodecLooper                   0
+1606       CodecLooper                   0
+1607       HwBinder:1428_1               0
+1638       fg                            0
+1706       android.bg                    0
+1783       emulated;0                    0
+1792       emulated;0                    0
+1793       Thread-8                      0
+1800       Thread-7                      0
+2129       public:253,80                 0
+2134       public:253,80                 0
+2135       Thread-4                      0
+2178       Thread-5                      0
+2342       binder:1428_4                 0
+2733       Thread-6                      0
+3226       AsyncTask #1                  0
+3737       Thread-9                      0
+3970       Thread-10                     0
+3975       Thread-11                     0
+5087       Thread-12                     0
+5092       Thread-13                     0
+5111       Thread-14                     0
+1444    [kworker/3:3H-kverityd]          0
+1447    com.android.printspooler         0
+1452       Signal Catcher                0
+1463       perfetto_hprof_               0
+1464       Jit thread pool               0
+1465       HeapTaskDaemon                0
+1466       ReferenceQueueD               0
+1467       FinalizerDaemon               0
+1468       FinalizerWatchd               0
+1469       binder:1447_1                 0
+1503       binder:1447_2                 0
+1530       binder:1447_3                 0
+1536       Profile Saver                 0
+2308       AsyncTask #1                  0
+2349       queued-work-loo               0
+5142       binder:1447_4                 0
+1470    com.google.android.as            0
+1478       Signal Catcher                0
+1479       perfetto_hprof_               0
+1484       Jit thread pool               0
+1485       HeapTaskDaemon                0
+1487       ReferenceQueueD               0
+1488       FinalizerDaemon               0
+1489       FinalizerWatchd               0
+1490       binder:1470_1                 0
+1498       binder:1470_2                 0
+1502       binder:1470_3                 0
+1510       Profile Saver                 0
+1599       BG Thread #0                  0
+1603       android.bg                    0
+1610       aiai-speech-rs-               0
+1620       aiai-app-predic               0
+1621       arch_disk_io_0                0
+1631       WM.task-1                     0
+1640       arch_disk_io_1                0
+1654       arch_disk_io_2                0
+1656       arch_disk_io_3                0
+1764       WM.task-2                     0
+1765       superpacks-cont               0
+1768       aiai-speech-rs-               0
+1769       WM.task-3                     0
+1791       aiai-normal-sha               0
+1827       Background #0                 0
+1828       aiai-min-shared               0
+1829       binder:1470_4                 0
+1853       aiai-brella-0                 0
+1856       grpc-timer-0                  0
+1881       DefaultDispatch               0
+1882       DefaultDispatch               0
+1974       CameraManagerGl               0
+1978       binder:1470_5                 0
+1979       binder:1470_6                 0
+1997       aiai-sp-0                     0
+2025       aiai-nls-0                    0
+2049       aiai-tc-0                     0
+2056       aiai-captions-l               0
+2117       aiai-vc-0                     0
+2148       aiai-cc-datasha               0
+2153       aiai-pecan-0                  0
+2155       aiai-autofill-0               0
+2168       aiai-chronicle-               0
+2192       aiai-notificati               0
+2201       Background #1                 0
+2236       Background #2                 0
+2237       aiai-geller-0                 0
+2254       aiai-overview-0               0
+2292       aiai-captions-r               0
+2316       aiai-translate-               0
+2307       aiai-fedass-0                 0
+2364       binder:1470_9                 0
+2377       greco                         0
+2384       queued-work-loo               0
+2386       aiai-echo-searc               0
+2390       greco                         0
+2397       superpacks-serv               0
+2433       vkp-mediapipe-0               0
+2434       vkp-mediapipe-1               0
+2436       ocr_det_0                     0
+2437       ocr_det_0                     0
+2438       ocr_det_0                     0
+2439       ocr_segm                      0
+2440       ocr_segm                      0
+2441       ocr_segm                      0
+2442       ocr_segm                      0
+2443       ocr_segm                      0
+2444       ocr_segm                      0
+2665       binder:1470_A                 0
+2748       aiai-echo-searc               0
+2814       AsyncTask #1                  0
+2817       aiai-tulip-tts-               0
+3169       binder:1470_B                 0
+3362       aiai-echo-searc               0
+3363       aiai-echo-searc               0
+3776       WifiManagerThre               0
+1473    com.google.process.gapps         0
+1486       Signal Catcher                0
+1491       perfetto_hprof_               0
+1492       Jit thread pool               0
+1493       HeapTaskDaemon                0
+1494       ReferenceQueueD               0
+1495       FinalizerDaemon               0
+1496       FinalizerWatchd               0
+1497       binder:1473_1                 0
+1499       binder:1473_2                 0
+1529       binder:1473_3                 0
+1542       Profile Saver                 0
+4091       binder:1473_4                 0
+4494       binder:1473_5                 0
+4678       binder:1473_6                 0
+5015       binder:1473_7                 0
+5068       binder:1473_8                 0
+5179       binder:1473_9                 0
+5181       binder:1473_A                 0
+5686       binder:1473_B                 0
+1504    com.google.process.gservices     0
+1512       Signal Catcher                0
+1514       perfetto_hprof_               0
+1515       Jit thread pool               0
+1516       HeapTaskDaemon                0
+1517       ReferenceQueueD               0
+1518       FinalizerDaemon               0
+1519       FinalizerWatchd               0
+1520       binder:1504_1                 0
+1521       binder:1504_2                 0
+1534       binder:1504_3                 0
+1543       Profile Saver                 0
+1580       GoogleApiHandle               0
+2861       binder:1504_4                 0
+2875       binder:1504_5                 0
+2918       binder:1504_6                 0
+3238       binder:1504_7                 0
+3353       binder:1504_8                 0
+3526       binder:1504_9                 0
+3645       binder:1504_A                 0
+3662       binder:1504_B                 0
+3719       binder:1504_C                 0
+3831       binder:1504_D                 0
+4626       binder:1504_E                 0
+4665       binder:1504_F                 0
+4666       binder:1504_10                0
+1528    com.google.android.googlequicksearchbox:interactor 0
+1551       Signal Catcher                0
+1552       perfetto_hprof_               0
+1553       Jit thread pool               0
+1554       HeapTaskDaemon                0
+1555       ReferenceQueueD               0
+1556       FinalizerDaemon               0
+1557       FinalizerWatchd               0
+1559       binder:1528_1                 0
+1560       binder:1528_2                 0
+1616       binder:1528_3                 0
+1727       Profile Saver                 0
+1931       Blocking Thread               0
+1936       GoogleApiHandle               0
+1958       Blocking Thread               0
+1959       Lite Thread #0                0
+1971       Blocking Thread               0
+1976       Scheduler Threa               0
+1980       Primes-1                      0
+1981       Primes-nativecr               0
+1982       Primes-2                      0
+2121       BG Thread #0                  0
+2123       BG Thread #1                  0
+2151       BG Thread #2                  0
+2152       BG Thread #3                  0
+2166       Lite Thread #0                0
+2171       Lite Thread #1                0
+2240       android.bg                    0
+2808       binder:1528_4                 0
+5436       binder:1528_5                 0
+5485       binder:1528_6                 0
+5660       binder:1528_7                 0
+1540    com.google.android.apps.messaging:rcs 0
+1567       Signal Catcher                0
+1581       perfetto_hprof_               0
+1584       Jit thread pool               0
+1585       HeapTaskDaemon                0
+1588       ReferenceQueueD               0
+1589       FinalizerDaemon               0
+1590       FinalizerWatchd               0
+1591       binder:1540_1                 0
+1592       binder:1540_2                 0
+1623       binder:1540_3                 0
+1681       Profile Saver                 0
+1886       Blocking Thread               0
+1887       GoogleApiHandle               0
+1903       Blocking Thread               0
+1905       Scheduler Threa               0
+1907       BG Thread #0                  0
+1908       Primes-nativecr               0
+1915       Blocking Thread               0
+1916       BG Thread #1                  0
+2026       BG Thread #2                  0
+2138       pool-3-thread-1               0
+2144       BG Thread #3                  0
+2150       ConnectivityThr               0
+2177       AsyncTask #1                  0
+2193       queued-work-loo               0
+2347       Lite Thread #0                0
+2344       DG                            0
+2378       ProvisioningSta               0
+2454       SimStateTracker               0
+2569       RCS Engine Hand               0
+2680       binder:1540_4                 0
+3443       binder:1540_5                 0
+3445       binder:1540_6                 0
+5146       binder:1540_7                 0
+1561    com.android.emulator.multidisplay 0
+1571       Signal Catcher                0
+1572       perfetto_hprof_               0
+1573       Jit thread pool               0
+1574       HeapTaskDaemon                0
+1575       ReferenceQueueD               0
+1576       FinalizerDaemon               0
+1577       FinalizerWatchd               0
+1578       binder:1561_1                 0
+1583       binder:1561_2                 0
+1615       binder:1561_3                 0
+1653       Profile Saver                 0
+2798       MultiDisplaySer               0
+2799       queued-work-loo               0
+1624    com.android.vending              0
+1629       Signal Catcher                0
+1642       perfetto_hprof_               0
+1643       Jit thread pool               0
+1646       HeapTaskDaemon                0
+1647       ReferenceQueueD               0
+1648       FinalizerDaemon               0
+1649       FinalizerWatchd               0
+1650       binder:1624_1                 0
+1652       binder:1624_2                 0
+1724       Profile Saver                 0
+1814       Monitor Thread                0
+1857       LightweightExec               0
+1858       LightweightExec               0
+1859       LightweightExec               0
+1860       BlockingExecuto               0
+1861       BlockingExecuto               0
+1925       ProtoDataStore-               0
+1941       ValueStore-0                  0
+1953       FileObserver                  0
+1954       ValueStore-1                  0
+1955       ValueStore-2                  0
+1975       ValueStore-3                  0
+1983       Primes-1                      0
+2008       bgExecutor #0                 0
+2030       SequenceEventBu               0
+2075       Scheduler Threa               0
+2124       bgExecutor #1                 0
+2126       queued-work-loo               0
+2132       CronetInit                    0
+2145       FinskyApp                     0
+2154       bgExecutor #2                 0
+2161       ThreadPoolServi               0
+2162       ThreadPoolForeg               0
+2163       GoogleApiHandle               0
+2164       ChromiumNet                   0
+2182       BlockingExecuto               0
+2183       bgExecutor #3                 0
+2184       BlockingExecuto               0
+2187       ThreadPoolForeg               0
+2188       ThreadPoolForeg               0
+2194       Network File Th               0
+2202       Thread-2                      0
+2203       Thread-3                      0
+2204       Thread-4                      0
+2205       Thread-5                      0
+2206       Thread-6                      0
+2199       anmz                          0
+2213       Thread-7                      0
+2214       Thread-8                      0
+2215       Thread-9                      0
+2216       Thread-10                     0
+2225       Thread-11                     0
+2227       Db-scheduler_ma               0
+2229       tentative-gc-ru               0
+2232       FinskyEventLog                0
+2235       VerifyAppsDataS               0
+2241       BlockingExecuto               0
+2281       -verify_apps.db               0
+2317       AsyncTask #1                  0
+2318       binder:1624_3                 0
+2472       grpc-timer-0                  0
+2531       OkHttp Connecti               0
+2548       Okio Watchdog                 0
+2607       PhoneskySchedul               0
+2618       PackageInstalle               0
+2646       OkHttp Connecti               0
+2777       Primes-2                      0
+2779       ProcessStablePh               0
+2789       grpc-default-ex               0
+2802       grpc-default-ex               0
+2868       RefQueueWorker@               0
+3089       InstallQueueUsi               0
+3094       InstallQueueDat               0
+3598       errer_status.db               0
+3618       OkHttp Connecti               0
+3681       BackgroundThrea               0
+3682       BackgroundThrea               0
+3739       ExpressIntegrit               0
+3755       DG                            0
+3764       anmz                          0
+3769       AsyncQueryWorke               0
+3928       Verification th               0
+4093       binder:1624_4                 0
+4552       groundLogger.db               0
+4558       grpc-shared-des               0
+4559       esource_data.db               0
+4561       /streamstore.db               0
+4563       ller_data_v2.db               0
+4564       task_manager.db               0
+4565       fetcher_data.db               0
+4567       data_fetcher.db               0
+4568       ller_data_v2.db               0
+4579       cquire_store.db               0
+4615       grpc-default-ex               0
+4648       Db-work_main.db               0
+4652       process reaper                0
+4679       binder:1624_5                 0
+5472       ance_summary.db               0
+1632    android.process.acore            0
+1637       Signal Catcher                0
+1658       perfetto_hprof_               0
+1659       Jit thread pool               0
+1660       HeapTaskDaemon                0
+1661       ReferenceQueueD               0
+1662       FinalizerDaemon               0
+1663       FinalizerWatchd               0
+1664       binder:1632_1                 0
+1665       binder:1632_2                 0
+1718       Profile Saver                 0
+1914       queued-work-loo               0
+1999       binder:1632_3                 0
+2000       binder:1632_4                 0
+2805       binder:1632_5                 0
+2812       binder:1632_6                 0
+4477       Worker-1                      0
+4499       binder:1632_7                 0
+1655    com.google.android.apps.youtube.music 0
+1682       Signal Catcher                0
+1692       perfetto_hprof_               0
+1693       ADB-JDWP Connec               0
+1694       Jit thread pool               0
+1695       HeapTaskDaemon                0
+1696       ReferenceQueueD               0
+1697       FinalizerDaemon               0
+1698       FinalizerWatchd               0
+1701       binder:1655_1                 0
+1703       binder:1655_2                 0
+1736       binder:1655_3                 0
+1803       Profile Saver                 0
+1930       ScionFrontendAp               0
+1933       GmsDynamite                   0
+1939       Firebase-Messag               0
+1944       Firebase-Messag               0
+1946       Firebase Backgr               0
+1942       FirebaseInstanc               0
+2010       Blocking Thread               0
+2011       BG Thread #0                  0
+2012       Scheduler Threa               0
+2013       BG Thread #1                  0
+2014       yt-critical15-1               0
+2015       yt-critical15-2               0
+2017       BG Thread #2                  0
+2031       BG Thread #3                  0
+2032       BG Thread #4                  0
+2036       BG Thread #5                  0
+2053       BG Thread #6                  0
+2055       BG Thread #7                  0
+2059       BG Thread #8                  0
+2076       BG Thread #9                  0
+2078       BG Thread #11                 0
+2081       Primes-1                      0
+2086       Primes-2                      0
+2095       ProcessStablePh               0
+2097       GoogleApiHandle               0
+2102       BG Thread #10                 0
+2103       CronetInit                    0
+2128       WifiManagerThre               0
+2169       ThreadPoolServi               0
+2170       ThreadPoolForeg               0
+2172       ChromiumNet                   0
+2173       BG Thread #12                 0
+2174       ConnectivityThr               0
+2175       BG Thread #13                 0
+2180       BG Thread #15                 0
+2176       BG Thread #14                 0
+2185       ANRGuard-Thread               0
+2218       CsiReporter-0                 0
+2223       ThreadPoolForeg               0
+2226       Network File Th               0
+2228       ThreadPoolForeg               0
+2238       queued-work-loo               0
+2269       android.bg                    0
+2272       yt-critical15-3               0
+2273       yt-critical15-4               0
+2274       Lite Thread #0                0
+2312       FeedbackLogger                0
+2335       Blocking Thread               0
+2372       binder:1655_4                 0
+2628       Lite Thread #0                0
+2641       Lite Thread #1                0
+2941       gads-2                        0
+2945       Verification th               0
+2951       gads-6                        0
+3044       mediaReq18-1                  0
+3065       FrameworkPlayer               0
+3088       ExoPlayer:Frame               0
+3113       ExoPlayer:Playb               0
+3181       AudioPortEventH               0
+3198       unnamed                       0
+3220       Firebase Backgr               0
+3223       pool-20-thread-               0
+3231       Thread-28                     0
+3261       OkHttp Connecti               0
+3288       pool-21-thread-               0
+3294       pool-22-thread-               0
+3305       GAThread                      0
+3338       Okio Watchdog                 0
+3365       MessengerIpcCli               0
+1669    com.android.keychain             0
+1675       Signal Catcher                0
+1684       perfetto_hprof_               0
+1685       Jit thread pool               0
+1686       HeapTaskDaemon                0
+1687       ReferenceQueueD               0
+1688       FinalizerDaemon               0
+1689       FinalizerWatchd               0
+1690       binder:1669_1                 0
+1691       binder:1669_2                 0
+1816       binder:1669_3                 0
+1826       queued-work-loo               0
+1702    com.android.providers.calendar   0
+1717       Signal Catcher                0
+1735       perfetto_hprof_               0
+1743       Jit thread pool               0
+1752       HeapTaskDaemon                0
+1754       ReferenceQueueD               0
+1755       FinalizerDaemon               0
+1756       FinalizerWatchd               0
+1763       binder:1702_1                 0
+1780       binder:1702_2                 0
+1807       Profile Saver                 0
+2100       binder:1702_3                 0
+4500       binder:1702_4                 0
+4501       binder:1702_5                 0
+4514       queued-work-loo               0
+1705    com.google.android.gms           0
+1712       Signal Catcher                0
+1737       perfetto_hprof_               0
+1738       Jit thread pool               0
+1739       HeapTaskDaemon                0
+1740       ReferenceQueueD               0
+1741       FinalizerDaemon               0
+1742       FinalizerWatchd               0
+1744       binder:1705_1                 0
+1746       binder:1705_2                 0
+1750       binder:1705_3                 0
+1835       Profile Saver                 0
+2077       FileObserver                  0
+2198       highpool[0]                   0
+2209       GlobalDispatchi               0
+2210       GlobalScheduler               0
+2346       highpool[1]                   0
+2366       lowpool[1]                    0
+2392       GoogleApiHandle               0
+2487       binder:1705_4                 0
+2550       binder:1705_5                 0
+2615       highpool[2]                   0
+2616       highpool[3]                   0
+2633       binder:1705_6                 0
+2642       binder:1705_7                 0
+2682       lowpool[3]                    0
+2681       lowpool[2]                    0
+2707       Measurement Wor               0
+2728       queued-work-loo               0
+2764       binder:1705_8                 0
+2791       ice] processing               0
+2850       .BOOT_COMPLETED               0
+2874       pool-34-thread-               0
+2910       binder:1705_9                 0
+2932       DG                            0
+3229       OkHttp Connecti               0
+3282       Okio Watchdog                 0
+3337       arch_disk_io_0                0
+3377       AsyncTask #1                  0
+3384       binder:1705_A                 0
+3607       OkHttp Connecti               0
+3713       binder:1705_B                 0
+3858       lowpool[4]                    0
+4387       Thread-28                     0
+4388       Thread-29                     0
+4389       Thread-30                     0
+4390       Thread-31                     0
+4391       Thread-32                     0
+4449       WNLOAD_COMPLETE               0
+4450       -Executor] idle               0
+4497       pool-104-thread               0
+4527       binder:1705_C                 0
+4607       -Executor] idle               0
+4625       binder:1705_D                 0
+4647       ModuleProviderH               0
+4657       GoogleApiHandle               0
+4658       MLHandler                     0
+4669       GoogleApiHandle               0
+4674       MLHandler                     0
+4701       CronetInit                    0
+4702       ThreadPoolServi               0
+4703       ThreadPoolForeg               0
+4704       ChromiumNet                   0
+4705       ThreadPoolForeg               0
+4706       ThreadPoolForeg               0
+4707       Network File Th               0
+4711       binder:1705_E                 0
+4728       binder:1705_F                 0
+4730       binder:1705_10                0
+4906       ConnectivityThr               0
+4976       LIT-TimeoutSche               0
+5019       pool-179-thread               0
+5031       WifiManagerThre               0
+5100       ThreadPoolForeg               0
+5119       lowpool[6]                    0
+5413       lowpool[7]                    0
+1720    [kworker/3:4H-kverityd]          0
+1722    [kworker/3:5H-kverityd]          0
+1725    com.google.android.googlequicksearchbox:search 0
+1761       Signal Catcher                0
+1762       perfetto_hprof_               0
+1774       Jit thread pool               0
+1775       HeapTaskDaemon                0
+1776       ReferenceQueueD               0
+1777       FinalizerDaemon               0
+1778       FinalizerWatchd               0
+1779       binder:1725_1                 0
+1789       binder:1725_2                 0
+1855       Profile Saver                 0
+1885       binder:1725_3                 0
+2050       Blocking Thread               0
+2051       GoogleApiHandle               0
+2085       Lite Thread #0                0
+2088       Primes-1                      0
+2089       Primes-nativecr               0
+2090       Primes-2                      0
+2091       BG Thread #0                  0
+2108       Scheduler Threa               0
+2116       BG Thread #1                  0
+2119       BG Thread #2                  0
+2120       BG Thread #3                  0
+2125       SharedPreferenc               0
+2130       Lite Thread #0                0
+2133       Lite Thread #1                0
+2140       SharedPreferenc               0
+2165       SharedPreferenc               0
+2189       binder:1725_4                 0
+2230       Blocking Thread               0
+2242       queued-work-loo               0
+2267       RenderThread                  0
+2275       WifiManagerThre               0
+2276       GmsDynamite                   0
+2305       ConnectivityThr               0
+2369       android.bg                    0
+2488       CookieMonsterCl               0
+2489       CookieMonsterBa               0
+2540       Blocking Thread               0
+2553       Blocking Thread               0
+2557       Blocking Thread               0
+2560       Blocking Thread               0
+2561       Blocking Thread               0
+2562       ProtoDataStore-               0
+2566       Blocking Thread               0
+2575       Blocking Thread               0
+2606       CronetInit                    0
+2611       ThreadPoolServi               0
+2612       ThreadPoolForeg               0
+2617       ChromiumNet                   0
+2651       binder:1725_5                 0
+2656       ThreadPoolForeg               0
+2657       ThreadPoolForeg               0
+2664       ExoPlayer:Frame               0
+2696       Network File Th               0
+2702       ExoPlayer:Playb               0
+2745       binder:1725_6                 0
+2751       EventBus0                     0
+2754       TimerThread0                  0
+2758       glide-active-re               0
+2775       UserFacingBlock               0
+2778       SurfaceSyncGrou               0
+2792       hwuiTask0                     0
+2793       hwuiTask1                     0
+2800       SharedPreferenc               0
+2878       binder:1725_3                 0
+2911       binder:1725_7                 0
+2916       binder:1725_8                 0
+3268       binder:1725_9                 0
+3270       binder:1725_A                 0
+3272       binder:1725_B                 0
+3570       glide-disk-cach               0
+3584       glide-source-th               0
+3591       glide-source-th               0
+3592       CronetInit                    0
+3593       ThreadPoolServi               0
+3594       ThreadPoolForeg               0
+3595       ChromiumNet                   0
+3596       ThreadPoolForeg               0
+3597       ThreadPoolForeg               0
+3608       Cookies thread0               0
+3621       Network File Th               0
+3656       glide-animation               0
+3657       glide-animation               0
+3749       glide-source-th               0
+3750       glide-source-th               0
+3844       arch_disk_io_0                0
+3899       arch_disk_io_1                0
+4107       mdh-standalone-               0
+4510       UserFacingBlock               0
+4511       UserFacingBlock               0
+4512       UserFacingBlock               0
+4517       UserFacingBlock               0
+4520       UserFacingBlock               0
+4519       UserFacingBlock               0
+4555       arch_disk_io_2                0
+5073       GAC_Executor[0]               0
+5074       GAC_Executor[1]               0
+1766    com.google.android.youtube       0
+1788       Signal Catcher                0
+1790       perfetto_hprof_               0
+1794       Jit thread pool               0
+1795       HeapTaskDaemon                0
+1796       ReferenceQueueD               0
+1797       FinalizerDaemon               0
+1798       FinalizerWatchd               0
+1799       binder:1766_1                 0
+1801       binder:1766_2                 0
+1812       binder:1766_3                 0
+1884       Profile Saver                 0
+2179       Blocking Thread               0
+2234       BG Thread #0                  0
+2244       Scheduler Threa               0
+2262       yt-critical Thr               0
+2263       yt-critical Thr               0
+2264       yt-critical Thr               0
+2266       yt-critical Thr               0
+2279       GoogleApiHandle               0
+2280       BG Thread #1                  0
+2283       BG Thread #2                  0
+2284       BG Thread #3                  0
+2285       BG Thread #4                  0
+2286       BG Thread #5                  0
+2287       BG Thread #6                  0
+2288       WifiManagerThre               0
+2290       BG Thread #7                  0
+2291       BG Thread #8                  0
+2293       cronet-ui-inner               0
+2294       cronet-ui-inner               0
+2295       cronet-ui-inner               0
+2296       cronet-ui-inner               0
+2297       cronetPrio-ui-i               0
+2298       cronet-bg-inner               0
+2299       cronet-bg-inner               0
+2300       cronet-bg-inner               0
+2301       cronet-bg-inner               0
+2302       cronetPrio-bg-i               0
+2303       BG Thread #9                  0
+2304       BG Thread #10                 0
+2306       BG Thread #11                 0
+2309       BG Thread #12                 0
+2313       BG Thread #13                 0
+2319       GmsDynamite                   0
+2321       ConnectivityThr               0
+2327       cronet-netReque               0
+2332       cronet-netReque               0
+2334       cronet-netReque               0
+2340       cronet-netReque               0
+2361       cronetPrio-netR               0
+2396       Lite Thread #0                0
+2427       mediaReq11-1                  0
+2462       gads-1                        0
+2465       gads-3                        0
+2469       FrameworkPlayer               0
+2476       Verification th               0
+2502       binder:1766_4                 0
+2539       ExoPlayer:Frame               0
+2568       queued-work-loo               0
+2576       ExoPlayer:Playb               0
+2670       glide-active-re               0
+2684       CronetInit                    0
+2692       CsiReporter-0                 0
+2703       ThreadPoolServi               0
+2704       ThreadPoolForeg               0
+2705       ChromiumNet                   0
+2716       ThreadPoolForeg               0
+2717       ThreadPoolForeg               0
+2769       FileObserver                  0
+2771       Network File Th               0
+2835       Firebase-Messag               0
+2836       Firebase-Messag               0
+2837       Firebase Backgr               0
+2845       FirebaseInstanc               0
+2866       Lite Thread #0                0
+2870       Firebase Backgr               0
+2909       BG Thread #14                 0
+2914       OkHttp Connecti               0
+2980       Lite Thread #1                0
+2984       Okio Watchdog                 0
+2994       Blocking Thread               0
+2997       BG Thread #15                 0
+3038       MessengerIpcCli               0
+3271       binder:1766_5                 0
+3610       pool-28-thread-               0
+3649       Firebase-Messag               0
+5437       ProcessStablePh               0
+5466       binder:1766_6                 0
+1819    com.google.android.apps.messaging 0
+1843       Signal Catcher                0
+1844       perfetto_hprof_               0
+1846       Jit thread pool               0
+1847       HeapTaskDaemon                0
+1848       ReferenceQueueD               0
+1849       FinalizerDaemon               0
+1850       FinalizerWatchd               0
+1854       binder:1819_1                 0
+1883       binder:1819_2                 0
+1901       Profile Saver                 0
+1943       Blocking Thread               0
+1945       BG Thread #0                  0
+1947       BG Thread #1                  0
+1948       BG Thread #2                  0
+1949       GoogleApiHandle               0
+1956       Blocking Thread               0
+1961       Blocking Thread               0
+1962       Scheduler Threa               0
+1964       BG Thread #3                  0
+1965       Primes-nativecr               0
+1967       Blocking Thread               0
+1968       Blocking Thread               0
+2113       AsyncTask #1                  0
+2137       Lite Thread #0                0
+2282       Lite Thread #1                0
+2314       binder:1819_3                 0
+2323       Lite Thread #0                0
+2324       Blocking Thread               0
+2333       Blocking Thread               0
+2336       Blocking Thread               0
+2339       Blocking Thread               0
+2375       Blocking Thread               0
+2368       Blocking Thread               0
+2367       Blocking Thread               0
+2385       ConnectivityThr               0
+2873       OkHttp Connecti               0
+2894       Okio Watchdog                 0
+2897       binder:1819_4                 0
+3341       SimStateTracker               0
+3358       queued-work-loo               0
+3398       Firebase-Messag               0
+3399       Firebase-Messag               0
+3400       Firebase Backgr               0
+3413       FirebaseInstanc               0
+3418       Firebase Backgr               0
+3425       OkHttp Connecti               0
+3428       Okio Watchdog                 0
+3444       binder:1819_5                 0
+3447       MessengerIpcCli               0
+3543       DG                            0
+3550       GmsDynamite                   0
+3573       CronetInit                    0
+3574       ThreadPoolServi               0
+3575       ThreadPoolForeg               0
+3578       ThreadPoolForeg               0
+3579       ThreadPoolForeg               0
+3582       ChromiumNet                   0
+3585       grpc-timer-0                  0
+3650       Network File Th               0
+3660       grpc-default-ex               0
+3801       OkHttp Dispatch               0
+3807       OkHttp Connecti               0
+3809       OkHttp Dispatch               0
+3812       OkHttp Connecti               0
+3813       OkHttp Dispatch               0
+3824       OkHttp Connecti               0
+3853       binder:1819_6                 0
+3878       OkHttp Dispatch               0
+3884       OkHttp Connecti               0
+3887       OkHttp Dispatch               0
+3891       OkHttp Connecti               0
+4691       android.bg                    0
+4727       binder:1819_7                 0
+5405       binder:1819_8                 0
+1875    com.google.android.as.oss        0
+1913       Signal Catcher                0
+1917       perfetto_hprof_               0
+1918       Jit thread pool               0
+1919       HeapTaskDaemon                0
+1920       ReferenceQueueD               0
+1921       FinalizerDaemon               0
+1922       FinalizerWatchd               0
+1923       binder:1875_1                 0
+1924       binder:1875_2                 0
+2035       binder:1875_3                 0
+2104       Profile Saver                 0
+2383       grpc-timer-0                  0
+5669       queued-work-loo               0
+2052    com.android.localtransport       0
+2065       Signal Catcher                0
+2066       perfetto_hprof_               0
+2067       Jit thread pool               0
+2068       HeapTaskDaemon                0
+2069       ReferenceQueueD               0
+2070       FinalizerDaemon               0
+2071       FinalizerWatchd               0
+2072       binder:2052_1                 0
+2073       binder:2052_2                 0
+2074       binder:2052_3                 0
+2092       Profile Saver                 0
+2207       binder:2052_4                 0
+2208       queued-work-loo               0
+2243    com.google.android.deskclock     0
+2251       Signal Catcher                0
+2253       perfetto_hprof_               0
+2255       Jit thread pool               0
+2256       HeapTaskDaemon                0
+2257       ReferenceQueueD               0
+2258       FinalizerDaemon               0
+2259       FinalizerWatchd               0
+2260       binder:2243_1                 0
+2261       binder:2243_2                 0
+2414       Profile Saver                 0
+2497       queued-work-loo               0
+2614       binder:2243_3                 0
+2653       Primes-1                      0
+2658       Analytics Threa               0
+2659       GoogleApiHandle               0
+3121       Primes-2                      0
+3124       Alarm                         0
+3127       ProcessStablePh               0
+2289    com.android.chrome               0
+2331       Signal Catcher                0
+2345       perfetto_hprof_               0
+2356       Jit thread pool               0
+2357       HeapTaskDaemon                0
+2358       ReferenceQueueD               0
+2359       FinalizerDaemon               0
+2360       FinalizerWatchd               0
+2362       binder:2289_1                 0
+2380       binder:2289_2                 0
+2395       Profile Saver                 0
+2741       queued-work-loo               0
+2750       SAFE_BROWSING_U               0
+2781       GoogleApiHandle               0
+2796       binder:2289_3                 0
+2807       GmsDynamite                   0
+2841       HangWatcher                   0
+2844       ThreadPoolServi               0
+2846       ThreadPoolForeg               0
+2847       ThreadPoolForeg               0
+2896       ThreadPoolForeg               0
+2898       Chrome_IOThread               0
+2899       MemoryInfra                   0
+2912       binder:2289_4                 0
+3000       ThreadPoolForeg               0
+3001       ThreadPoolForeg               0
+3002       ThreadPoolForeg               0
+3003       AudioThread                   0
+3004       VideoCaptureThr               0
+3005       NetworkService                0
+3006       ThreadPoolSingl               0
+3030       ThreadPoolSingl               0
+3172       android.bg                    0
+3197       ThreadPoolSingl               0
+3354       binder:2289_5                 0
+3364       NetworkStatusLi               0
+3864       Chrome_ProcessL               0
+3982       binder:2289_6                 0
+2409    [kworker/3:6H-kverityd]          0
+2500    com.google.android.webview:webview_service 0
+2509       Signal Catcher                0
+2510       perfetto_hprof_               0
+2512       Jit thread pool               0
+2513       HeapTaskDaemon                0
+2534       ReferenceQueueD               0
+2535       FinalizerDaemon               0
+2536       FinalizerWatchd               0
+2537       binder:2500_1                 0
+2538       binder:2500_2                 0
+2605       Profile Saver                 0
+2852       binder:2500_3                 0
+2853       queued-work-loo               0
+2858       seed_holder                   0
+5143       binder:2500_4                 0
+2567    com.android.vending:background   0
+2574       Signal Catcher                0
+2579       perfetto_hprof_               0
+2580       Jit thread pool               0
+2581       HeapTaskDaemon                0
+2582       ReferenceQueueD               0
+2583       FinalizerDaemon               0
+2584       FinalizerWatchd               0
+2585       binder:2567_1                 0
+2589       binder:2567_2                 0
+2648       binder:2567_3                 0
+2660       Profile Saver                 0
+2694       Monitor Thread                0
+2695       ProtoDataStore-               0
+2697       ValueStore-0                  0
+2698       FileObserver                  0
+2699       ValueStore-1                  0
+2700       ValueStore-2                  0
+2706       ValueStore-3                  0
+2806       Db-download_ser               0
+2824       DownloadService               0
+2926       ConnectivityThr               0
+2942       Db-scheduler_ba               0
+2948       bgExecutor #0                 0
+2992       bgExecutor #1                 0
+2998       bgExecutor #2                 0
+3007       bgExecutor #3                 0
+3257       PhoneskySchedul               0
+3260       LightweightExec               0
+3280       BlockingExecuto               0
+3281       Scheduler Threa               0
+3350       OkHttp Connecti               0
+3356       Okio Watchdog                 0
+3440       queued-work-loo               0
+3514       binder:2567_4                 0
+3622       LightweightExec               0
+3644       LightweightExec               0
+3754       anmz                          0
+4576       binder:2567_5                 0
+4601       OkHttp Connecti               0
+2590    com.google.android.apps.wallpaper 0
+2596       Signal Catcher                0
+2597       perfetto_hprof_               0
+2598       Jit thread pool               0
+2599       HeapTaskDaemon                0
+2600       ReferenceQueueD               0
+2601       FinalizerDaemon               0
+2602       FinalizerWatchd               0
+2603       binder:2590_1                 0
+2613       binder:2590_2                 0
+2671       Profile Saver                 0
+2724       binder:2590_3                 0
+2725       binder:2590_4                 0
+2620    com.google.android.tts           0
+2625       Signal Catcher                0
+2632       perfetto_hprof_               0
+2634       Jit thread pool               0
+2635       HeapTaskDaemon                0
+2636       ReferenceQueueD               0
+2637       FinalizerDaemon               0
+2638       FinalizerWatchd               0
+2639       binder:2620_1                 0
+2647       binder:2620_2                 0
+2677       binder:2620_3                 0
+2687       Profile Saver                 0
+2709       Blocking Thread               0
+2710       BG Thread #0                  0
+2711       Scheduler Threa               0
+2726       GoogleApiHandle               0
+2735       Blocking Thread               0
+2739       Blocking Thread               0
+2743       voice-downloade               0
+2746       Blocking Thread               0
+2747       superpacks-cont               0
+2813       BG Thread #1                  0
+2823       superpacks-task               0
+2893       Blocking Thread               0
+2900       p dl.google.com               0
+2901       OkHttp Connecti               0
+2904       ogle.com Writer               0
+3170       binder:2620_4                 0
+3184       BG Thread #2                  0
+3185       BG Thread #3                  0
+3186       Blocking Thread               0
+3237       queued-work-loo               0
+3388       Lite Thread #0                0
+3389       Lite Thread #1                0
+4007       Lite Thread #0                0
+4106       CronetInit                    0
+4108       ThreadPoolServi               0
+4109       ThreadPoolForeg               0
+4110       ChromiumNet                   0
+4111       ThreadPoolForeg               0
+4112       ThreadPoolForeg               0
+4113       Network File Th               0
+4328       binder:2620_5                 0
+5776       binder:2620_6                 0
+2749    com.google.android.projection.gearhead:shared 0
+2763       Signal Catcher                0
+2765       perfetto_hprof_               0
+2766       ADB-JDWP Connec               0
+2767       Jit thread pool               0
+2768       HeapTaskDaemon                0
+2772       ReferenceQueueD               0
+2773       FinalizerDaemon               0
+2774       FinalizerWatchd               0
+2776       binder:2749_1                 0
+2780       binder:2749_2                 0
+2795       binder:2749_3                 0
+2801       Profile Saver                 0
+2943       GoogleApiHandle               0
+3193       queued-work-loo               0
+4392       binder:2749_4                 0
+5661       ProcessStablePh               0
+5672       binder:2749_5                 0
+2877    com.google.android.gm            0
+2883       Signal Catcher                0
+2884       perfetto_hprof_               0
+2885       ADB-JDWP Connec               0
+2886       Jit thread pool               0
+2887       HeapTaskDaemon                0
+2888       ReferenceQueueD               0
+2889       FinalizerDaemon               0
+2890       FinalizerWatchd               0
+2891       binder:2877_1                 0
+2892       binder:2877_2                 0
+2913       binder:2877_3                 0
+2921       Profile Saver                 0
+2972       queued-work-loo               0
+3011       Blocking Thread               0
+3017       GoogleApiHandle               0
+3026       Primes-1                      0
+3027       Primes-2                      0
+3028       Primes-nativecr               0
+3032       Lite Thread #0                0
+3033       Blocking Thread               0
+3034       BG Thread #0                  0
+3035       BG Thread #1                  0
+3048       Blocking Thread               0
+3052       Blocking Thread               0
+3053       Blocking Thread               0
+3054       Blocking Thread               0
+3061       Blocking Thread               0
+3062       Blocking Thread               0
+3073       Blocking Thread               0
+3074       Blocking Thread               0
+3075       BG Thread #2                  0
+3077       Scheduler Threa               0
+3082       BG Thread #3                  0
+3092       BackgroundSingl               0
+3098       ProtoDataStore-               0
+3104       GmsDynamite                   0
+3152       Lite Thread #0                0
+3164       Firebase-Messag               0
+3165       Firebase-Messag               0
+3166       Firebase Backgr               0
+3177       Lite Thread #1                0
+3196       FirebaseInstanc               0
+3215       AsyncTask #3                  0
+3227       Firebase Backgr               0
+3228       gm counters ini               0
+3248       OkHttp Connecti               0
+3273       Okio Watchdog                 0
+3274       EmailNotificati               0
+3289       arch_disk_io_0                0
+3295       MessengerIpcCli               0
+3527       binder:2877_4                 0
+3577       arch_disk_io_1                0
+3845       MailIntentServi               0
+3863       BaseWidgetProvi               0
+3865       android.bg                    0
+3866       pool-10-thread-               0
+4281       GoogleMailSwitc               0
+4336       EmailBroadcastP               0
+4400       arch_disk_io_2                0
+4401       CronetInit                    0
+4417       ThreadPoolServi               0
+4418       ThreadPoolForeg               0
+4424       ThreadPoolForeg               0
+4425       ThreadPoolForeg               0
+4427       ChromiumNet                   0
+4429       Network File Th               0
+4446       arch_disk_io_3                0
+4493       binder:2877_5                 0
+2934    com.google.android.contacts      0
+2939       Signal Catcher                0
+2970       perfetto_hprof_               0
+2971       ADB-JDWP Connec               0
+2973       Jit thread pool               0
+2974       HeapTaskDaemon                0
+2975       ReferenceQueueD               0
+2976       FinalizerDaemon               0
+2977       FinalizerWatchd               0
+2978       binder:2934_1                 0
+2979       binder:2934_2                 0
+2987       binder:2934_3                 0
+2989       Profile Saver                 0
+3010       Primes-1                      0
+3022       Scheduling thre               0
+3031       GoogleApiHandle               0
+3037       ProcessStablePh               0
+3051       queued-work-loo               0
+3253       AsyncTask #1                  0
+3265       arch_disk_io_0                0
+3386       binder:2934_4                 0
+3471       DefaultDispatch               0
+3472       DefaultDispatch               0
+3528       arch_disk_io_1                0
+4013       binder:2934_5                 0
+4504       binder:2934_6                 0
+3014    /system/bin/sh                   sigsuspend
+3016    logcat                           __skb_wait_for_more_packets
+3045    com.google.android.gms.unstable  0
+3063       Signal Catcher                0
+3064       perfetto_hprof_               0
+3066       Jit thread pool               0
+3067       HeapTaskDaemon                0
+3068       ReferenceQueueD               0
+3069       FinalizerDaemon               0
+3070       FinalizerWatchd               0
+3071       binder:3045_1                 0
+3072       binder:3045_2                 0
+3178       Profile Saver                 0
+3290       FileObserver                  0
+3325       highpool[0]                   0
+3326       GlobalDispatchi               0
+3327       GlobalScheduler               0
+3349       lowpool[0]                    0
+3371       highpool[1]                   0
+3376       GoogleApiHandle               0
+3379       binder:3045_3                 0
+3385       binder:3045_4                 0
+3391       highpool[2]                   0
+3393       CronetInit                    0
+3394       ThreadPoolServi               0
+3395       ThreadPoolForeg               0
+3397       ChromiumNet                   0
+3401       highpool[3]                   0
+3407       lowpool[1]                    0
+3408       lowpool[2]                    0
+3419       ThreadPoolForeg               0
+3420       ThreadPoolForeg               0
+3435       Network File Th               0
+3442       lowpool[3]                    0
+3446       binder:3045_5                 0
+3503       Verification th               0
+3576       queued-work-loo               0
+3720       binder:3045_6                 0
+3834       binder:3045_7                 0
+3835       binder:3045_8                 0
+3081    /system/bin/sh                   sigsuspend
+3086    logcat                           __skb_wait_for_more_packets
+3103    /system/bin/sh                   sigsuspend
+3108    logcat                           __skb_wait_for_more_packets
+3116    /system/bin/sh                   sigsuspend
+3123    logcat                           __skb_wait_for_more_packets
+3130    /system/bin/sh                   sigsuspend
+3133    logcat                           __skb_wait_for_more_packets
+3139    /system/bin/sh                   sigsuspend
+3144    logcat                           __skb_wait_for_more_packets
+3309    com.android.imsserviceentitlement 0
+3314       Signal Catcher                0
+3328       perfetto_hprof_               0
+3329       Jit thread pool               0
+3330       HeapTaskDaemon                0
+3331       ReferenceQueueD               0
+3332       FinalizerDaemon               0
+3333       FinalizerWatchd               0
+3335       binder:3309_1                 0
+3336       binder:3309_2                 0
+3343       Profile Saver                 0
+3405       binder:3309_3                 0
+4180       AsyncTask #1                  0
+4209       binder:3309_4                 0
+4220       queued-work-loo               0
+3448    com.android.carrierdefaultapp    0
+3453       Signal Catcher                0
+3460       perfetto_hprof_               0
+3461       Jit thread pool               0
+3462       HeapTaskDaemon                0
+3463       ReferenceQueueD               0
+3464       FinalizerDaemon               0
+3465       FinalizerWatchd               0
+3466       binder:3448_1                 0
+3467       binder:3448_2                 0
+3487       Profile Saver                 0
+3525    com.google.android.rkpdapp       0
+3533       Signal Catcher                0
+3534       perfetto_hprof_               0
+3535       Jit thread pool               0
+3536       HeapTaskDaemon                0
+3537       ReferenceQueueD               0
+3538       FinalizerDaemon               0
+3539       FinalizerWatchd               0
+3540       binder:3525_1                 0
+3541       binder:3525_2                 0
+3547       binder:3525_3                 0
+3549       Profile Saver                 0
+3553       WM.task-1                     0
+3667       ConnectivityThr               0
+3669       WM.task-2                     0
+3670       WM.task-3                     0
+3671       androidx.work-1               0
+3673       pool-2-thread-1               0
+3676       queued-work-loo               0
+3680       OkHttp Connecti               0
+3684       Okio Watchdog                 0
+3700       pool-2-thread-2               0
+3701       pool-2-thread-3               0
+3717       pool-2-thread-4               0
+3782       binder:3525_4                 0
+4436       androidx.work-2               0
+3554    com.google.android.settings.intelligence 0
+3559       Signal Catcher                0
+3560       perfetto_hprof_               0
+3562       Jit thread pool               0
+3563       HeapTaskDaemon                0
+3564       ReferenceQueueD               0
+3565       FinalizerDaemon               0
+3566       FinalizerWatchd               0
+3568       binder:3554_1                 0
+3571       binder:3554_2                 0
+3580       binder:3554_3                 0
+3587       Profile Saver                 0
+3590       WM.task-1                     0
+3609       GoogleApiHandle               0
+3672       WM.task-2                     0
+3691       WifiManagerThre               0
+3714       queued-work-loo               0
+3716       rvcDelegateImpl               0
+3718       AsyncTask #1                  0
+3723       pool-2-thread-1               0
+3724       arch_disk_io_0                0
+3748       pool-3-thread-1               0
+3762       arch_disk_io_1                0
+3763       arch_disk_io_2                0
+3775       arch_disk_io_3                0
+3778       binder:3554_4                 0
+4530       binder:3554_5                 0
+4562       android.bg                    0
+4590       IndexHandlerThr               0
+4595       pool-5-thread-1               0
+4596       pool-5-thread-2               0
+4597       pool-5-thread-3               0
+4598       pool-5-thread-4               0
+4599       pool-5-thread-5               0
+4600       pool-5-thread-6               0
+4633       Lite Thread #0                0
+4646       Lite Thread #1                0
+4710       binder:3554_6                 0
+4741       pool-5-thread-7               0
+4742       pool-5-thread-8               0
+4745       pool-5-thread-9               0
+4749       pool-5-thread-1               0
+4751       pool-5-thread-1               0
+4752       pool-5-thread-1               0
+4755       pool-5-thread-1               0
+4756       pool-5-thread-1               0
+4761       pool-5-thread-1               0
+4905       binder:3554_7                 0
+4916       binder:3554_8                 0
+5005       binder:3554_9                 0
+5040       pool-6-thread-1               0
+5235       binder:3554_A                 0
+5379       pool-8-thread-1               0
+5467       ProcessStablePh               0
+5479       pool-10-thread-               0
+5480       pool-10-thread-               0
+5481       GmsDynamite                   0
+5486       pool-10-thread-               0
+5487       pool-10-thread-               0
+5500       ProcessStablePh               0
+5511       GoogleApiHandle               0
+5635       brella-pds-0                  0
+5640       AsyncTask #6                  0
+5671       binder:3554_B                 0
+5683       AsyncTask #7                  0
+3612    com.android.vending:quick_launch 0
+3630       Signal Catcher                0
+3631       perfetto_hprof_               0
+3632       Jit thread pool               0
+3633       HeapTaskDaemon                0
+3634       ReferenceQueueD               0
+3635       FinalizerDaemon               0
+3636       FinalizerWatchd               0
+3637       binder:3612_1                 0
+3639       binder:3612_2                 0
+3647       binder:3612_3                 0
+3652       Profile Saver                 0
+3658       Monitor Thread                0
+3659       ProtoDataStore-               0
+3661       ValueStore-0                  0
+3663       FileObserver                  0
+3664       ValueStore-1                  0
+3665       ValueStore-2                  0
+3666       ValueStore-3                  0
+3688       Scheduler Threa               0
+3689       LightweightExec               0
+3690       bgExecutor #0                 0
+3692       LightweightExec               0
+3696       LightweightExec               0
+3697       bgExecutor #1                 0
+3702       bgExecutor #2                 0
+3703       BlockingExecuto               0
+3707       OkHttp Connecti               0
+3710       Okio Watchdog                 0
+3715       bgExecutor #3                 0
+3756       queued-work-loo               0
+3761       anmz                          0
+3783    com.google.android.dialer        0
+3790       Signal Catcher                0
+3791       perfetto_hprof_               0
+3792       Jit thread pool               0
+3793       HeapTaskDaemon                0
+3794       ReferenceQueueD               0
+3795       FinalizerDaemon               0
+3796       FinalizerWatchd               0
+3797       binder:3783_1                 0
+3799       binder:3783_2                 0
+3806       Profile Saver                 0
+3816       Blocking Thread               0
+3817       Scheduler Threa               0
+3818       BG Thread #0                  0
+3819       GoogleApiHandle               0
+3820       BG Thread #1                  0
+3821       Lite Thread #0                0
+3822       BG Thread #2                  0
+3823       Blocking Thread               0
+3825       Blocking Thread               0
+3826       Lite Thread #1                0
+3827       BG Thread #3                  0
+3828       Blocking Thread               0
+3832       Lite Thread #0                0
+3836       binder:3783_3                 0
+3847       binder:3783_4                 0
+3848       binder:3783_5                 0
+3850       Blocking Thread               0
+3852       binder:3783_6                 0
+3971       ConnectivityThr               0
+4006       DG                            0
+4042       queued-work-loo               0
+4094       AsyncQueryWorke               0
+4101       Blocking Thread               0
+4102       Blocking Thread               0
+3981    com.android.traceur              0
+3987       Signal Catcher                0
+3988       perfetto_hprof_               0
+3994       Jit thread pool               0
+3995       HeapTaskDaemon                0
+3996       ReferenceQueueD               0
+3997       FinalizerDaemon               0
+3998       FinalizerWatchd               0
+3999       binder:3981_1                 0
+4008       binder:3981_2                 0
+4011       Profile Saver                 0
+4748       binder:3981_3                 0
+4023    com.google.android.onetimeinitializer 0
+4028       Signal Catcher                0
+4029       perfetto_hprof_               0
+4030       Jit thread pool               0
+4031       HeapTaskDaemon                0
+4032       ReferenceQueueD               0
+4033       FinalizerDaemon               0
+4034       FinalizerWatchd               0
+4035       binder:4023_1                 0
+4036       binder:4023_2                 0
+4041       Profile Saver                 0
+4046    com.android.externalstorage      0
+4051       Signal Catcher                0
+4052       perfetto_hprof_               0
+4053       Jit thread pool               0
+4054       HeapTaskDaemon                0
+4055       ReferenceQueueD               0
+4056       FinalizerDaemon               0
+4057       FinalizerWatchd               0
+4058       binder:4046_1                 0
+4062       binder:4046_2                 0
+4064       Profile Saver                 0
+4085       binder:4046_3                 0
+4067    android.process.media            0
+4075       Signal Catcher                0
+4076       perfetto_hprof_               0
+4077       Jit thread pool               0
+4078       HeapTaskDaemon                0
+4079       ReferenceQueueD               0
+4080       FinalizerDaemon               0
+4081       FinalizerWatchd               0
+4082       binder:4067_1                 0
+4083       binder:4067_2                 0
+4087       Profile Saver                 0
+4100       binder:4067_3                 0
+4103       sAsyncHandlerTh               0
+4495       binder:4067_4                 0
+5016       binder:4067_5                 0
+5025       OkHttp Connecti               0
+5026       Okio Watchdog                 0
+5033       queued-work-loo               0
+5064       OkHttp Connecti               0
+4120    com.android.vending:instant_app_installer 0
+4125       Signal Catcher                0
+4126       perfetto_hprof_               0
+4127       Jit thread pool               0
+4128       HeapTaskDaemon                0
+4129       ReferenceQueueD               0
+4130       FinalizerDaemon               0
+4131       FinalizerWatchd               0
+4132       binder:4120_1                 0
+4133       binder:4120_2                 0
+4136       binder:4120_3                 0
+4139       Profile Saver                 0
+4149       bg-1                          0
+4151       queued-work-loo               0
+4152       RxSchedulerPurg               0
+4153       RxCachedWorkerP               0
+4157       bg-2                          0
+4179       GmsConnection                 0
+4181       GAC_Executor[0]               0
+4207       bg-3                          0
+4208       bg-4                          0
+4246       GoogleApiHandle               0
+4252       GAC_Executor[1]               0
+4305       AsyncTask #3                  0
+4307       fg-1                          0
+4308       binder:4120_4                 0
+4327       anmz                          0
+4346       OkHttp Connecti               0
+4366       Okio Watchdog                 0
+4732       binder:4120_5                 0
+5795       binder:4120_1                 0
+4148    com.android.camera2              0
+4162       Signal Catcher                0
+4163       perfetto_hprof_               0
+4168       Jit thread pool               0
+4169       HeapTaskDaemon                0
+4170       ReferenceQueueD               0
+4171       FinalizerDaemon               0
+4172       FinalizerWatchd               0
+4173       binder:4148_1                 0
+4174       binder:4148_2                 0
+4178       Profile Saver                 0
+4175    com.android.dynsystem            0
+4186       Signal Catcher                0
+4187       perfetto_hprof_               0
+4188       Jit thread pool               0
+4189       HeapTaskDaemon                0
+4190       ReferenceQueueD               0
+4191       FinalizerDaemon               0
+4192       FinalizerWatchd               0
+4193       binder:4175_1                 0
+4194       binder:4175_2                 0
+4203       binder:4175_3                 0
+4206       Profile Saver                 0
+4210    com.android.dynsystem:dynsystem  0
+4218       Signal Catcher                0
+4219       perfetto_hprof_               0
+4226       Jit thread pool               0
+4227       HeapTaskDaemon                0
+4228       ReferenceQueueD               0
+4229       FinalizerDaemon               0
+4230       FinalizerWatchd               0
+4231       binder:4210_1                 0
+4242       binder:4210_2                 0
+4248       binder:4210_3                 0
+4250       Profile Saver                 0
+4256       queued-work-loo               0
+4213    com.android.managedprovisioning  0
+4225       Signal Catcher                0
+4232       perfetto_hprof_               0
+4236       Jit thread pool               0
+4237       HeapTaskDaemon                0
+4238       ReferenceQueueD               0
+4239       FinalizerDaemon               0
+4240       FinalizerWatchd               0
+4244       binder:4213_1                 0
+4245       binder:4213_2                 0
+4249       binder:4213_3                 0
+4255       Profile Saver                 0
+4258    com.android.shell                0
+4263       Signal Catcher                0
+4265       perfetto_hprof_               0
+4266       Jit thread pool               0
+4267       HeapTaskDaemon                0
+4268       ReferenceQueueD               0
+4269       FinalizerDaemon               0
+4270       FinalizerWatchd               0
+4271       binder:4258_1                 0
+4272       binder:4258_2                 0
+4277       Profile Saver                 0
+4290       AsyncTask #1                  0
+4279    com.google.android.configupdater 0
+4294       Signal Catcher                0
+4295       perfetto_hprof_               0
+4296       Jit thread pool               0
+4297       HeapTaskDaemon                0
+4298       ReferenceQueueD               0
+4299       FinalizerDaemon               0
+4300       FinalizerWatchd               0
+4301       binder:4279_1                 0
+4302       binder:4279_2                 0
+4304       Profile Saver                 0
+4954       binder:4279_3                 0
+4955       AsyncTask #1                  0
+4956       binder:4279_4                 0
+4957       queued-work-loo               0
+5218       GoogleApiHandle               0
+4309    com.google.android.packageinstaller 0
+4315       Signal Catcher                0
+4316       perfetto_hprof_               0
+4317       Jit thread pool               0
+4318       HeapTaskDaemon                0
+4319       ReferenceQueueD               0
+4320       FinalizerDaemon               0
+4321       FinalizerWatchd               0
+4322       binder:4309_1                 0
+4323       binder:4309_2                 0
+4333       Profile Saver                 0
+4347    com.google.android.partnersetup  0
+4352       Signal Catcher                0
+4355       perfetto_hprof_               0
+4356       Jit thread pool               0
+4357       HeapTaskDaemon                0
+4358       ReferenceQueueD               0
+4359       FinalizerDaemon               0
+4360       FinalizerWatchd               0
+4361       binder:4347_1                 0
+4363       binder:4347_2                 0
+4371       Profile Saver                 0
+4439       queued-work-loo               0
+4462       GoogleApiHandle               0
+4623       binder:4347_3                 0
+4634       binder:4347_4                 0
+4731       binder:4347_5                 0
+5747       ProcessStablePh               0
+4404    com.google.android.adservices.api 0
+4410       Signal Catcher                0
+4411       perfetto_hprof_               0
+4412       Jit thread pool               0
+4413       HeapTaskDaemon                0
+4414       ReferenceQueueD               0
+4415       FinalizerDaemon               0
+4416       FinalizerWatchd               0
+4419       binder:4404_1                 0
+4422       binder:4404_2                 0
+4438       Profile Saver                 0
+4478       background-1                  0
+4484       pool-3-thread-1               0
+4485       binder:4404_3                 0
+4486       pool-3-thread-2               0
+4487       pool-3-thread-3               0
+4488       pool-3-thread-4               0
+4489       binder:4404_4                 0
+4490       pool-3-thread-5               0
+4498       background-2                  0
+4680       binder:4404_5                 0
+4743    com.android.emergency            0
+4766       Signal Catcher                0
+4768       perfetto_hprof_               0
+4769       Jit thread pool               0
+4770       HeapTaskDaemon                0
+4771       ReferenceQueueD               0
+4772       FinalizerDaemon               0
+4773       FinalizerWatchd               0
+4780       binder:4743_1                 0
+4781       binder:4743_2                 0
+4836       Profile Saver                 0
+4794    com.google.android.gms.ui        0
+4801       Signal Catcher                0
+4802       perfetto_hprof_               0
+4803       Jit thread pool               0
+4804       HeapTaskDaemon                0
+4805       ReferenceQueueD               0
+4806       FinalizerDaemon               0
+4807       FinalizerWatchd               0
+4808       binder:4794_1                 0
+4817       binder:4794_2                 0
+4824       Profile Saver                 0
+4907       FileObserver                  0
+4908       binder:4794_3                 0
+4909       binder:4794_4                 0
+4912       pool-7-thread-1               0
+4927       highpool[0]                   0
+4928       GlobalScheduler               0
+4929       GlobalDispatchi               0
+4931       ice] processing               0
+4932       queued-work-loo               0
+4938       highpool[1]                   0
+4939       highpool[2]                   0
+4940       GoogleApiHandle               0
+4942       highpool[3]                   0
+4947       pool-17-thread-               0
+4952       binder:4794_5                 0
+5017       binder:4794_6                 0
+5732       -Executor] idle               0
+5735       -Executor] idle               0
+5736       -Executor] idle               0
+5737       -Executor] idle               0
+5738       -Executor] idle               0
+5741       -Executor] idle               0
+5742       -Executor] idle               0
+5743       -Executor] idle               0
+4828    com.google.android.healthconnect.controller 0
+4853       Signal Catcher                0
+4854       perfetto_hprof_               0
+4857       Jit thread pool               0
+4858       HeapTaskDaemon                0
+4859       ReferenceQueueD               0
+4860       FinalizerDaemon               0
+4861       FinalizerWatchd               0
+4862       binder:4828_1                 0
+4863       binder:4828_2                 0
+4874       binder:4828_3                 0
+4891       Profile Saver                 0
+5010       binder:4828_4                 0
+5085    bugreportz                       unix_stream_read_generic
+5088    /system/bin/dumpstate            0
+5488       dumpstate_1                   futex_wait
+5489       dumpstate_2                   do_sigtimedwait
+5490       dumpstate_3                   futex_wait
+5127    com.google.android.apps.photos   0
+5132       Signal Catcher                0
+5134       perfetto_hprof_               0
+5137       Jit thread pool               0
+5138       HeapTaskDaemon                0
+5139       ReferenceQueueD               0
+5140       FinalizerDaemon               0
+5141       FinalizerWatchd               0
+5145       binder:5127_1                 0
+5147       binder:5127_2                 0
+5151       Profile Saver                 0
+5160       ptz-scheduled                 0
+5161       Primes-1                      0
+5163       ptz-ui-1                      0
+5180       ptz-ui-2                      0
+5183       glide-active-re               0
+5185       ConnectivityThr               0
+5193       binder:5127_3                 0
+5194       GoogleApiHandle               0
+5202       binder:5127_4                 0
+5210       ptz-ui-3                      0
+5211       ptz-ui-4                      0
+5212       queued-work-loo               0
+5216       GmsDynamite                   0
+5242       ptz-fgd-1                     0
+5439       ProcessStablePh               0
+5465       binder:5127_5                 0
+5184    com.google.android.googlequicksearchbox 0
+5191       Signal Catcher                0
+5195       perfetto_hprof_               0
+5196       Jit thread pool               0
+5197       HeapTaskDaemon                0
+5198       ReferenceQueueD               0
+5199       FinalizerDaemon               0
+5200       FinalizerWatchd               0
+5203       binder:5184_1                 0
+5204       binder:5184_2                 0
+5206       binder:5184_3                 0
+5214       Profile Saver                 0
+5222       pool-3-thread-1               0
+5224       queued-work-loo               0
+5226       Blocking Thread               0
+5227       GoogleApiHandle               0
+5233       Blocking Thread               0
+5234       Lite Thread #0                0
+5236       Blocking Thread               0
+5237       Primes-1                      0
+5238       Primes-nativecr               0
+5239       Primes-2                      0
+5327       Scheduler Threa               0
+5404       binder:5184_4                 0
+5473       BG Thread #0                  0
+5474       BG Thread #1                  0
+5475       BG Thread #2                  0
+5476       Lite Thread #0                0
+5477       BG Thread #3                  0
+5478       Lite Thread #1                0
+5254    [kworker/3:7H-kverityd]          0
+5255    [kworker/3:8H-kverityd]          0
+5441    com.google.android.webview       0
+5446       Signal Catcher                0
+5447       perfetto_hprof_               0
+5448       Jit thread pool               0
+5449       HeapTaskDaemon                0
+5450       ReferenceQueueD               0
+5451       FinalizerDaemon               0
+5452       FinalizerWatchd               0
+5454       binder:5441_1                 0
+5455       binder:5441_2                 0
+5458       binder:5441_3                 0
+5459       Profile Saver                 0
+5492    incident                         pipe_wait_readable
+5496       binder:5492_1                 binder_ioctl_write_read
+5497       binder:5492_3                 binder_ioctl_write_read
+5508       binder:5492_4                 binder_ioctl_write_read
+5502    /vendor/bin/hw/android.hardware.dumpstate-service.example 0
+5748    ps                               0
+5759    /system/bin/incident_helper      0
+5775    /vendor/bin/hw/android.hardware.drm-service-lazy.clearkey 0
+5791    /system/bin/sh                   sigsuspend
+5794    ps                               0
+------ 0.050s was the duration of 'for_each_tid(BLOCKED PROCESS WAIT-CHANNELS)' ------
+
+------ PROCESS TIMES (pid cmd user system iowait+percentage) ------
+1     /system/bin/init                               0.09    5.59    0.00
+2     [kthreadd]                                             0.01
+6     [kworker/0:0-virtio_vsock]                             0.85
+8     [kworker/u8:0-events_unbound]                          1.94
+10    [kworker/u8:1-events_unbound]                          2.21
+13    [ksoftirqd/0]                                          2.47
+14    [rcu_preempt]                                  0.05    0.74    0.01  1.3%
+18    [migration/0]                                          0.01    0.01 100.0%
+22    [migration/1]                                  0.34    0.00    0.01  2.9%
+23    [ksoftirqd/1]                                          0.37
+27    [migration/2]                                  0.42    0.01    0.01  2.3%
+28    [ksoftirqd/2]                                          0.13
+32    [migration/3]                                  0.51    0.00    0.01  2.0%
+33    [ksoftirqd/3]                                          0.36
+35    [kworker/3:0H-kblockd]                                 0.30
+41    [kcompactd0]                                           0.08
+46    [kworker/2:1-virtio_vsock]                             1.02
+50    [kworker/0:1H-kblockd]                                 1.38
+51    [kswapd0]                                             12.42
+52    [kworker/u9:0-fscrypt_read_queue]                      0.09
+58    [kworker/1:1-kdmflush/254:40]                          1.01
+62    [kworker/1:1H-kverityd]                                0.02
+66    [kworker/u8:2-ext4-rsv-conversion]                     1.08
+71    [kworker/2:2-virtio_vsock]                             1.55
+72    [kworker/2:1H-kblockd]                                 1.33
+73    [kworker/3:1H-kblockd]                                 0.04
+90    [kworker/3:2H-kverityd]                                2.97
+92    /system/bin/init                               0.01    0.01    0.00
+93    /system/bin/ueventd                            0.07    0.07    0.00
+146   /system/bin/prng_seeder                        0.00    0.05    0.00
+153   /system/bin/logd                               0.10    3.19    0.00
+155   /system/bin/lmkd                               0.02    0.62    0.01  1.6%
+156   /system/bin/servicemanager                     0.12    0.69    0.00
+157   [psimon]                                       0.02    0.00    0.01 50.0%
+161   /system/bin/hwservicemanager                   0.02    0.08    0.00
+167   /vendor/bin/qemu-props                         0.00    0.02    0.00
+168   /system/bin/vold                               0.00    0.20    0.00
+175   /system/bin/hw/android.system.suspend-service  0.02    0.11    0.00
+176   /system/bin/keystore2                          0.03    0.24    0.00
+177   /vendor/bin/hw/android.hardware.atrace@1.0-service 0.00 0.02   0.00
+182   /vendor/bin/hw/android.hardware.security.keymint-service 0.05 0.03 0.00
+192   [kworker/u9:1-fscrypt_read_queue]                      1.86
+193   [kworker/u9:2-fscrypt_read_queue]                      1.95
+198   [jbd2/dm-40-8]                                         4.76
+205   /system/bin/tombstoned                         0.00    0.04    0.00
+206   [kworker/3:2-sock_diag_events]                         0.11
+246   [kworker/u8:3-events_unbound]                          2.15
+287   [kworker/1:3H-kverityd]                                0.06
+327   [kworker/0:2-events]                                   0.27
+335   /vendor/bin/dhcpclient                         0.00    0.91    0.00
+350   /apex/com.android.os.statsd/bin/statsd         0.02    1.79    0.00
+351   /system/bin/netd                               0.05    0.46    0.00
+352   zygote64                                       0.44    2.19    0.00
+356   /system/bin/hw/android.hidl.allocator@1.0-service 0.00 0.01    0.00
+357   /vendor/bin/hw/android.hardware.audio.service  0.00    0.22    0.00
+359   /vendor/bin/hw/android.hardware.camera.provider.ranchu 0.00 0.06 0.00
+360   /vendor/bin/hw/android.hardware.camera.provider@2.7-service-google 0.01 0.11 0.00
+361   /vendor/bin/hw/android.hardware.gatekeeper@1.0-service.software 0.00 0.02 0.00
+362   /vendor/bin/hw/android.hardware.graphics.allocator@3.0-service.ranchu 0.00 0.69 0.00
+363   /vendor/bin/hw/android.hardware.health-service.example 0.00 0.04 0.00
+364   /vendor/bin/hw/android.hardware.media.c2@1.0-service-goldfish 0.02 0.14 0.00
+367   /vendor/bin/hw/android.hardware.neuralnetworks-service-sample-all 0.00 0.06 0.00
+368   /vendor/bin/hw/android.hardware.neuralnetworks-service-sample-limited 0.00 0.04 0.00
+369   /vendor/bin/hw/android.hardware.neuralnetworks-shim-service-sample 0.01 0.05 0.00
+370   /vendor/bin/hw/android.hardware.sensors-service.multihal 0.01 1.44 0.00
+371   /vendor/bin/hw/android.hardware.thermal@2.0-service.mock 0.00 0.01 0.00
+372   /vendor/bin/hw/android.hardware.usb-service.example 0.00 0.01  0.00
+373   /vendor/bin/hw/android.hardware.wifi-service   0.00    0.05    0.00
+374   /system/bin/iptables-restore                   0.00    0.05    0.00
+375   /system/bin/ip6tables-restore                  0.01    0.03    0.00
+377   /vendor/bin/hw/android.hardware.bluetooth-service.default 0.00 0.03 0.00
+378   /vendor/bin/hw/android.hardware.cas-service.example 0.01 0.00  0.00
+396   /vendor/bin/hw/android.hardware.biometrics.face-service.example 0.00 0.01 0.00
+397   /vendor/bin/hw/android.hardware.graphics.composer3-service.ranchu 0.10 3.48 0.01 0.3%
+398   /vendor/bin/hw/android.hardware.identity-service.example 0.00 0.01 0.00
+403   /vendor/bin/hw/android.hardware.power-service.example 0.00 0.01 0.00
+408   /vendor/bin/hw/android.hardware.power.stats-service.example 0.00 0.01 0.00
+409   /vendor/bin/hw/android.hardware.rebootescrow-service.default 0.00 0.01 0.00
+410   /vendor/bin/hw/android.hardware.vibrator-service.example 0.00 0.01 0.00
+411   /apex/com.google.android.widevine/bin/hw/android.hardware.drm-service.widevine 0.04 0.08 0.00
+413   /system/bin/audioserver                        0.05    0.84    0.00
+415   /system/bin/credstore                          0.00    0.02    0.00
+416   /system/bin/gpuservice                         0.00    0.06    0.00
+417   /system/bin/surfaceflinger                     0.36    5.12    0.01  0.2%
+429   /apex/com.android.adbd/bin/adbd                1.34    5.75    0.00
+435   /system/bin/drmserver                          0.00    0.04    0.00
+439   /system/bin/traced_probes                      0.00    0.02    0.00
+440   /system/bin/traced                             0.00    0.02    0.00
+451   /system/bin/mdnsd                              0.00    0.07    0.00
+457   /vendor/bin/bt_vhci_forwarder                  0.00    0.02    0.00
+458   /system/bin/cameraserver                       0.03    0.17    0.00
+461   /system/bin/incidentd                          0.01    0.02    0.00
+462   /system/bin/installd                           0.09    0.47    0.00
+463   media.extractor                                0.05    0.19    0.00
+465   media.metrics                                  0.00    0.07    0.00
+468   /system/bin/mediaserver                        0.03    0.37    0.00
+469   /system/bin/storaged                           0.00    0.02    0.00
+470   /system/bin/wificond                           0.01    0.05    0.00
+471   /vendor/bin/hw/libgoldfish-rild                0.01    0.29    0.00
+474   media.swcodec                                  0.08    0.46    0.00
+475   /system/bin/gatekeeperd                        0.00    0.02    0.00
+552   system_server                                 15.07   57.91    0.00
+558   [kworker/1:4H-kblockd]                                 2.28
+725   /vendor/bin/hw/android.hardware.biometrics.fingerprint-service.ranchu 0.00 0.04 0.00
+747   /vendor/bin/hw/wpa_supplicant                  0.01    0.08    0.00
+760   com.android.systemui                           1.48    4.00    0.00
+809   /vendor/bin/hw/android.hardware.gnss-service.ranchu 0.01 0.02  0.00
+855   webview_zygote                                 0.01    0.06    0.00
+868   com.android.networkstack.process               0.16    0.50    0.00
+900   com.google.android.bluetooth                   0.14    0.79    0.00
+927   com.android.se                                 0.02    0.07    0.00
+945   com.android.phone                              0.55    2.01    0.00
+947   com.android.settings                           0.73    2.99    0.00
+982   com.google.android.ext.services                0.02    0.15    0.00
+992   com.google.android.apps.nexuslauncher          0.73    2.10    0.00
+1097  com.google.android.cellbroadcastreceiver       0.03    0.24    0.00
+1219  com.google.android.gms.persistent              4.17   22.05    0.00
+1240  com.google.android.permissioncontroller        0.26    1.16    0.00
+1263  [kworker/u9:3-fscrypt_read_queue]                      1.29
+1264  [kworker/u9:4-fscrypt_read_queue]                      0.31
+1335  com.google.android.apps.wellbeing              0.98    3.27    0.00
+1356  com.google.android.inputmethod.latin           0.85    1.19    0.00
+1396  com.google.android.devicelockcontroller        0.05    0.23    0.00
+1428  com.google.android.providers.media.module      0.75    1.42    0.00
+1444  [kworker/3:3H-kverityd]                                1.67
+1447  com.android.printspooler                       0.00    0.05    0.00
+1470  com.google.android.as                          0.70    2.25    0.00
+1473  com.google.process.gapps                       0.04    0.25    0.00
+1504  com.google.process.gservices                   0.23    0.46    0.00
+1528  com.google.android.googlequicksearchbox:interactor 0.23 0.63   0.00
+1540  com.google.android.apps.messaging:rcs          0.28    0.65    0.00
+1561  com.android.emulator.multidisplay              0.04    0.06    0.00
+1624  com.android.vending                            3.53    9.92    0.00
+1632  android.process.acore                          0.08    0.23    0.00
+1655  com.google.android.apps.youtube.music          0.75    2.09    0.00
+1669  com.android.keychain                           0.01    0.07    0.00
+1702  com.android.providers.calendar                 0.01    0.08    0.00
+1705  com.google.android.gms                         3.96    8.46    0.00
+1722  [kworker/3:5H-kverityd]                                0.50
+1725  com.google.android.googlequicksearchbox:search 3.48    7.64    0.00
+1766  com.google.android.youtube                     0.74    2.43    0.00
+1819  com.google.android.apps.messaging              2.21    4.84    0.00
+1875  com.google.android.as.oss                      0.03    0.09    0.00
+2052  com.android.localtransport                     0.01    0.03    0.00
+2243  com.google.android.deskclock                   0.06    0.22    0.00
+2289  com.android.chrome                             0.22    2.71    0.00
+2409  [kworker/3:6H-kverityd]                                0.77
+2500  com.google.android.webview:webview_service     0.03    0.05    0.00
+2567  com.android.vending:background                 0.40    0.78    0.00
+2590  com.google.android.apps.wallpaper              0.02    0.09    0.00
+2620  com.google.android.tts                         2.34    5.81    0.00
+2749  com.google.android.projection.gearhead:shared  0.03    0.13    0.00
+2877  com.google.android.gm                          0.37    1.56    0.00
+2934  com.google.android.contacts                    0.20    0.60    0.00
+3016  logcat                                         0.10    0.97    0.00
+3045  com.google.android.gms.unstable                3.83    3.06    0.00
+3086  logcat                                         0.01    0.15    0.00
+3108  logcat                                         0.01    0.08    0.00
+3123  logcat                                         0.02    0.04    0.00
+3139  /system/bin/sh                                 0.00    0.01    0.00
+3309  com.android.imsserviceentitlement              0.01    0.06    0.00
+3448  com.android.carrierdefaultapp                  0.00    0.05    0.00
+3525  com.google.android.rkpdapp                     0.08    0.27    0.00
+3554  com.google.android.settings.intelligence       1.06    2.35    0.00
+3612  com.android.vending:quick_launch               0.23    0.33    0.00
+3783  com.google.android.dialer                      0.31    0.87    0.00
+3981  com.android.traceur                            0.00    0.08    0.00
+4023  com.google.android.onetimeinitializer          0.01    0.03    0.00
+4046  com.android.externalstorage                    0.00    0.04    0.00
+4067  android.process.media                          0.06    0.22    0.00
+4120  com.android.vending:instant_app_installer      0.06    0.25    0.00
+4148  com.android.camera2                            0.01    0.04    0.00
+4175  com.android.dynsystem                          0.02    0.02    0.00
+4210  com.android.dynsystem:dynsystem                0.00    0.03    0.00
+4213  com.android.managedprovisioning                0.00    0.04    0.00
+4258  com.android.shell                              0.01    0.03    0.00
+4279  com.google.android.configupdater               0.04    0.15    0.00
+4309  com.google.android.packageinstaller            0.02    0.02    0.00
+4347  com.google.android.partnersetup                0.07    0.17    0.00
+4404  com.google.android.adservices.api              0.05    0.31    0.00
+4743  com.android.emergency                          0.00    0.06    0.00
+4794  com.google.android.gms.ui                      0.09    0.71    0.00
+4828  com.google.android.healthconnect.controller    0.01    0.03    0.00
+5088  /system/bin/dumpstate                          0.07    0.84    0.00
+5127  com.google.android.apps.photos                 0.17    0.72    0.00
+5184  com.google.android.googlequicksearchbox        0.21    0.50    0.00
+5255  [kworker/3:8H-kverityd]                                0.45
+5441  com.google.android.webview                     0.00    0.10    0.00
+5492  incident                                       0.00    0.01    0.00
+5502  /vendor/bin/hw/android.hardware.dumpstate-service.example 0.00 0.01 0.00
+5748  ps                                             0.01    0.22    0.00
+5759  /system/bin/incident_helper                    0.01    0.13    0.00
+5775  /vendor/bin/hw/android.hardware.drm-service-lazy.clearkey 0.00 0.02 0.00
+------ 0.008s was the duration of 'for_each_pid(PROCESS TIMES (pid cmd user system iowait+percentage))' ------
+------ PROCESSES AND THREADS (ps -A -T -Z -O pri,nice,rtprio,sched,pcy,time) ------
+LABEL                          USER           PID   TID  PPID        VSZ    RSS WCHAN            ADDR S PRI  NI RTPRIO SCH PCY     TIME CMD            
+u:r:init:s0                    root             1     1     0   10877468   3744 0                   0 S  19   0      -   0  fg 00:00:04 init
+u:r:init:s0                    root             1    91     0   10877468   3744 0                   0 S  39 -20      -   0  fg 00:00:01 init
+u:r:kernel:s0                  root             2     2     0          0      0 0                   0 S  19   0      -   0  fg 00:00:00 kthreadd
+u:r:kernel:s0                  root             3     3     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 rcu_gp
+u:r:kernel:s0                  root             4     4     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 slub_flushwq
+u:r:kernel:s0                  root             5     5     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 netns
+u:r:kernel:s0                  root             6     6     2          0      0 0                   0 I  19   0      -   0  fg 00:00:00 kworker/0:0-events
+u:r:kernel:s0                  root             7     7     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/0:0H-kverityd
+u:r:kernel:s0                  root             8     8     2          0      0 0                   0 I  19   0      -   0  fg 00:00:01 kworker/u8:0-events_unbound
+u:r:kernel:s0                  root             9     9     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 mm_percpu_wq
+u:r:kernel:s0                  root            10    10     2          0      0 0                   0 I  19   0      -   0  fg 00:00:02 kworker/u8:1-events_unbound
+u:r:kernel:s0                  root            11    11     2          0      0 0                   0 I  19   0      -   0  fg 00:00:00 rcu_tasks_kthread
+u:r:kernel:s0                  root            12    12     2          0      0 0                   0 I  19   0      -   0  fg 00:00:00 rcu_tasks_trace_kthread
+u:r:kernel:s0                  root            13    13     2          0      0 0                   0 S  19   0      -   0  fg 00:00:02 ksoftirqd/0
+u:r:kernel:s0                  root            14    14     2          0      0 0                   0 I  41   0      1   1  fg 00:00:00 rcu_preempt
+u:r:kernel:s0                  root            15    15     2          0      0 0                   0 S  41   0      1   1  fg 00:00:00 rcub/0
+u:r:kernel:s0                  root            16    16     2          0      0 0                   0 S  41   0      1   1  fg 00:00:00 rcu_exp_gp_kthread_worker
+u:r:kernel:s0                  root            17    17     2          0      0 0                   0 S  41   0      1   1  fg 00:00:00 rcu_exp_par_gp_kthread_worker
+u:r:kernel:s0                  root            18    18     2          0      0 0                   0 S 139   0     99   1  fg 00:00:00 migration/0
+u:r:kernel:s0                  root            19    19     2          0      0 0                   0 I  19   0      -   0  fg 00:00:00 kworker/0:1-cgroup_destroy
+u:r:kernel:s0                  root            20    20     2          0      0 0                   0 S  19   0      -   0  fg 00:00:00 cpuhp/0
+u:r:kernel:s0                  root            21    21     2          0      0 0                   0 S  19   0      -   0  fg 00:00:00 cpuhp/1
+u:r:kernel:s0                  root            22    22     2          0      0 0                   0 S 139   0     99   1  fg 00:00:00 migration/1
+u:r:kernel:s0                  root            23    23     2          0      0 0                   0 S  19   0      -   0  fg 00:00:00 ksoftirqd/1
+u:r:kernel:s0                  root            24    24     2          0      0 0                   0 I  19   0      -   0  fg 00:00:00 kworker/1:0-events
+u:r:kernel:s0                  root            25    25     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/1:0H-kverityd
+u:r:kernel:s0                  root            26    26     2          0      0 0                   0 S  19   0      -   0  fg 00:00:00 cpuhp/2
+u:r:kernel:s0                  root            27    27     2          0      0 0                   0 S 139   0     99   1  fg 00:00:00 migration/2
+u:r:kernel:s0                  root            28    28     2          0      0 0                   0 S  19   0      -   0  fg 00:00:00 ksoftirqd/2
+u:r:kernel:s0                  root            29    29     2          0      0 0                   0 I  19   0      -   0  fg 00:00:00 kworker/2:0-slub_flushwq
+u:r:kernel:s0                  root            30    30     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/2:0H-kverityd
+u:r:kernel:s0                  root            31    31     2          0      0 0                   0 S  19   0      -   0  fg 00:00:00 cpuhp/3
+u:r:kernel:s0                  root            32    32     2          0      0 0                   0 S 139   0     99   1  fg 00:00:00 migration/3
+u:r:kernel:s0                  root            33    33     2          0      0 0                   0 S  19   0      -   0  fg 00:00:00 ksoftirqd/3
+u:r:kernel:s0                  root            34    34     2          0      0 0                   0 I  19   0      -   0  fg 00:00:00 kworker/3:0-events
+u:r:kernel:s0                  root            35    35     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/3:0H-kblockd
+u:r:kernel:s0                  root            36    36     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 inet_frag_wq
+u:r:kernel:s0                  root            37    37     2          0      0 0                   0 S  19   0      -   0  fg 00:00:00 kauditd
+u:r:kernel:s0                  root            38    38     2          0      0 0                   0 S  19   0      -   0  fg 00:00:00 khungtaskd
+u:r:kernel:s0                  root            39    39     2          0      0 0                   0 S  19   0      -   0  fg 00:00:00 oom_reaper
+u:r:kernel:s0                  root            40    40     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 writeback
+u:r:kernel:s0                  root            41    41     2          0      0 0                   0 S  19   0      -   0  fg 00:00:00 kcompactd0
+u:r:kernel:s0                  root            42    42     2          0      0 0                   0 S   0  19      -   0  fg 00:00:00 khugepaged
+u:r:kernel:s0                  root            43    43     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 cryptd
+u:r:kernel:s0                  root            44    44     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kblockd
+u:r:kernel:s0                  root            45    45     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 blkcg_punt_bio
+u:r:kernel:s0                  root            46    46     2          0      0 0                   0 I  19   0      -   0  fg 00:00:00 kworker/2:1-virtio_vsock
+u:r:kernel:s0                  root            47    47     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 edac-poller
+u:r:kernel:s0                  root            48    48     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 devfreq_wq
+u:r:kernel:s0                  root            49    49     2          0      0 0                   0 S  90   0     50   1  fg 00:00:00 watchdogd
+u:r:kernel:s0                  root            50    50     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:01 kworker/0:1H-kverityd
+u:r:kernel:s0                  root            51    51     2          0      0 0                   0 R  19   0      -   0  fg 00:00:12 kswapd0
+u:r:kernel:s0                  root            52    52     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/u9:0-fscrypt_read_queue
+u:r:kernel:s0                  root            53    53     2          0      0 0                   0 S  41   0      1   1  fg 00:00:00 erofs_worker/0
+u:r:kernel:s0                  root            54    54     2          0      0 0                   0 S  41   0      1   1  fg 00:00:00 erofs_worker/1
+u:r:kernel:s0                  root            55    55     2          0      0 0                   0 S  41   0      1   1  fg 00:00:00 erofs_worker/2
+u:r:kernel:s0                  root            56    56     2          0      0 0                   0 S  41   0      1   1  fg 00:00:00 erofs_worker/3
+u:r:kernel:s0                  root            57    57     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kthrotld
+u:r:kernel:s0                  root            58    58     2          0      0 0                   0 I  19   0      -   0  fg 00:00:00 kworker/1:1-kdmflush/254:40
+u:r:kernel:s0                  root            59    59     2          0      0 0                   0 S   0  19      -   0  fg 00:00:00 dmabuf-deferred-free-worker
+u:r:kernel:s0                  root            60    60     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 uas
+u:r:kernel:s0                  root            61    61     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 dm_bufio_cache
+u:r:kernel:s0                  root            62    62     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/1:1H-kverityd
+u:r:kernel:s0                  root            63    63     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 mld
+u:r:kernel:s0                  root            64    64     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ipv6_addrconf
+u:r:kernel:s0                  root            66    66     2          0      0 0                   0 I  19   0      -   0  fg 00:00:01 kworker/u8:2-events_unbound
+u:r:kernel:s0                  root            67    67     2          0      0 0                   0 I  19   0      -   0  fg 00:00:00 kworker/3:1-cgroup_destroy
+u:r:kernel:s0                  root            68    68     2          0      0 0                   0 I  19   0      -   0  fg 00:00:00 kworker/1:2-events
+u:r:kernel:s0                  root            69    69     2          0      0 0                   0 S  19   0      -   0  fg 00:00:00 khvcd
+u:r:kernel:s0                  root            70    70     2          0      0 0                   0 S  19   0      -   0  fg 00:00:00 hwrng
+u:r:kernel:s0                  root            71    71     2          0      0 0                   0 I  19   0      -   0  fg 00:00:01 kworker/2:2-virtio_vsock
+u:r:kernel:s0                  root            72    72     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:01 kworker/2:1H-kverityd
+u:r:kernel:s0                  root            73    73     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/3:1H-kblockd
+u:r:kernel:s0                  root            77    77     2          0      0 0                   0 S  19   0      -   0  fg 00:00:00 jbd2/vdd1-8
+u:r:kernel:s0                  root            78    78     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root            79    79     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:0
+u:r:kernel:s0                  root            80    80     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:1
+u:r:kernel:s0                  root            81    81     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:2
+u:r:kernel:s0                  root            82    82     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:3
+u:r:kernel:s0                  root            83    83     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:4
+u:r:kernel:s0                  root            84    84     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:5
+u:r:kernel:s0                  root            85    85     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root            86    86     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root            87    87     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root            88    88     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root            89    89     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root            90    90     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:02 kworker/3:2H-kverityd
+u:r:vendor_init:s0             root            92    92     1   10883652   1564 0                   0 S  19   0      -   0  fg 00:00:00 init
+u:r:ueventd:s0                 root            93    93     1   10849068   1952 0                   0 S  19   0      -   0  fg 00:00:00 ueventd
+u:r:kernel:s0                  root           100   100     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:6
+u:r:kernel:s0                  root           102   102     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:8
+u:r:kernel:s0                  root           103   103     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:9
+u:r:kernel:s0                  root           104   104     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:10
+u:r:kernel:s0                  root           105   105     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:11
+u:r:kernel:s0                  root           107   107     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:13
+u:r:kernel:s0                  root           109   109     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:15
+u:r:kernel:s0                  root           110   110     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:16
+u:r:kernel:s0                  root           111   111     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:17
+u:r:kernel:s0                  root           112   112     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:18
+u:r:kernel:s0                  root           113   113     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:19
+u:r:kernel:s0                  root           114   114     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:20
+u:r:kernel:s0                  root           115   115     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:21
+u:r:kernel:s0                  root           117   117     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:23
+u:r:kernel:s0                  root           118   118     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:24
+u:r:kernel:s0                  root           119   119     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:25
+u:r:kernel:s0                  root           121   121     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:27
+u:r:kernel:s0                  root           123   123     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:29
+u:r:kernel:s0                  root           124   124     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:30
+u:r:kernel:s0                  root           128   128     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:34
+u:r:kernel:s0                  root           130   130     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:36
+u:r:kernel:s0                  root           131   131     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:37
+u:r:kernel:s0                  root           132   132     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:38
+u:r:kernel:s0                  root           133   133     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:39
+u:r:kernel:s0                  root           138   138     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           139   139     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           140   140     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           141   141     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:prng_seeder:s0             prng_seeder    146   146     1   10954376   3288 0                   0 S  19   0      -   0  fg 00:00:00 prng_seeder
+u:r:kernel:s0                  root           148   148     2          0      0 0                   0 S 140   0      -   6  fg 00:00:00 sugov:0
+u:r:kernel:s0                  root           149   149     2          0      0 0                   0 S 140   0      -   6  fg 00:00:00 sugov:1
+u:r:kernel:s0                  root           150   150     2          0      0 0                   0 S 140   0      -   6  fg 00:00:00 sugov:2
+u:r:kernel:s0                  root           151   151     2          0      0 0                   0 S 140   0      -   6  fg 00:00:00 sugov:3
+u:r:kernel:s0                  root           152   152     2          0      0 0                   0 S  90   0     50   1  fg 00:00:00 irq/18-goldfish_pipe_dprctd
+u:r:logd:s0                    logd           153   153     1   10848848   4008 0                   0 S   9  10      -   0  bg 00:00:00 logd
+u:r:logd:s0                    logd           153   162     1   10848848   4008 0                   0 S   9  10      -   0  bg 00:00:00 logd.reader
+u:r:logd:s0                    logd           153   163     1   10848848   4008 0                   0 S   9  10      -   0  bg 00:00:01 logd.writer
+u:r:logd:s0                    logd           153   164     1   10848848   4008 0                   0 S   9  10      -   0  bg 00:00:00 logd.control
+u:r:logd:s0                    logd           153   166     1   10848848   4008 0                   0 S   9  10      -   0  bg 00:00:00 logd.auditd
+u:r:logd:s0                    logd           153  3019     1   10848848   4008 0                   0 R   9  10      -   0  bg 00:00:00 logd.reader.per
+u:r:logd:s0                    logd           153  3096     1   10848848   4008 0                   0 S   9  10      -   0  bg 00:00:00 logd.reader.per
+u:r:logd:s0                    logd           153  3110     1   10848848   4008 0                   0 S   9  10      -   0  bg 00:00:00 logd.reader.per
+u:r:logd:s0                    logd           153  3126     1   10848848   4008 0                   0 S   9  10      -   0  bg 00:00:00 logd.reader.per
+u:r:logd:s0                    logd           153  3134     1   10848848   4008 0                   0 S   9  10      -   0  bg 00:00:00 logd.reader.per
+u:r:logd:s0                    logd           153  3149     1   10848848   4008 0                   0 S   9  10      -   0  bg 00:00:00 logd.reader.per
+u:r:logd:s0                    logd           153  5245     1   10848848   4008 0                   0 S   9  10      -   0  bg 00:00:00 logd.pkglist
+u:r:kernel:s0                  root           154   154     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 cfg80211
+u:r:lmkd:s0                    lmkd           155   155     1   10865948   2912 0                   0 S  41   0      1   1     00:00:00 lmkd
+u:r:lmkd:s0                    lmkd           155   158     1   10865948   2912 0                   0 S  39 -20      -   0  fg 00:00:00 lmkd_reaper0
+u:r:lmkd:s0                    lmkd           155   159     1   10865948   2912 0                   0 S  39 -20      -   0  fg 00:00:00 lmkd_reaper1
+u:r:lmkd:s0                    lmkd           155   160     1   10865948   2912 0                   0 S  41   0      1   1  fg 00:00:00 lmkd_watchdog
+u:r:servicemanager:s0          system         156   156     1   10842064   2776 0                   0 S  19   0      -   0     00:00:00 servicemanager
+u:r:kernel:s0                  root           157   157     2          0      0 0                   0 S  41   0      1   1  fg 00:00:00 psimon
+u:r:hwservicemanager:s0        system         161   161     1   10909344   2540 0                   0 S  19   0      -   0  fg 00:00:00 hwservicemanage
+u:r:qemu_props:s0              root           167   167     1   10778560   1428 0                   0 S  19   0      -   0  fg 00:00:00 qemu-props
+u:r:vold:s0                    root           168   168     1   10967588   3216 0                   0 S  19   0      -   0  fg 00:00:00 binder:168_2
+u:r:vold:s0                    root           168   171     1   10967588   3216 0                   0 S  19   0      -   0  fg 00:00:00 binder:168_1
+u:r:vold:s0                    root           168   172     1   10967588   3216 0                   0 S  19   0      -   0  fg 00:00:00 binder:168_3
+u:r:vold:s0                    root           168   173     1   10967588   3216 0                   0 S  19   0      -   0  fg 00:00:00 binder:168_2
+u:r:vold:s0                    root           168   197     1   10967588   3216 0                   0 S  19   0      -   0  fg 00:00:00 binder:168_4
+u:r:vold:s0                    root           168   319     1   10967588   3216 0                   0 S  19   0      -   0  fg 00:00:00 binder:168_5
+u:r:kernel:s0                  root           170   170     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kdmflush/254:40
+u:r:system_suspend:s0          system         175   175     1   10777380   3220 0                   0 S  19   0      -   0  fg 00:00:00 android.system.
+u:r:system_suspend:s0          system         175   178     1   10777380   3220 0                   0 S  19   0      -   0  fg 00:00:00 binder:175_1
+u:r:system_suspend:s0          system         175   179     1   10777380   3220 0                   0 S  19   0      -   0  fg 00:00:00 binder:175_2
+u:r:system_suspend:s0          system         175   499     1   10777380   3220 0                   0 S  19   0      -   0  fg 00:00:00 binder:175_3
+u:r:system_suspend:s0          system         175   715     1   10777380   3220 0                   0 S  19   0      -   0  fg 00:00:00 binder:175_4
+u:r:system_suspend:s0          system         175   716     1   10777380   3220 0                   0 S  19   0      -   0  fg 00:00:00 binder:175_5
+u:r:keystore:s0                keystore       176   176     1   10845212   5032 0                   0 S  19   0      -   0  fg 00:00:00 binder:176_2
+u:r:keystore:s0                keystore       176   186     1   10845212   5032 0                   0 S  19   0      -   0  fg 00:00:00 binder:176_1
+u:r:keystore:s0                keystore       176   187     1   10845212   5032 0                   0 S  19   0      -   0  fg 00:00:00 binder:176_3
+u:r:keystore:s0                keystore       176  3698     1   10845212   5032 0                   0 S  19   0      -   0  fg 00:00:00 binder:176_4
+u:r:keystore:s0                keystore       176  3699     1   10845212   5032 0                   0 S  19   0      -   0  fg 00:00:00 binder:176_5
+u:r:keystore:s0                keystore       176  3722     1   10845212   5032 0                   0 S  19   0      -   0  fg 00:00:00 binder:176_3
+u:r:hal_atrace_default:s0      system         177   177     1   10856316   2232 0                   0 S  19   0      -   0  fg 00:00:00 atrace@1.0-serv
+u:r:kernel:s0                  root           180   180     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 usbip_event
+u:r:kernel:s0                  root           181   181     2          0      0 0                   0 I  19   0      -   0  fg 00:00:00 kworker/1:3-events
+u:r:hal_keymint_default:s0     nobody         182   182     1   10838580   2812 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:kernel:s0                  root           190   190     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 blk_crypto_wq
+u:r:kernel:s0                  root           192   192     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:01 kworker/u9:1-fscrypt_read_queue
+u:r:kernel:s0                  root           193   193     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:01 kworker/u9:2-fscrypt_read_queue
+u:r:kernel:s0                  root           198   198     2          0      0 0                   0 S  19   0      -   0  fg 00:00:04 jbd2/dm-40-8
+u:r:kernel:s0                  root           199   199     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:tombstoned:s0              tombstoned     205   205     1   10841472   2692 0                   0 S  19   0      -   0     00:00:00 tombstoned
+u:r:kernel:s0                  root           206   206     2          0      0 0                   0 I  19   0      -   0  fg 00:00:00 kworker/3:2-mm_percpu_wq
+u:r:kernel:s0                  root           235   235     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           236   236     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           243   243     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           244   244     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           245   245     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           246   246     2          0      0 0                   0 I  19   0      -   0  fg 00:00:02 kworker/u8:3-events_unbound
+u:r:kernel:s0                  root           255   255     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           256   256     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           257   257     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           258   258     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           259   259     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           260   260     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           261   261     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           262   262     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           263   263     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           264   264     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           265   265     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           266   266     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           267   267     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           268   268     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           269   269     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           270   270     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           271   271     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           272   272     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           273   273     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           274   274     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/1:2H-kverityd
+u:r:kernel:s0                  root           275   275     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           276   276     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           277   277     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           278   278     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           279   279     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           280   280     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           281   281     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           282   282     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           283   283     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           284   284     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           285   285     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           286   286     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           287   287     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/1:3H-kverityd
+u:r:kernel:s0                  root           288   288     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           289   289     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/0:2H-kblockd
+u:r:kernel:s0                  root           290   290     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           291   291     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           292   292     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           293   293     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/2:2H-kverityd
+u:r:kernel:s0                  root           294   294     2          0      0 0                   0 I  19   0      -   0  fg 00:00:00 kworker/u8:4
+u:r:kernel:s0                  root           295   295     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           296   296     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           297   297     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           298   298     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           299   299     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           300   300     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           301   301     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           302   302     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           303   303     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           304   304     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           305   305     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           306   306     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kverityd
+u:r:kernel:s0                  root           307   307     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           308   308     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           309   309     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           310   310     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           311   311     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           312   312     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 ext4-rsv-conver
+u:r:kernel:s0                  root           327   327     2          0      0 0                   0 I  19   0      -   0  fg 00:00:00 kworker/0:2-events
+u:r:dhcpclient:s0              root           335   335     1   10856020   1748 0                   0 S  19   0      -   0  fg 00:00:00 dhcpclient
+u:r:statsd:s0                  statsd         350   350     1   10810192   2420 0                   0 S  19   0      -   0     00:00:00 binder:350_2
+u:r:statsd:s0                  statsd         350   353     1   10810192   2420 0                   0 S  19   0      -   0     00:00:00 binder:350_1
+u:r:statsd:s0                  statsd         350   354     1   10810192   2420 0                   0 S  19   0      -   0     00:00:00 binder:350_2
+u:r:statsd:s0                  statsd         350   355     1   10810192   2420 0                   0 S  19   0      -   0     00:00:00 binder:350_3
+u:r:statsd:s0                  statsd         350   606     1   10810192   2420 0                   0 S  19   0      -   0     00:00:01 statsd.writer
+u:r:statsd:s0                  statsd         350   607     1   10810192   2420 0                   0 S  19   0      -   0     00:00:00 binder:350_2
+u:r:statsd:s0                  statsd         350   735     1   10810192   2420 0                   0 S  19   0      -   0     00:00:00 binder:350_4
+u:r:statsd:s0                  statsd         350   853     1   10810192   2420 0                   0 S  19   0      -   0     00:00:00 binder:350_5
+u:r:statsd:s0                  statsd         350  1333     1   10810192   2420 0                   0 S  19   0      -   0     00:00:00 binder:350_4
+u:r:netd:s0                    root           351   351     1   10880144   2776 0                   0 S  19   0      -   0  fg 00:00:00 binder:351_3
+u:r:netd:s0                    root           351   376     1   10880144   2776 0                   0 S  19   0      -   0  fg 00:00:00 netd
+u:r:netd:s0                    root           351   379     1   10880144   2776 0                   0 S  19   0      -   0  fg 00:00:00 netd
+u:r:netd:s0                    root           351   380     1   10880144   2776 0                   0 S  19   0      -   0  fg 00:00:00 netd
+u:r:netd:s0                    root           351   381     1   10880144   2776 0                   0 S  19   0      -   0  fg 00:00:00 netd
+u:r:netd:s0                    root           351   382     1   10880144   2776 0                   0 S  19   0      -   0  fg 00:00:00 netd
+u:r:netd:s0                    root           351   383     1   10880144   2776 0                   0 S  19   0      -   0  fg 00:00:00 NFLogListener
+u:r:netd:s0                    root           351   389     1   10880144   2776 0                   0 S  19   0      -   0  fg 00:00:00 doh-handler
+u:r:netd:s0                    root           351   390     1   10880144   2776 0                   0 S  19   0      -   0  fg 00:00:00 netd
+u:r:netd:s0                    root           351   391     1   10880144   2776 0                   0 S  19   0      -   0  fg 00:00:00 binder:351_1
+u:r:netd:s0                    root           351   392     1   10880144   2776 0                   0 S  19   0      -   0  fg 00:00:00 binder:351_2
+u:r:netd:s0                    root           351   393     1   10880144   2776 0                   0 S  19   0      -   0  fg 00:00:00 MDnsSdMonitor
+u:r:netd:s0                    root           351   394     1   10880144   2776 0                   0 S  19   0      -   0  fg 00:00:00 binder:351_3
+u:r:netd:s0                    root           351   395     1   10880144   2776 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:351_1
+u:r:zygote:s0                  root           352   352     1   14263320  47076 0                   0 S  19   0      -   0  ta 00:00:02 main
+u:r:hal_allocator_default:s0   system         356   356     1   10792132   1028 0                   0 S  19   0      -   0  fg 00:00:00 allocator@1.0-s
+u:r:hal_audio_default:s0       audioserver    357   357     1   10898152   2692 0                   0 S  19   0      -   0  fg 00:00:00 binder:357_2
+u:r:hal_audio_default:s0       audioserver    357   365     1   10898152   2692 0                   0 S  19   0      -   0  fg 00:00:00 binder:357_1
+u:r:hal_audio_default:s0       audioserver    357   366     1   10898152   2692 0                   0 S  19   0      -   0  fg 00:00:00 binder:357_3
+u:r:hal_audio_default:s0       audioserver    357   406     1   10898152   2692 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:357_1
+u:r:hal_audio_default:s0       audioserver    357   407     1   10898152   2692 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:357_2
+u:r:hal_audio_default:s0       audioserver    357  4543     1   10898152   2692 0                   0 S  35 -16      -   0  fg 00:00:00 HwBinder:357_2
+u:r:hal_authsecret_default:s0  hsm            358   358     1   10792936    960 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_camera_default:s0      system         359   359     1   10865428   2660 0                   0 S  19   0      -   0  bg 00:00:00 binder:359_2
+u:r:hal_camera_default:s0      system         359   387     1   10865428   2660 0                   0 S  19   0      -   0  bg 00:00:00 binder:359_1
+u:r:hal_camera_default:s0      system         359   388     1   10865428   2660 0                   0 S  19   0      -   0  bg 00:00:00 binder:359_3
+u:r:hal_camera_default:s0      system         360   360     1   10875416   2496 0                   0 S  19   0      -   0  bg 00:00:00 camera.provider
+u:r:hal_camera_default:s0      system         360   400     1   10875416   2496 0                   0 S  19   0      -   0  bg 00:00:00 binder:360_1
+u:r:hal_camera_default:s0      system         360   401     1   10875416   2496 0                   0 S  19   0      -   0  bg 00:00:00 binder:360_3
+u:r:hal_gatekeeper_default:s0  system         361   361     1   10866172   1348 0                   0 S  19   0      -   0  fg 00:00:00 gatekeeper@1.0-
+u:r:hal_graphics_allocator_default:s0 system  362   362     1   10958504   2396 0                   0 S  19   0      -   0  fg 00:00:00 allocator@3.0-s
+u:r:hal_graphics_allocator_default:s0 system  362   404     1   10958504   2396 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:362_1
+u:r:hal_graphics_allocator_default:s0 system  362   405     1   10958504   2396 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:362_2
+u:r:hal_health_default:s0      system         363   363     1   10815472   2540 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:mediacodec:s0              media          364   364     1   10974624   4000 0                   0 S  19   0      -   0  fg 00:00:00 c2@1.0-service-
+u:r:mediacodec:s0              media          364   412     1   10974624   4000 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:364_1
+u:r:mediacodec:s0              media          364   414     1   10974624   4000 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:364_2
+u:r:mediacodec:s0              media          364   755     1   10974624   4000 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:364_2
+u:r:mediacodec:s0              media          364   756     1   10974624   4000 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:364_2
+u:r:mediacodec:s0              media          364  1613     1   10974624   4000 0                   0 S  29 -10      -   0  fg 00:00:00 c2@1.0-service-
+u:r:hal_neuralnetworks_sample:s0 system       367   367     1   10905360   2264 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_neuralnetworks_sample:s0 system       368   368     1   10899260   2288 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_neuralnetworks_sample:s0 system       369   369     1   10920528   2504 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_sensors_default:s0     system         370   370     1   10875000   2368 0                   0 S  19   0      -   0     00:00:00 android.hardwar
+u:r:hal_sensors_default:s0     system         370   385     1   10875000   2368 0                   0 S  19   0      -   0     00:00:01 android.hardwar
+u:r:hal_sensors_default:s0     system         370   386     1   10875000   2368 0                   0 S  19   0      -   0     00:00:00 android.hardwar
+u:r:hal_sensors_default:s0     system         370   624     1   10875000   2368 0                   0 S  21  -2      -   0     00:00:00 android.hardwar
+u:r:hal_sensors_default:s0     system         370   625     1   10875000   2368 0                   0 S  21  -2      -   0     00:00:00 android.hardwar
+u:r:hal_thermal_default:s0     system         371   371     1   10864704   2504 0                   0 S  19   0      -   0  fg 00:00:00 thermal@2.0-ser
+u:r:hal_usb_default:s0         system         372   372     1   10892892   2392 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_usb_default:s0         system         372   710     1   10892892   2392 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_wifi_default:s0        wifi           373   373     1   11044116   1872 0                   0 S  19   0      -   0  fg 00:00:00 binder:373_2
+u:r:hal_wifi_default:s0        wifi           373   399     1   11044116   1872 0                   0 S  19   0      -   0  fg 00:00:00 binder:373_1
+u:r:hal_wifi_default:s0        wifi           373   744     1   11044116   1872 0                   0 S  19   0      -   0  fg 00:00:00 binder:373_1
+u:r:netd:s0                    root           374   374   351   10849452   1700 0                   0 S  19   0      -   0  fg 00:00:00 iptables-restor
+u:r:netd:s0                    root           375   375   351   10788012   1604 0                   0 S  19   0      -   0  fg 00:00:00 ip6tables-resto
+u:r:hal_bluetooth_default:s0   bluetooth      377   377     1   10797484   2256 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_bluetooth_default:s0   bluetooth      377  1039     1   10797484   2256 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_cas_default:s0         media          378   378     1   10805568   2412 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_contexthub_default:s0  context_hub    384   384     1   10866728    896 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_face_default:s0        nobody         396   396     1   10817484   2304 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_face_default:s0        nobody         396   973     1   10817484   2304 0                   0 S  21  -2      -   0  fg 00:00:00 android.hardwar
+u:r:hal_graphics_composer_default:s0 system   397   397     1   11016504   2740 0                   0 S  42 -10      2   1     00:00:02 binder:397_2
+u:r:hal_graphics_composer_default:s0 system   397   418     1   11016504   2740 0                   0 S  42  -8      2   1     00:00:00 binder:397_1
+u:r:hal_graphics_composer_default:s0 system   397   460     1   11016504   2740 0                   0 S  42   0      2   1     00:00:00 binder:397_3
+u:r:hal_graphics_composer_default:s0 system   397   473     1   11016504   2740 0                   0 S  19   0      -   0     00:00:00 binder:397_2
+u:r:hal_identity_default:s0    nobody         398   398     1   10928112   1848 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_light_default:s0       nobody         402   402     1   10832240   2372 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_power_default:s0       nobody         403   403     1   10826124   2508 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_power_stats_default:s0 system         408   408     1   10836012   2668 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_rebootescrow_default:s0 system        409   409     1   10795124   2328 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_vibrator_default:s0    nobody         410   410     1   10770884   2420 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:hal_drm_widevine:s0        media          411   411     1   10845856   2432 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:audioserver:s0             audioserver    413   413     1   11063480   4240 0                   0 S  19   0      -   0  fg 00:00:00 audioserver
+u:r:audioserver:s0             audioserver    413   430     1   11063480   4240 0                   0 S  19   0      -   0  fg 00:00:00 binder:413_1
+u:r:audioserver:s0             audioserver    413   431     1   11063480   4240 0                   0 S  19   0      -   0  fg 00:00:00 binder:413_2
+u:r:audioserver:s0             audioserver    413   432     1   11063480   4240 0                   0 S  35 -16      -   0  fg 00:00:00 AudioFlinger_Pa
+u:r:audioserver:s0             audioserver    413   436     1   11063480   4240 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:413_1
+u:r:audioserver:s0             audioserver    413   437     1   11063480   4240 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:413_2
+u:r:audioserver:s0             audioserver    413   481     1   11063480   4240 0                   0 S  35 -16      -   0  fg 00:00:00 ApmAudio
+u:r:audioserver:s0             audioserver    413   482     1   11063480   4240 0                   0 S  35 -16      -   0  fg 00:00:00 ApmOutput
+u:r:audioserver:s0             audioserver    413   490     1   11063480   4240 0                   0 S  19   0      -   0  fg 00:00:00 TimerThread
+u:r:audioserver:s0             audioserver    413   498     1   11063480   4240 0                   0 S  38 -19      -   0  fg 00:00:00 AudioOut_D
+u:r:audioserver:s0             audioserver    413   501     1   11063480   4240 0                   0 S  38 -19      -   0  fg 00:00:00 AudioOut_15
+u:r:audioserver:s0             audioserver    413   702     1   11063480   4240 0                   0 S  19   0      -   0  fg 00:00:00 binder:413_3
+u:r:audioserver:s0             audioserver    413  1239     1   11063480   4240 0                   0 S  19   0      -   0  fg 00:00:00 binder:413_4
+u:r:audioserver:s0             audioserver    413  1429     1   11063480   4240 0                   0 S  19   0      -   0  fg 00:00:00 binder:413_5
+u:r:audioserver:s0             audioserver    413  2678     1   11063480   4240 0                   0 S  19   0      -   0  fg 00:00:00 binder:413_6
+u:r:audioserver:s0             audioserver    413  5353     1   11063480   4240 0                   0 S  19   0      -   0  fg 00:00:00 binder:413_7
+u:r:audioserver:s0             audioserver    413  5354     1   11063480   4240 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:413_3
+u:r:credstore:s0               credstore      415   415     1   10894804   1156 0                   0 S  19   0      -   0  fg 00:00:00 credstore
+u:r:credstore:s0               credstore      415   421     1   10894804   1156 0                   0 S  19   0      -   0  fg 00:00:00 binder:415_1
+u:r:gpuservice:s0              gpu_service    416   416     1   10876504   2136 0                   0 S  19   0      -   0  fg 00:00:00 binder:416_2
+u:r:gpuservice:s0              gpu_service    416   424     1   10876504   2136 0                   0 S  19   0      -   0  fg 00:00:00 binder:416_1
+u:r:gpuservice:s0              gpu_service    416   425     1   10876504   2136 0                   0 S  19   0      -   0  fg 00:00:00 TracingMuxer
+u:r:gpuservice:s0              gpu_service    416   428     1   10876504   2136 0                   0 S  19   0      -   0  fg 00:00:00 gpuservice
+u:r:surfaceflinger:s0          system         417   417     1   10976340   3148 0                   0 S  42  -8      2   1  fg 00:00:01 surfaceflinger
+u:r:surfaceflinger:s0          system         417   426     1   10976340   3148 0                   0 S  19   0      -   0  fg 00:00:00 binder:417_1
+u:r:surfaceflinger:s0          system         417   427     1   10976340   3148 0                   0 S  19   0      -   0  fg 00:00:00 binder:417_2
+u:r:surfaceflinger:s0          system         417   433     1   10976340   3148 0                   0 S  42  -8      2   1  fg 00:00:01 RenderEngine
+u:r:surfaceflinger:s0          system         417   483     1   10976340   3148 0                   0 S  42  -8      2   1  fg 00:00:00 HwcAsyncWorker
+u:r:surfaceflinger:s0          system         417   488     1   10976340   3148 0                   0 S  42  -8      2   1  fg 00:00:00 TimerDispatch
+u:r:surfaceflinger:s0          system         417   489     1   10976340   3148 0                   0 S  42  -8      2   1  fg 00:00:00 app
+u:r:surfaceflinger:s0          system         417   491     1   10976340   3148 0                   0 S  42  -8      2   1  fg 00:00:00 appSf
+u:r:surfaceflinger:s0          system         417   492     1   10976340   3148 0                   0 S  27  -8      -   0  fg 00:00:00 RegionSampling
+u:r:surfaceflinger:s0          system         417   493     1   10976340   3148 0                   0 S  27  -8      -   0  fg 00:00:00 RegSampIdle
+u:r:surfaceflinger:s0          system         417   494     1   10976340   3148 0                   0 S  27  -8      -   0  fg 00:00:00 surfaceflinger
+u:r:surfaceflinger:s0          system         417   497     1   10976340   3148 0                   0 S  42  -8      2   1  fg 00:00:00 surfaceflinger
+u:r:surfaceflinger:s0          system         417   542     1   10976340   3148 0                   0 S  19   0      -   0  fg 00:00:00 binder:417_3
+u:r:surfaceflinger:s0          system         417   543     1   10976340   3148 0                   0 S  19   0      -   0  fg 00:00:00 binder:417_4
+u:r:surfaceflinger:s0          system         417   861     1   10976340   3148 0                   0 S  19   0      -   0  fg 00:00:00 binder:417_5
+u:r:surfaceflinger:s0          system         417  1322     1   10976340   3148 0                   0 S  19   0      -   0  fg 00:00:00 TracingMuxer
+u:r:adbd:s0                    shell          429   429     1   10867088   4788 0                   0 R  19   0      -   0  fg 00:00:04 adbd
+u:r:adbd:s0                    shell          429   442     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:00 adbd
+u:r:adbd:s0                    shell          429   443     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:00 adbd
+u:r:adbd:s0                    shell          429   444     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:00 adbd auth
+u:r:adbd:s0                    shell          429   446     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:00 server socket
+u:r:adbd:s0                    shell          429   447     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:00 server socket
+u:r:adbd:s0                    shell          429   448     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:00 jdwp control
+u:r:adbd:s0                    shell          429   505     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:00 adbd
+u:r:adbd:s0                    shell          429   506     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:00 adbd
+u:r:adbd:s0                    shell          429  1699     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:01 adbd
+u:r:adbd:s0                    shell          429  1700     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:00 adbd
+u:r:adbd:s0                    shell          429  3015     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:00 shell svc 3014
+u:r:adbd:s0                    shell          429  3084     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:00 shell svc 3081
+u:r:adbd:s0                    shell          429  3105     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:00 shell svc 3103
+u:r:adbd:s0                    shell          429  3119     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:00 shell svc 3116
+u:r:adbd:s0                    shell          429  3132     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:00 shell svc 3130
+u:r:adbd:s0                    shell          429  3140     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:00 shell svc 3139
+u:r:adbd:s0                    shell          429  5086     1   10867088   4788 0                   0 S  19   0      -   0  fg 00:00:00 shell svc 5085
+u:r:drmserver:s0               drm            435   435     1   10870532   2512 0                   0 S  19   0      -   0  fg 00:00:00 drmserver
+u:r:drmserver:s0               drm            435   441     1   10870532   2512 0                   0 S  19   0      -   0  fg 00:00:00 DrmManagerMetri
+u:r:drmserver:s0               drm            435   449     1   10870532   2512 0                   0 S  19   0      -   0  fg 00:00:00 binder:435_1
+u:r:drmserver:s0               drm            435  5381     1   10870532   2512 0                   0 S  19   0      -   0  fg 00:00:00 binder:435_2
+u:r:traced_probes:s0           nobody         439   439     1   10854528   1364 0                   0 S  19   0      -   0     00:00:00 traced_probes
+u:r:traced_probes:s0           nobody         439   450     1   10854528   1364 0                   0 S  19   0      -   0     00:00:00 traced_probes
+u:r:traced_probes:s0           nobody         439   453     1   10854528   1364 0                   0 S  19   0      -   0     00:00:00 traced_probes
+u:r:traced:s0                  nobody         440   440     1   10802684   1456 0                   0 S  19   0      -   0     00:00:00 traced
+u:r:traced:s0                  nobody         440   452     1   10802684   1456 0                   0 S  19   0      -   0     00:00:00 traced
+u:r:mdnsd:s0                   mdnsr          451   451     1   10773732   1928 0                   0 S  19   0      -   0  fg 00:00:00 mdnsd
+u:r:bt_vhci_forwarder:s0       bluetooth      457   457     1   10811336   1668 0                   0 S  19   0      -   0  fg 00:00:00 bt_vhci_forward
+u:r:cameraserver:s0            cameraserver   458   458     1   11417616   4408 0                   0 S  19   0      -   0  ta 00:00:00 binder:458_2
+u:r:cameraserver:s0            cameraserver   458   529     1   11417616   4408 0                   0 S  19   0      -   0  ta 00:00:00 HwBinder:458_1
+u:r:cameraserver:s0            cameraserver   458   530     1   11417616   4408 0                   0 S  19   0      -   0  ta 00:00:00 HwBinder:458_2
+u:r:cameraserver:s0            cameraserver   458   533     1   11417616   4408 0                   0 S  19   0      -   0  ta 00:00:00 binder:458_1
+u:r:cameraserver:s0            cameraserver   458   534     1   11417616   4408 0                   0 S  19   0      -   0  ta 00:00:00 binder:458_3
+u:r:cameraserver:s0            cameraserver   458   535     1   11417616   4408 0                   0 S  19   0      -   0  ta 00:00:00 binder:458_4
+u:r:cameraserver:s0            cameraserver   458  3777     1   11417616   4408 0                   0 S  19   0      -   0  ta 00:00:00 binder:458_5
+u:r:cameraserver:s0            cameraserver   458  5397     1   11417616   4408 0                   0 S  19   0      -   0  ta 00:00:00 binder:458_6
+u:r:incidentd:s0               incidentd      461   461     1   10843176   3148 0                   0 S  19   0      -   0  fg 00:00:00 binder:461_2
+u:r:incidentd:s0               incidentd      461   466     1   10843176   3148 0                   0 S  19   0      -   0  fg 00:00:00 binder:461_1
+u:r:incidentd:s0               incidentd      461   467     1   10843176   3148 0                   0 S  19   0      -   0  fg 00:00:00 binder:461_3
+u:r:installd:s0                root           462   462     1   10852104   2420 0                   0 S  19   0      -   0  fg 00:00:00 binder:462_2
+u:r:installd:s0                root           462   472     1   10852104   2420 0                   0 S  19   0      -   0  fg 00:00:00 binder:462_1
+u:r:mediaextractor:s0          mediaex        463   463     1   11254380   4352 0                   0 S  19   0      -   0  fg 00:00:00 mediaextractor
+u:r:mediaextractor:s0          mediaex        463   487     1   11254380   4352 0                   0 S  19   0      -   0  fg 00:00:00 binder:463_1
+u:r:mediaextractor:s0          mediaex        463   763     1   11254380   4352 0                   0 S  19   0      -   0  fg 00:00:00 binder:463_2
+u:r:mediaextractor:s0          mediaex        463   764     1   11254380   4352 0                   0 S  19   0      -   0  fg 00:00:00 binder:463_3
+u:r:mediaextractor:s0          mediaex        463  3426     1   11254380   4352 0                   0 S  19   0      -   0  fg 00:00:00 binder:463_4
+u:r:mediametrics:s0            media          465   465     1   10906496   2252 0                   0 S  19   0      -   0  fg 00:00:00 mediametrics
+u:r:mediametrics:s0            media          465   476     1   10906496   2252 0                   0 S  19   0      -   0  fg 00:00:00 mediametrics
+u:r:mediametrics:s0            media          465   477     1   10906496   2252 0                   0 S  19   0      -   0  fg 00:00:00 binder:465_1
+u:r:mediametrics:s0            media          465   612     1   10906496   2252 0                   0 S  19   0      -   0  fg 00:00:00 binder:465_2
+u:r:mediametrics:s0            media          465   613     1   10906496   2252 0                   0 S  19   0      -   0  fg 00:00:00 binder:465_3
+u:r:mediametrics:s0            media          465   614     1   10906496   2252 0                   0 S  19   0      -   0  fg 00:00:00 binder:465_4
+u:r:mediametrics:s0            media          465  1098     1   10906496   2252 0                   0 S  19   0      -   0  fg 00:00:00 binder:465_5
+u:r:mediametrics:s0            media          465  1099     1   10906496   2252 0                   0 S  19   0      -   0  fg 00:00:00 binder:465_6
+u:r:mediaserver:s0             media          468   468     1   11150328   3944 0                   0 S  19   0      -   0  fg 00:00:00 mediaserver
+u:r:mediaserver:s0             media          468   486     1   11150328   3944 0                   0 S  19   0      -   0  fg 00:00:00 binder:468_1
+u:r:mediaserver:s0             media          468   812     1   11150328   3944 0                   0 S  19   0      -   0  fg 00:00:00 binder:468_2
+u:r:mediaserver:s0             media          468   813     1   11150328   3944 0                   0 S  19   0      -   0  fg 00:00:00 binder:468_3
+u:r:mediaserver:s0             media          468  3300     1   11150328   3944 0                   0 S  19   0      -   0  fg 00:00:00 binder:468_4
+u:r:mediaserver:s0             media          468  3301     1   11150328   3944 0                   0 S  19   0      -   0  fg 00:00:00 binder:468_5
+u:r:mediaserver:s0             media          468  3318     1   11150328   3944 0                   0 S  19   0      -   0  fg 00:00:00 binder:468_6
+u:r:mediaserver:s0             media          468  4523     1   11150328   3944 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:468_1
+u:r:mediaserver:s0             media          468  4524     1   11150328   3944 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:468_2
+u:r:mediaserver:s0             media          468  4534     1   11150328   3944 0                   0 S  19   0      -   0  fg 00:00:00 CCodecWatchdog
+u:r:mediaserver:s0             media          468  4535     1   11150328   3944 0                   0 S  35 -16      -   0  fg 00:00:00 NPDecoder-CL
+u:r:mediaserver:s0             media          468  4536     1   11150328   3944 0                   0 S  35 -16      -   0  fg 00:00:00 NPDecoder-CL
+u:r:mediaserver:s0             media          468  4538     1   11150328   3944 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:468_3
+u:r:mediaserver:s0             media          468  4539     1   11150328   3944 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:468_4
+u:r:mediaserver:s0             media          468  4540     1   11150328   3944 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:468_5
+u:r:mediaserver:s0             media          468  4554     1   11150328   3944 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:468_6
+u:r:storaged:s0                root           469   469     1   10891700   2408 0                   0 S   9  10      -   0     00:00:00 storaged
+u:r:storaged:s0                root           469   615     1   10891700   2408 0                   0 S   9  10      -   0     00:00:00 storaged
+u:r:storaged:s0                root           469   616     1   10891700   2408 0                   0 S   9  10      -   0     00:00:00 binder:469_1
+u:r:storaged:s0                root           469   617     1   10891700   2408 0                   0 S   9  10      -   0     00:00:00 binder:469_2
+u:r:wificond:s0                wifi           470   470     1   10830948   2344 0                   0 S  19   0      -   0  fg 00:00:00 wificond
+u:r:wificond:s0                wifi           470   480     1   10830948   2344 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:470_1
+u:r:rild:s0                    radio          471   471     1   10968992   2772 0                   0 S  19   0      -   0  fg 00:00:00 libgoldfish-ril
+u:r:rild:s0                    radio          471   500     1   10968992   2772 0                   0 S  19   0      -   0  fg 00:00:00 libgoldfish-ril
+u:r:rild:s0                    radio          471   502     1   10968992   2772 0                   0 S  19   0      -   0  fg 00:00:00 libgoldfish-ril
+u:r:rild:s0                    radio          471   503     1   10968992   2772 0                   0 S  19   0      -   0  fg 00:00:00 libgoldfish-ril
+u:r:rild:s0                    radio          471   504     1   10968992   2772 0                   0 S  19   0      -   0  fg 00:00:00 libgoldfish-ril
+u:r:mediaswcodec:s0            mediacodec     474   474     1   11147984   4708 0                   0 S  19   0      -   0  fg 00:00:00 mediaswcodec
+u:r:mediaswcodec:s0            mediacodec     474   509     1   11147984   4708 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:474_1
+u:r:mediaswcodec:s0            mediacodec     474   757     1   11147984   4708 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:474_1
+u:r:mediaswcodec:s0            mediacodec     474   758     1   11147984   4708 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:474_1
+u:r:mediaswcodec:s0            mediacodec     474   803     1   11147984   4708 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:474_2
+u:r:mediaswcodec:s0            mediacodec     474   806     1   11147984   4708 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:474_3
+u:r:mediaswcodec:s0            mediacodec     474   822     1   11147984   4708 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:474_4
+u:r:mediaswcodec:s0            mediacodec     474   824     1   11147984   4708 0                   0 S  19   0      -   0  fg 00:00:00 HwBinder:474_5
+u:r:mediaswcodec:s0            mediacodec     474   825     1   11147984   4708 0                   0 S  35 -16      -   0  fg 00:00:00 HwBinder:474_2
+u:r:gatekeeperd:s0             system         475   475     1   10833288   2136 0                   0 S  19   0      -   0     00:00:00 gatekeeperd
+u:r:system_server:s0           system         552   552   352   15666344 136208 0                   0 R  21  -2      -   0  fg 00:00:05 system_server
+u:r:system_server:s0           system         552   559   352   15666344 136208 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:system_server:s0           system         552   560   352   15666344 136208 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:system_server:s0           system         552   561   352   15666344 136208 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:system_server:s0           system         552   562   352   15666344 136208 0                   0 S  15   4      -   0  fg 00:00:01 HeapTaskDaemon
+u:r:system_server:s0           system         552   563   352   15666344 136208 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:system_server:s0           system         552   564   352   15666344 136208 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:system_server:s0           system         552   565   352   15666344 136208 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:system_server:s0           system         552   566   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 binder:552_1
+u:r:system_server:s0           system         552   567   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 binder:552_2
+u:r:system_server:s0           system         552   568   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 atchdog.monitor
+u:r:system_server:s0           system         552   569   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 android.fg
+u:r:system_server:s0           system         552   570   352   15666344 136208 0                   0 S  21  -2      -   0  ta 00:00:01 android.ui
+u:r:system_server:s0           system         552   571   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 android.io
+u:r:system_server:s0           system         552   572   352   15666344 136208 0                   0 S  22  -3      -   0  ta 00:00:00 android.display
+u:r:system_server:s0           system         552   573   352   15666344 136208 0                   0 S  23  -4      -   0  ta 00:00:00 android.anim
+u:r:system_server:s0           system         552   574   352   15666344 136208 0                   0 S  23  -4      -   0  ta 00:00:00 android.anim.lf
+u:r:system_server:s0           system         552   575   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 watchdog
+u:r:system_server:s0           system         552   579   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 PowerStatsServi
+u:r:system_server:s0           system         552   580   352   15666344 136208 0                   0 R   9  10      -   0  fg 00:00:02 android.bg
+u:r:system_server:s0           system         552   581   352   15666344 136208 0                   0 R  21  -2      -   0  fg 00:00:01 ActivityManager
+u:r:system_server:s0           system         552   582   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 ActivityManager
+u:r:system_server:s0           system         552   583   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 ActivityManager
+u:r:system_server:s0           system         552   584   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 ActivityManager
+u:r:system_server:s0           system         552   585   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 Thread-2
+u:r:system_server:s0           system         552   586   352   15666344 136208 0                   0 S  29 -10      -   0  fg 00:00:00 OomAdjuster
+u:r:system_server:s0           system         552   587   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 batterystats-ha
+u:r:system_server:s0           system         552   588   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 batterystats-wo
+u:r:system_server:s0           system         552   589   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 bgres-controlle
+u:r:system_server:s0           system         552   590   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 FileObserver
+u:r:system_server:s0           system         552   592   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 CpuTracker
+u:r:system_server:s0           system         552   593   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 CriticalEventLo
+u:r:system_server:s0           system         552   594   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 DataLoaderManag
+u:r:system_server:s0           system         552   595   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 Thread-3
+u:r:system_server:s0           system         552   596   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 Thread-4
+u:r:system_server:s0           system         552   597   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 Thread-5
+u:r:system_server:s0           system         552   598   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 Thread-6
+u:r:system_server:s0           system         552   599   352   15666344 136208 0                   0 S  23  -4      -   0  fg 00:00:00 PowerManagerSer
+u:r:system_server:s0           system         552   600   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 BatteryStats_wa
+u:r:system_server:s0           system         552   602   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 PackageManagerB
+u:r:system_server:s0           system         552   603   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 PermissionManag
+u:r:system_server:s0           system         552   604   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 DefaultPermGran
+u:r:system_server:s0           system         552   605   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 PackageManager
+u:r:system_server:s0           system         552   619   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 PackageInstalle
+u:r:system_server:s0           system         552   620   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 binder:552_3
+u:r:system_server:s0           system         552   621   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 OverlayManager
+u:r:system_server:s0           system         552   626   352   15666344 136208 0                   0 S  27  -8      -   0  fg 00:00:00 SensorEventAckR
+u:r:system_server:s0           system         552   627   352   15666344 136208 0                   0 S  50  -8     10   1  fg 00:00:00 SensorService
+u:r:system_server:s0           system         552   628   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 HealthServiceBi
+u:r:system_server:s0           system         552   629   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:02 eduling.default
+u:r:system_server:s0           system         552   630   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 RollbackPackage
+u:r:system_server:s0           system         552   631   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 RollbackManager
+u:r:system_server:s0           system         552   632   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 NativeTombstone
+u:r:system_server:s0           system         552   634   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 AccountManagerS
+u:r:system_server:s0           system         552   635   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 SettingsProvide
+u:r:system_server:s0           system         552   636   352   15666344 136208 0                   0 S  17   2      -   0  fg 00:00:00 CachedAppOptimi
+u:r:system_server:s0           system         552   637   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 oregroundThread
+u:r:system_server:s0           system         552   638   352   15666344 136208 0                   0 S  27  -8      -   0  fg 00:00:00 Thread-7
+u:r:system_server:s0           system         552   639   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 tare
+u:r:system_server:s0           system         552   640   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 AlarmManager
+u:r:system_server:s0           system         552   642   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-2-thread-1
+u:r:system_server:s0           system         552   643   352   15666344 136208 0                   0 S  23  -4      -   0  fg 00:00:00 CameraService_p
+u:r:system_server:s0           system         552   644   352   15666344 136208 0                   0 S   9  10      -   0  ta 00:00:00 LazyTaskWriterT
+u:r:system_server:s0           system         552   645   352   15666344 136208 0                   0 S  19   0      -   0  ta 00:00:00 AccessibilityTr
+u:r:system_server:s0           system         552   646   352   15666344 136208 0                   0 S  27  -8      -   0  fg 00:00:00 InputDispatcher
+u:r:system_server:s0           system         552   647   352   15666344 136208 0                   0 S  27  -8      -   0  fg 00:00:00 InputReader
+u:r:system_server:s0           system         552   648   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 HwBinder:552_1
+u:r:system_server:s0           system         552   649   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 HwBinder:552_2
+u:r:system_server:s0           system         552   650   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 BluetoothManage
+u:r:system_server:s0           system         552   651   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:11 NetworkWatchlis
+u:r:system_server:s0           system         552   652   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 AppIntegrityMan
+u:r:system_server:s0           system         552   653   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 android.imms
+u:r:system_server:s0           system         552   654   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 FlashNotificati
+u:r:system_server:s0           system         552   655   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 FlashNotifContr
+u:r:system_server:s0           system         552   656   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 StorageManagerS
+u:r:system_server:s0           system         552   658   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 LocaleManagerSe
+u:r:system_server:s0           system         552   661   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:01 binder:552_4
+u:r:system_server:s0           system         552   662   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 LockSettingsSer
+u:r:system_server:s0           system         552   678   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 NetworkStats
+u:r:system_server:s0           system         552   679   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 NetworkPolicy
+u:r:system_server:s0           system         552   680   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 tworkPolicy.uid
+u:r:system_server:s0           system         552   681   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 WifiHandlerThre
+u:r:system_server:s0           system         552   682   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 WifiDiagnostics
+u:r:system_server:s0           system         552   683   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 WifiP2pService
+u:r:system_server:s0           system         552   684   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 PasspointProvis
+u:r:system_server:s0           system         552   685   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 WifiScanningSer
+u:r:system_server:s0           system         552   686   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 WifiManagerThre
+u:r:system_server:s0           system         552   687   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pacproxyservice
+u:r:system_server:s0           system         552   688   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 ConnectivitySer
+u:r:system_server:s0           system         552   689   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 CarrierPrivileg
+u:r:system_server:s0           system         552   690   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 ackgroundThread
+u:r:system_server:s0           system         552   691   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 NsdService
+u:r:system_server:s0           system         552   692   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 oregroundThread
+u:r:system_server:s0           system         552   693   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 VpnManagerServi
+u:r:system_server:s0           system         552   694   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 VcnManagementSe
+u:r:system_server:s0           system         552   695   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 ranker
+u:r:system_server:s0           system         552   696   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 onProviders.ECP
+u:r:system_server:s0           system         552   697   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 DeviceStorageMo
+u:r:system_server:s0           system         552   698   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 AS.SfxWorker
+u:r:system_server:s0           system         552   699   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 AudioService
+u:r:system_server:s0           system         552   700   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 AudioDeviceBrok
+u:r:system_server:s0           system         552   701   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 AudioPortEventH
+u:r:system_server:s0           system         552   703   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 backActivityMon
+u:r:system_server:s0           system         552   704   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 MediaFocusContr
+u:r:system_server:s0           system         552   705   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 Thread-8
+u:r:system_server:s0           system         552   706   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-16-thread-
+u:r:system_server:s0           system         552   707   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 SoundTriggerHal
+u:r:system_server:s0           system         552   709   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 UEventObserver
+u:r:system_server:s0           system         552   711   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 ConnectivityThr
+u:r:system_server:s0           system         552   712   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 backup
+u:r:system_server:s0           system         552   713   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 AppWidgetServic
+u:r:system_server:s0           system         552   714   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 ackgroundThread
+u:r:system_server:s0           system         552   717   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 NetworkTimeUpda
+u:r:system_server:s0           system         552   718   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 BlobStore
+u:r:system_server:s0           system         552   719   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 GraphicsStats-d
+u:r:system_server:s0           system         552   721   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 SessionRecordTh
+u:r:system_server:s0           system         552   726   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 BackgroundInsta
+u:r:system_server:s0           system         552   727   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 SliceManagerSer
+u:r:system_server:s0           system         552   728   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 StatsCompanionS
+u:r:system_server:s0           system         552   730   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 SdkSandboxManag
+u:r:system_server:s0           system         552   731   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 SdkSandboxManag
+u:r:system_server:s0           system         552   732   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 ackgroundThread
+u:r:system_server:s0           system         552   733   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 AdServicesManag
+u:r:system_server:s0           system         552   737   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 Thread-10
+u:r:system_server:s0           system         552   738   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 ClipboardServic
+u:r:system_server:s0           system         552   739   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 PhotonicModulat
+u:r:system_server:s0           system         552   742   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 HealthServiceBi
+u:r:system_server:s0           system         552   743   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 TaskSnapshotPer
+u:r:system_server:s0           system         552   745   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 android.perm
+u:r:system_server:s0           system         552   749   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 GameManagerServ
+u:r:system_server:s0           system         552   750   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:01 binder:552_5
+u:r:system_server:s0           system         552   751   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-22-thread-
+u:r:system_server:s0           system         552   753   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 ackgroundThread
+u:r:system_server:s0           system         552   754   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 SyncManager
+u:r:system_server:s0           system         552   759   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 NetworkStatsObs
+u:r:system_server:s0           system         552   782   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 Thread-13
+u:r:system_server:s0           system         552   801   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 nearbyfg
+u:r:system_server:s0           system         552   816   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 CCodecWatchdog
+u:r:system_server:s0           system         552   817   352   15666344 136208 0                   0 S  35 -16      -   0  fg 00:00:00 NDK MediaCodec_
+u:r:system_server:s0           system         552   818   352   15666344 136208 0                   0 S  35 -16      -   0  fg 00:00:00 NDK MediaCodec_
+u:r:system_server:s0           system         552   826   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 binder:552_6
+u:r:system_server:s0           system         552   827   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 HwBinder:552_3
+u:r:system_server:s0           system         552   828   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 HwBinder:552_4
+u:r:system_server:s0           system         552   830   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 EmergencyAfford
+u:r:system_server:s0           system         552   833   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 HwBinder:552_5
+u:r:system_server:s0           system         552   834   352   15666344 136208 0                   0 R  19   0      -   0  fg 00:00:00 binder:552_7
+u:r:system_server:s0           system         552   835   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:01 binder:552_8
+u:r:system_server:s0           system         552   841   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 binder:552_9
+u:r:system_server:s0           system         552   842   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:01 binder:552_A
+u:r:system_server:s0           system         552   944   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 DeviceLockContr
+u:r:system_server:s0           system         552  1067   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 BluetoothRouteM
+u:r:system_server:s0           system         552  1071   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 uteStateMachine
+u:r:system_server:s0           system         552  1072   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 CallAudioModeSt
+u:r:system_server:s0           system         552  1073   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 ConnectionSvrFo
+u:r:system_server:s0           system         552  1077   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 binder:552_B
+u:r:system_server:s0           system         552  1079   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 binder:552_C
+u:r:system_server:s0           system         552  1080   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 VoipCallMonitor
+u:r:system_server:s0           system         552  1209   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-25-thread-
+u:r:system_server:s0           system         552  1277   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 AsyncTask #2
+u:r:system_server:s0           system         552  1328   352   15666344 136208 0                   0 S  19   0      -   0  ta 00:00:00 PowerStatsServi
+u:r:system_server:s0           system         552  1329   352   15666344 136208 0                   0 S  19   0      -   0  ta 00:00:00 pool-7-thread-1
+u:r:system_server:s0           system         552  1331   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 RedirectListene
+u:r:system_server:s0           system         552  1332   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 AdbDebuggingMan
+u:r:system_server:s0           system         552  1351   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 OsuServerHandle
+u:r:system_server:s0           system         552  1413   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 StorageUserConn
+u:r:system_server:s0           system         552  1412   352   15666344 136208 0                   0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:system_server:s0           system         552  1471   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 backup-0
+u:r:system_server:s0           system         552  1523   352   15666344 136208 0                   0 R  21  -2      -   0  fg 00:00:01 binder:552_D
+u:r:system_server:s0           system         552  1526   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 binder:552_E
+u:r:system_server:s0           system         552  1527   352   15666344 136208 0                   0 R  21  -2      -   0  fg 00:00:01 binder:552_F
+u:r:system_server:s0           system         552  1531   352   15666344 136208 0                   0 R  21  -2      -   0  fg 00:00:01 binder:552_10
+u:r:system_server:s0           system         552  1533   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:01 pool-63-thread-
+u:r:system_server:s0           system         552  1538   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-65-thread-
+u:r:system_server:s0           system         552  1597   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 LazyTaskWriterT
+u:r:system_server:s0           system         552  1614   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-21-thread-
+u:r:system_server:s0           system         552  1617   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-70-thread-
+u:r:system_server:s0           system         552  1745   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:01 binder:552_11
+u:r:system_server:s0           system         552  1747   352   15666344 136208 0                   0 R  19   0      -   0  fg 00:00:00 binder:552_12
+u:r:system_server:s0           system         552  1937   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:01 binder:552_13
+u:r:system_server:s0           system         552  1938   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:01 binder:552_14
+u:r:system_server:s0           system         552  1977   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:01 binder:552_15
+u:r:system_server:s0           system         552  1987   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:01 binder:552_16
+u:r:system_server:s0           system         552  1995   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 binder:552_17
+u:r:system_server:s0           system         552  1996   352   15666344 136208 0                   0 R  21  -2      -   0  fg 00:00:01 binder:552_18
+u:r:system_server:s0           system         552  2018   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 binder:552_19
+u:r:system_server:s0           system         552  2019   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:01 binder:552_1A
+u:r:system_server:s0           system         552  2020   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 binder:552_1B
+u:r:system_server:s0           system         552  2021   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 binder:552_1C
+u:r:system_server:s0           system         552  2023   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:01 binder:552_1D
+u:r:system_server:s0           system         552  2024   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:01 binder:552_1E
+u:r:system_server:s0           system         552  2027   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:01 binder:552_1F
+u:r:system_server:s0           system         552  2034   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:01 binder:552_20
+u:r:system_server:s0           system         552  2156   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-61-thread-
+u:r:system_server:s0           system         552  2195   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-50-thread-
+u:r:system_server:s0           system         552  2315   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-56-thread-
+u:r:system_server:s0           system         552  2353   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-57-thread-
+u:r:system_server:s0           system         552  3259   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-38-thread-
+u:r:system_server:s0           system         552  4063   352   15666344 136208 0                   0 S   9  10      -   0  fg 00:00:00 pool-9-thread-1
+u:r:system_server:s0           system         552  4066   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 AsyncQueryWorke
+u:r:system_server:s0           system         552  4482   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-164-thread
+u:r:system_server:s0           system         552  5032   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-174-thread
+u:r:system_server:s0           system         552  5149   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-175-thread
+u:r:system_server:s0           system         552  5213   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-176-thread
+u:r:system_server:s0           system         552  5223   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-177-thread
+u:r:system_server:s0           system         552  5273   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-178-thread
+u:r:system_server:s0           system         552  5460   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-179-thread
+u:r:system_server:s0           system         552  5471   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-6-thread-1
+u:r:system_server:s0           system         552  5483   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-180-thread
+u:r:system_server:s0           system         552  5484   352   15666344 136208 0                   0 S  19   0      -   0  fg 00:00:00 pool-181-thread
+u:r:kernel:s0                  root           558   558     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:02 kworker/1:4H-kblockd
+u:r:hal_fingerprint_default:s0 system         725   725     1   10833624   1936 0                   0 S  19   0      -   0     00:00:00 binder:725_2
+u:r:hal_fingerprint_default:s0 system         725   734     1   10833624   1936 0                   0 S  19   0      -   0     00:00:00 binder:725_1
+u:r:hal_fingerprint_default:s0 system         725   736     1   10833624   1936 0                   0 S  19   0      -   0     00:00:00 binder:725_3
+u:r:hal_fingerprint_default:s0 system         725   978     1   10833624   1936 0                   0 S  21  -2      -   0     00:00:00 binder:725_2
+u:r:hal_wifi_supplicant_default:s0 wifi       747   747     1   10963764   2664 0                   0 S  19   0      -   0  fg 00:00:00 wpa_supplicant
+u:r:platform_app:s0:c512,c768  u0_a164        760   760   352   14027820  69812 0                   0 R  19   0      -   0  fg 00:00:02 ndroid.systemui
+u:r:platform_app:s0:c512,c768  u0_a164        760   770   352   14027820  69812 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:platform_app:s0:c512,c768  u0_a164        760   771   352   14027820  69812 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:platform_app:s0:c512,c768  u0_a164        760   772   352   14027820  69812 0                   0 S  39 -20      -   0  fg 00:00:00 ADB-JDWP Connec
+u:r:platform_app:s0:c512,c768  u0_a164        760   773   352   14027820  69812 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:platform_app:s0:c512,c768  u0_a164        760   774   352   14027820  69812 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:platform_app:s0:c512,c768  u0_a164        760   775   352   14027820  69812 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:platform_app:s0:c512,c768  u0_a164        760   776   352   14027820  69812 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:platform_app:s0:c512,c768  u0_a164        760   777   352   14027820  69812 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:platform_app:s0:c512,c768  u0_a164        760   779   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 binder:760_1
+u:r:platform_app:s0:c512,c768  u0_a164        760   780   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 binder:760_2
+u:r:platform_app:s0:c512,c768  u0_a164        760   781   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 binder:760_3
+u:r:platform_app:s0:c512,c768  u0_a164        760   795   352   14027820  69812 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:platform_app:s0:c512,c768  u0_a164        760   802   352   14027820  69812 0                   0 S  23  -4      -   0  fg 00:00:00 wmshell.main
+u:r:platform_app:s0:c512,c768  u0_a164        760   808   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 InteractionJank
+u:r:platform_app:s0:c512,c768  u0_a164        760   810   352   14027820  69812 0                   0 S   9  10      -   0  fg 00:00:00 hell.background
+u:r:platform_app:s0:c512,c768  u0_a164        760   811   352   14027820  69812 0                   0 S  23  -4      -   0  fg 00:00:00 wmshell.anim
+u:r:platform_app:s0:c512,c768  u0_a164        760   814   352   14027820  69812 0                   0 S  29 -10      -   0  fg 00:00:00 ll.splashscreen
+u:r:platform_app:s0:c512,c768  u0_a164        760   815   352   14027820  69812 0                   0 S  29 -10      -   0  fg 00:00:00 ll.splashworker
+u:r:platform_app:s0:c512,c768  u0_a164        760   829   352   14027820  69812 0                   0 S   9  10      -   0  fg 00:00:00 SysUiBg
+u:r:platform_app:s0:c512,c768  u0_a164        760   831   352   14027820  69812 0                   0 S   9  10      -   0  fg 00:00:00 BroadcastRunnin
+u:r:platform_app:s0:c512,c768  u0_a164        760   837   352   14027820  69812 0                   0 S  23  -4      -   0  fg 00:00:00 RenderThread
+u:r:platform_app:s0:c512,c768  u0_a164        760   845   352   14027820  69812 0                   0 S   9  10      -   0  fg 00:00:00 android.bg
+u:r:platform_app:s0:c512,c768  u0_a164        760   846   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 pool-2-thread-1
+u:r:platform_app:s0:c512,c768  u0_a164        760   862   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 binder:760_4
+u:r:platform_app:s0:c512,c768  u0_a164        760   867   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 biometrics
+u:r:platform_app:s0:c512,c768  u0_a164        760   886   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 plugin
+u:r:platform_app:s0:c512,c768  u0_a164        760   892   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 pool-4-thread-1
+u:r:platform_app:s0:c512,c768  u0_a164        760   895   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 async_sensor
+u:r:platform_app:s0:c512,c768  u0_a164        760   897   352   14027820  69812 0                   0 S   9  10      -   0  fg 00:00:00 AsyncTask #1
+u:r:platform_app:s0:c512,c768  u0_a164        760   905   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 DefaultDispatch
+u:r:platform_app:s0:c512,c768  u0_a164        760   922   352   14027820  69812 0                   0 S   9  10      -   0  fg 00:00:00 SysUiLng
+u:r:platform_app:s0:c512,c768  u0_a164        760   923   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 DefaultWallpape
+u:r:platform_app:s0:c512,c768  u0_a164        760   924   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 ImageWallpaper
+u:r:platform_app:s0:c512,c768  u0_a164        760   942   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 binder:760_5
+u:r:platform_app:s0:c512,c768  u0_a164        760   954   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 ScreenDecoratio
+u:r:platform_app:s0:c512,c768  u0_a164        760   999   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 WifiManagerThre
+u:r:platform_app:s0:c512,c768  u0_a164        760  1035   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 ConnectivityThr
+u:r:platform_app:s0:c512,c768  u0_a164        760  1081   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 VolumeDialogCon
+u:r:platform_app:s0:c512,c768  u0_a164        760  1091   352   14027820  69812 0                   0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:platform_app:s0:c512,c768  u0_a164        760  1092   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 binder:760_5
+u:r:platform_app:s0:c512,c768  u0_a164        760  1094   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 TimeTick
+u:r:platform_app:s0:c512,c768  u0_a164        760  1102   352   14027820  69812 0                   0 S   9  10      -   0  fg 00:00:00 Keyboard
+u:r:platform_app:s0:c512,c768  u0_a164        760  1127   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 CCodecWatchdog
+u:r:platform_app:s0:c512,c768  u0_a164        760  1129   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 DefaultDispatch
+u:r:platform_app:s0:c512,c768  u0_a164        760  1130   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 DefaultDispatch
+u:r:platform_app:s0:c512,c768  u0_a164        760  1131   352   14027820  69812 0                   0 S  35 -16      -   0  fg 00:00:00 NDK MediaCodec_
+u:r:platform_app:s0:c512,c768  u0_a164        760  1133   352   14027820  69812 0                   0 S  35 -16      -   0  fg 00:00:00 NDK MediaCodec_
+u:r:platform_app:s0:c512,c768  u0_a164        760  1134   352   14027820  69812 0                   0 S  23  -4      -   0  fg 00:00:00 HwBinder:760_1
+u:r:platform_app:s0:c512,c768  u0_a164        760  1142   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 DefaultDispatch
+u:r:platform_app:s0:c512,c768  u0_a164        760  1158   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 CameraManagerGl
+u:r:platform_app:s0:c512,c768  u0_a164        760  1162   352   14027820  69812 0                   0 S  21  -2      -   0  fg 00:00:00 MTViewCapture
+u:r:platform_app:s0:c512,c768  u0_a164        760  1165   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 pool-5-thread-1
+u:r:platform_app:s0:c512,c768  u0_a164        760  1208   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 AsyncLayoutInfl
+u:r:platform_app:s0:c512,c768  u0_a164        760  1214   352   14027820  69812 0                   0 S  20  -1      -   0  fg 00:00:00 ndroid.systemui
+u:r:platform_app:s0:c512,c768  u0_a164        760  1215   352   14027820  69812 0                   0 S  20  -1      -   0  fg 00:00:00 ndroid.systemui
+u:r:platform_app:s0:c512,c768  u0_a164        760  1216   352   14027820  69812 0                   0 S  20  -1      -   0  fg 00:00:00 ndroid.systemui
+u:r:platform_app:s0:c512,c768  u0_a164        760  1217   352   14027820  69812 0                   0 S  20  -1      -   0  fg 00:00:00 ndroid.systemui
+u:r:platform_app:s0:c512,c768  u0_a164        760  1218   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 RSMessageThread
+u:r:platform_app:s0:c512,c768  u0_a164        760  1238   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 binder:760_6
+u:r:platform_app:s0:c512,c768  u0_a164        760  1258   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 binder:760_7
+u:r:platform_app:s0:c512,c768  u0_a164        760  1270   352   14027820  69812 0                   0 R  19   0      -   0  fg 00:00:00 binder:760_8
+u:r:platform_app:s0:c512,c768  u0_a164        760  1286   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 SurfaceSyncGrou
+u:r:platform_app:s0:c512,c768  u0_a164        760  1290   352   14027820  69812 0                   0 S  21  -2      -   0  fg 00:00:00 hwuiTask0
+u:r:platform_app:s0:c512,c768  u0_a164        760  1291   352   14027820  69812 0                   0 S  21  -2      -   0  fg 00:00:00 hwuiTask1
+u:r:platform_app:s0:c512,c768  u0_a164        760  1462   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 GrallocUploadTh
+u:r:platform_app:s0:c512,c768  u0_a164        760  1657   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 binder:760_9
+u:r:platform_app:s0:c512,c768  u0_a164        760  1667   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 binder:760_A
+u:r:platform_app:s0:c512,c768  u0_a164        760  2822   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 pool-7-thread-1
+u:r:platform_app:s0:c512,c768  u0_a164        760  4542   352   14027820  69812 0                   0 S  19   0      -   0  fg 00:00:00 AudioPortEventH
+u:r:hal_gnss_default:s0        gps            809   809     1   10822680   1976 0                   0 S  19   0      -   0  fg 00:00:00 binder:809_2
+u:r:hal_gnss_default:s0        gps            809   819     1   10822680   1976 0                   0 S  19   0      -   0  fg 00:00:00 binder:809_1
+u:r:hal_gnss_default:s0        gps            809   820     1   10822680   1976 0                   0 S  19   0      -   0  fg 00:00:00 binder:809_3
+u:r:webview_zygote:s0          webview_zygote 855   855   352   14205796  34084 0                   0 S  19   0      -   0  fg 00:00:00 webview_zygote
+u:r:webview_zygote:s0          webview_zygote 855   863   352   14205796  34084 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:webview_zygote:s0          webview_zygote 855   864   352   14205796  34084 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:webview_zygote:s0          webview_zygote 855   865   352   14205796  34084 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:webview_zygote:s0          webview_zygote 855   866   352   14205796  34084 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:network_stack:s0           network_stack  868   868   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 rkstack.process
+u:r:network_stack:s0           network_stack  868   874   352   13709388  51128 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:network_stack:s0           network_stack  868   875   352   13709388  51128 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:network_stack:s0           network_stack  868   876   352   13709388  51128 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:network_stack:s0           network_stack  868   877   352   13709388  51128 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:network_stack:s0           network_stack  868   878   352   13709388  51128 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:network_stack:s0           network_stack  868   879   352   13709388  51128 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:network_stack:s0           network_stack  868   880   352   13709388  51128 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:network_stack:s0           network_stack  868   881   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 binder:868_1
+u:r:network_stack:s0           network_stack  868   883   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 binder:868_2
+u:r:network_stack:s0           network_stack  868   885   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 binder:868_3
+u:r:network_stack:s0           network_stack  868   896   352   13709388  51128 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:network_stack:s0           network_stack  868   946   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 NetworkStackNot
+u:r:network_stack:s0           network_stack  868   980   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 droid.tethering
+u:r:network_stack:s0           network_stack  868  1017   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 WifiManagerThre
+u:r:network_stack:s0           network_stack  868  1064   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 IpClient.wlan0
+u:r:network_stack:s0           network_stack  868  1096   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 binder:868_4
+u:r:network_stack:s0           network_stack  868  1330   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 pool-2-thread-1
+u:r:network_stack:s0           network_stack  868  2114   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 binder:868_5
+u:r:network_stack:s0           network_stack  868  2136   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 NetworkMonitor/
+u:r:network_stack:s0           network_stack  868  2142   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 Thread-2
+u:r:network_stack:s0           network_stack  868  2310   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 binder:868_6
+u:r:network_stack:s0           network_stack  868  2453   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 OkHttp Connecti
+u:r:network_stack:s0           network_stack  868  2464   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 Okio Watchdog
+u:r:network_stack:s0           network_stack  868  3424   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 NetworkMonitor/
+u:r:network_stack:s0           network_stack  868  3430   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 binder:868_7
+u:r:network_stack:s0           network_stack  868  3485   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 OkHttp Connecti
+u:r:network_stack:s0           network_stack  868  5051   352   13709388  51128 0                   0 S  19   0      -   0  fg 00:00:00 AsyncTask #1
+u:r:bluetooth:s0               bluetooth      900   900   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 droid.bluetooth
+u:r:bluetooth:s0               bluetooth      900   912   352   13888052  47488 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:bluetooth:s0               bluetooth      900   913   352   13888052  47488 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:bluetooth:s0               bluetooth      900   914   352   13888052  47488 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:bluetooth:s0               bluetooth      900   915   352   13888052  47488 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:bluetooth:s0               bluetooth      900   916   352   13888052  47488 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:bluetooth:s0               bluetooth      900   917   352   13888052  47488 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:bluetooth:s0               bluetooth      900   918   352   13888052  47488 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:bluetooth:s0               bluetooth      900   920   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 binder:900_1
+u:r:bluetooth:s0               bluetooth      900   921   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 binder:900_2
+u:r:bluetooth:s0               bluetooth      900   925   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 binder:900_3
+u:r:bluetooth:s0               bluetooth      900   941   352   13888052  47488 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:bluetooth:s0               bluetooth      900   983   352   13888052  47488 0                   0 S   9  10      -   0  fg 00:00:00 ackgroundThread
+u:r:bluetooth:s0               bluetooth      900  1013   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 AdapterState
+u:r:bluetooth:s0               bluetooth      900  1022   352   13888052  47488 0                   0 S   9  10      -   0  fg 00:00:00 android.bg
+u:r:bluetooth:s0               bluetooth      900  1025   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 bt_stack_manage
+u:r:bluetooth:s0               bluetooth      900  1026   352   13888052  47488 0                   0 S  41   0      1   1  fg 00:00:00 bt_main_thread
+u:r:bluetooth:s0               bluetooth      900  1027   352   13888052  47488 0                   0 S  41   0      1   1  fg 00:00:00 POSIX timer 0
+u:r:bluetooth:s0               bluetooth      900  1028   352   13888052  47488 0                   0 S  41   0      1   1  fg 00:00:00 POSIX timer 1
+u:r:bluetooth:s0               bluetooth      900  1029   352   13888052  47488 0                   0 S  41   0      1   1  fg 00:00:00 alarm_default_c
+u:r:bluetooth:s0               bluetooth      900  1030   352   13888052  47488 0                   0 S  41   0      1   1  fg 00:00:00 alarm_dispatche
+u:r:bluetooth:s0               bluetooth      900  1033   352   13888052  47488 0                   0 S  41   0      1   1  fg 00:00:00 bt_stack_manage
+u:r:bluetooth:s0               bluetooth      900  1034   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 bt_stack_manage
+u:r:bluetooth:s0               bluetooth      900  1050   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 BT Service Call
+u:r:bluetooth:s0               bluetooth      900  1051   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 Thread-4
+u:r:bluetooth:s0               bluetooth      900  1052   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 Thread-5
+u:r:bluetooth:s0               bluetooth      900  1053   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 BluetoothDataba
+u:r:bluetooth:s0               bluetooth      900  1055   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 BluetoothActive
+u:r:bluetooth:s0               bluetooth      900  1057   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 AudioPortEventH
+u:r:bluetooth:s0               bluetooth      900  1062   352   13888052  47488 0                   0 S   9  10      -   0  fg 00:00:00 AsyncTask #1
+u:r:bluetooth:s0               bluetooth      900  1122   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 BondStateMachin
+u:r:bluetooth:s0               bluetooth      900  1135   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 BluetoothAdvert
+u:r:bluetooth:s0               bluetooth      900  1147   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 BluetoothScanMa
+u:r:bluetooth:s0               bluetooth      900  1151   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 DistanceMeasure
+u:r:bluetooth:s0               bluetooth      900  1152   352   13888052  47488 0                   0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:bluetooth:s0               bluetooth      900  1156   352   13888052  47488 0                   0 S  41   0      1   1  fg 00:00:00 bt_main_thread
+u:r:bluetooth:s0               bluetooth      900  1157   352   13888052  47488 0                   0 S  41   0      1   1  fg 00:00:00 btif_sock
+u:r:bluetooth:s0               bluetooth      900  1160   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 bt_stack_manage
+u:r:bluetooth:s0               bluetooth      900  1163   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 e.StateMachines
+u:r:bluetooth:s0               bluetooth      900  1164   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 bt_a2dp_source_
+u:r:bluetooth:s0               bluetooth      900  1173   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 e.StateMachines
+u:r:bluetooth:s0               bluetooth      900  1174   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 e.StateMachines
+u:r:bluetooth:s0               bluetooth      900  1175   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 BluetoothMapHan
+u:r:bluetooth:s0               bluetooth      900  1179   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 Thread-6
+u:r:bluetooth:s0               bluetooth      900  1180   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 Thread-7
+u:r:bluetooth:s0               bluetooth      900  1181   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 PbapHandlerThre
+u:r:bluetooth:s0               bluetooth      900  1190   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 binder:900_4
+u:r:bluetooth:s0               bluetooth      900  1191   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 Thread-9
+u:r:bluetooth:s0               bluetooth      900  1192   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 Thread-10
+u:r:bluetooth:s0               bluetooth      900  1197   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 Thread-11
+u:r:bluetooth:s0               bluetooth      900  1198   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 Thread-12
+u:r:bluetooth:s0               bluetooth      900  1246   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 binder:900_5
+u:r:bluetooth:s0               bluetooth      900  1641   352   13888052  47488 0                   0 S  19   0      -   0  fg 00:00:00 binder:900_6
+u:r:secure_element:s0:c44,c260,c512,c768 secure_element 927 927 352 13689388 44740 0                0 S  19   0      -   0  fg 00:00:00 com.android.se
+u:r:secure_element:s0:c44,c260,c512,c768 secure_element 927 932 352 13689388 44740 0                0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:secure_element:s0:c44,c260,c512,c768 secure_element 927 933 352 13689388 44740 0                0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:secure_element:s0:c44,c260,c512,c768 secure_element 927 934 352 13689388 44740 0                0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:secure_element:s0:c44,c260,c512,c768 secure_element 927 935 352 13689388 44740 0                0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:secure_element:s0:c44,c260,c512,c768 secure_element 927 936 352 13689388 44740 0                0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:secure_element:s0:c44,c260,c512,c768 secure_element 927 937 352 13689388 44740 0                0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:secure_element:s0:c44,c260,c512,c768 secure_element 927 938 352 13689388 44740 0                0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:secure_element:s0:c44,c260,c512,c768 secure_element 927 939 352 13689388 44740 0                0 S  19   0      -   0  fg 00:00:00 binder:927_1
+u:r:secure_element:s0:c44,c260,c512,c768 secure_element 927 943 352 13689388 44740 0                0 S  19   0      -   0  fg 00:00:00 binder:927_2
+u:r:secure_element:s0:c44,c260,c512,c768 secure_element 927 979 352 13689388 44740 0                0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:secure_element:s0:c44,c260,c512,c768 secure_element 927 993 352 13689388 44740 0                0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:radio:s0                   radio          945   945   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:01 m.android.phone
+u:r:radio:s0                   radio          945   952   352   13797604  53972 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:radio:s0                   radio          945   953   352   13797604  53972 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:radio:s0                   radio          945   955   352   13797604  53972 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:radio:s0                   radio          945   956   352   13797604  53972 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:radio:s0                   radio          945   957   352   13797604  53972 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:radio:s0                   radio          945   958   352   13797604  53972 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:radio:s0                   radio          945   959   352   13797604  53972 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:radio:s0                   radio          945   960   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 binder:945_1
+u:r:radio:s0                   radio          945   976   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 binder:945_2
+u:r:radio:s0                   radio          945   984   352   13797604  53972 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:radio:s0                   radio          945  1069   352   13797604  53972 0                   0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:radio:s0                   radio          945  1074   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 PersistAtomsThr
+u:r:radio:s0                   radio          945  1075   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 DeviceStateHelp
+u:r:radio:s0                   radio          945  1076   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 binder:945_3
+u:r:radio:s0                   radio          945  1078   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 binder:945_4
+u:r:radio:s0                   radio          945  1088   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 RHC
+u:r:radio:s0                   radio          945  1093   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 SMSVC
+u:r:radio:s0                   radio          945  1095   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 SMSVC
+u:r:radio:s0                   radio          945  1100   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 binder:945_5
+u:r:radio:s0                   radio          945  1101   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 CellBroadcastCo
+u:r:radio:s0                   radio          945  1167   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 ConnectivityThr
+u:r:radio:s0                   radio          945  1196   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 pool-2-thread-1
+u:r:radio:s0                   radio          945  1199   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 ImsResolver
+u:r:radio:s0                   radio          945  1200   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 RcsProvisioning
+u:r:radio:s0                   radio          945  1201   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 SatelliteContro
+u:r:radio:s0                   radio          945  1203   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 ImsStateCallbac
+u:r:radio:s0                   radio          945  1204   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 ImsProvisioning
+u:r:radio:s0                   radio          945  1206   352   13797604  53972 0                   0 S   9  10      -   0  fg 00:00:00 android.bg
+u:r:radio:s0                   radio          945  1210   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 binder:945_6
+u:r:radio:s0                   radio          945  1211   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 binder:945_7
+u:r:radio:s0                   radio          945  1212   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 binder:945_8
+u:r:radio:s0                   radio          945  1220   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 binder:945_9
+u:r:radio:s0                   radio          945  1221   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 DataService
+u:r:radio:s0                   radio          945  1262   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 binder:945_A
+u:r:radio:s0                   radio          945  1266   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 binder:945_B
+u:r:radio:s0                   radio          945  1267   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 binder:945_C
+u:r:radio:s0                   radio          945  1268   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 binder:945_D
+u:r:radio:s0                   radio          945  1269   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 binder:945_E
+u:r:radio:s0                   radio          945  1271   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 CatServiceThrea
+u:r:radio:s0                   radio          945  1272   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 RilMessageDecod
+u:r:radio:s0                   radio          945  1274   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 Cat Icon Loader
+u:r:radio:s0                   radio          945  1276   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 NetworkService
+u:r:radio:s0                   radio          945  1321   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 Stk App Service
+u:r:radio:s0                   radio          945  1407   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 binder:945_F
+u:r:radio:s0                   radio          945  1426   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 binder:945_10
+u:r:radio:s0                   radio          945  1749   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 Thread-2
+u:r:radio:s0                   radio          945  1753   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 ONSNetworkScanC
+u:r:radio:s0                   radio          945  1782   352   13797604  53972 0                   0 S  19   0      -   0  fg 00:00:00 ONSProfileSelec
+u:r:system_app:s0              system         947   947   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 ndroid.settings
+u:r:system_app:s0              system         947   965   352   13867488 106644 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:system_app:s0              system         947   966   352   13867488 106644 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:system_app:s0              system         947   967   352   13867488 106644 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:system_app:s0              system         947   968   352   13867488 106644 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:system_app:s0              system         947   969   352   13867488 106644 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:system_app:s0              system         947   970   352   13867488 106644 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:system_app:s0              system         947   971   352   13867488 106644 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:system_app:s0              system         947   972   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 binder:947_1
+u:r:system_app:s0              system         947   975   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 binder:947_2
+u:r:system_app:s0              system         947  1021   352   13867488 106644 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:system_app:s0              system         947  1040   352   13867488 106644 0                   0 S  23  -4      -   0  fg 00:00:01 RenderThread
+u:r:system_app:s0              system         947  1046   352   13867488 106644 0                   0 S   9  10      -   0  fg 00:00:00 AsyncTask #1
+u:r:system_app:s0              system         947  1059   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 binder:947_3
+u:r:system_app:s0              system         947  1061   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 SurfaceSyncGrou
+u:r:system_app:s0              system         947  1086   352   13867488 106644 0                   0 S  21  -2      -   0  fg 00:00:00 hwuiTask0
+u:r:system_app:s0              system         947  1087   352   13867488 106644 0                   0 S  21  -2      -   0  fg 00:00:00 hwuiTask1
+u:r:system_app:s0              system         947  1259   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 binder:947_3
+u:r:system_app:s0              system         947  1383   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 binder:947_4
+u:r:system_app:s0              system         947  1600   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 binder:947_5
+u:r:system_app:s0              system         947  2626   352   13867488 106644 0                   0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:system_app:s0              system         947  4605   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 binder:947_6
+u:r:system_app:s0              system         947  4613   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 binder:947_7
+u:r:system_app:s0              system         947  4616   352   13867488 106644 0                   0 S   9  10      -   0  fg 00:00:00 SettingsIntelli
+u:r:system_app:s0              system         947  4617   352   13867488 106644 0                   0 S   9  10      -   0  fg 00:00:00 SettingsIntelli
+u:r:system_app:s0              system         947  4618   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 binder:947_8
+u:r:system_app:s0              system         947  4621   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 WifiManagerThre
+u:r:system_app:s0              system         947  4667   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 onsState.Loader
+u:r:system_app:s0              system         947  4673   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 InteractionJank
+u:r:system_app:s0              system         947  4677   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 pool-6-thread-1
+u:r:system_app:s0              system         947  4684   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 pool-7-thread-1
+u:r:system_app:s0              system         947  4696   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 pool-8-thread-1
+u:r:system_app:s0              system         947  4700   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 pool-9-thread-1
+u:r:system_app:s0              system         947  4708   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 pool-10-thread-
+u:r:system_app:s0              system         947  4714   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 pool-11-thread-
+u:r:system_app:s0              system         947  4719   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 pool-12-thread-
+u:r:system_app:s0              system         947  4720   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 pool-13-thread-
+u:r:system_app:s0              system         947  4723   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 pool-6-thread-2
+u:r:system_app:s0              system         947  4724   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 pool-6-thread-3
+u:r:system_app:s0              system         947  4729   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 CameraManagerGl
+u:r:system_app:s0              system         947  4734   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 pool-6-thread-4
+u:r:system_app:s0              system         947  5433   352   13867488 106644 0                   0 S   9  10      -   0  fg 00:00:00 NotifySliceChan
+u:r:system_app:s0              system         947  5434   352   13867488 106644 0                   0 S  19   0      -   0  fg 00:00:00 pool-19-thread-
+u:r:system_app:s0              system         947  5435   352   13867488 106644 0                   0 S   9  10      -   0  fg 00:00:00 WifiPickerTrack
+u:r:priv_app:s0:c512,c768      u0_a179        982   982   352   13692164  44856 0                   0 S  19   0      -   0  fg 00:00:00 id.ext.services
+u:r:priv_app:s0:c512,c768      u0_a179        982   989   352   13692164  44856 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a179        982   991   352   13692164  44856 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a179        982   994   352   13692164  44856 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a179        982   995   352   13692164  44856 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a179        982   996   352   13692164  44856 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a179        982   997   352   13692164  44856 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a179        982   998   352   13692164  44856 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a179        982  1005   352   13692164  44856 0                   0 S  19   0      -   0  fg 00:00:00 binder:982_1
+u:r:priv_app:s0:c512,c768      u0_a179        982  1009   352   13692164  44856 0                   0 S  19   0      -   0  fg 00:00:00 binder:982_2
+u:r:priv_app:s0:c512,c768      u0_a179        982  1018   352   13692164  44856 0                   0 S  19   0      -   0  fg 00:00:00 binder:982_3
+u:r:priv_app:s0:c512,c768      u0_a179        982  1024   352   13692164  44856 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a179        982  1124   352   13692164  44856 0                   0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a179        982  1247   352   13692164  44856 0                   0 S  19   0      -   0  fg 00:00:00 binder:982_4
+u:r:priv_app:s0:c512,c768      u0_a179        982  5182   352   13692164  44856 0                   0 S  19   0      -   0  fg 00:00:00 binder:982_5
+u:r:priv_app:s0:c512,c768      u0_a160        992   992   352   13774808  68460 0                   0 S  29 -10      -   0  ta 00:00:00 s.nexuslauncher
+u:r:priv_app:s0:c512,c768      u0_a160        992  1004   352   13774808  68460 0                   0 S  39 -20      -   0  ta 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a160        992  1006   352   13774808  68460 0                   0 S  39 -20      -   0  ta 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a160        992  1007   352   13774808  68460 0                   0 S  10   9      -   0  ta 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a160        992  1008   352   13774808  68460 0                   0 S  15   4      -   0  ta 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a160        992  1010   352   13774808  68460 0                   0 S  15   4      -   0  ta 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a160        992  1011   352   13774808  68460 0                   0 S  15   4      -   0  ta 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a160        992  1012   352   13774808  68460 0                   0 S  15   4      -   0  ta 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a160        992  1014   352   13774808  68460 0                   0 S  19   0      -   0  ta 00:00:00 binder:992_1
+u:r:priv_app:s0:c512,c768      u0_a160        992  1023   352   13774808  68460 0                   0 S  19   0      -   0  ta 00:00:00 binder:992_2
+u:r:priv_app:s0:c512,c768      u0_a160        992  1038   352   13774808  68460 0                   0 S  10   9      -   0  ta 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a160        992  1056   352   13774808  68460 0                   0 S  21  -2      -   0  ta 00:00:00 UiThreadHelper
+u:r:priv_app:s0:c512,c768      u0_a160        992  1058   352   13774808  68460 0                   0 S  19   0      -   0  ta 00:00:00 launcher-loader
+u:r:priv_app:s0:c512,c768      u0_a160        992  1237   352   13774808  68460 0                   0 S  19   0      -   0  ta 00:00:00 binder:992_3
+u:r:priv_app:s0:c512,c768      u0_a160        992  1257   352   13774808  68460 0                   0 S  19   0      -   0  ta 00:00:00 binder:992_4
+u:r:priv_app:s0:c512,c768      u0_a160        992  1593   352   13774808  68460 0                   0 S  19   0      -   0  ta 00:00:00 InteractionJank
+u:r:priv_app:s0:c512,c768      u0_a160        992  1644   352   13774808  68460 0                   0 S  29 -10      -   0  ta 00:00:00 RenderThread
+u:r:priv_app:s0:c512,c768      u0_a160        992  1668   352   13774808  68460 0                   0 S  19   0      -   0  ta 00:00:00 pool-2-thread-1
+u:r:priv_app:s0:c512,c768      u0_a160        992  1734   352   13774808  68460 0                   0 S  19   0      -   0  ta 00:00:00 equicksearchbox
+u:r:priv_app:s0:c512,c768      u0_a160        992  1751   352   13774808  68460 0                   0 S  19   0      -   0  ta 00:00:00 pool-2-thread-2
+u:r:priv_app:s0:c512,c768      u0_a160        992  1836   352   13774808  68460 0                   0 S   9  10      -   0  ta 00:00:00 android.bg
+u:r:priv_app:s0:c512,c768      u0_a160        992  1899   352   13774808  68460 0                   0 S  19   0      -   0  ta 00:00:00 GrallocUploadTh
+u:r:priv_app:s0:c512,c768      u0_a160        992  1992   352   13774808  68460 0                   0 S  21  -2      -   0  ta 00:00:00 SAViewCapture
+u:r:priv_app:s0:c512,c768      u0_a160        992  2118   352   13774808  68460 0                   0 S  21  -2      -   0  ta 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a160        992  2191   352   13774808  68460 0                   0 S  19   0      -   0  ta 00:00:00 grpc-timer-0
+u:r:priv_app:s0:c512,c768      u0_a160        992  2577   352   13774808  68460 0                   0 S  19   0      -   0  ta 00:00:00 llpaper.recents
+u:r:priv_app:s0:c512,c768      u0_a160        992  2586   352   13774808  68460 0                   0 S  19   0      -   0  ta 00:00:00 SurfaceSyncGrou
+u:r:priv_app:s0:c512,c768      u0_a160        992  2587   352   13774808  68460 0                   0 S  21  -2      -   0  ta 00:00:00 hwuiTask0
+u:r:priv_app:s0:c512,c768      u0_a160        992  2588   352   13774808  68460 0                   0 S  21  -2      -   0  ta 00:00:00 hwuiTask1
+u:r:priv_app:s0:c512,c768      u0_a160        992  2608   352   13774808  68460 0                   0 S  19   0      -   0  ta 00:00:00 WellbeingHandle
+u:r:priv_app:s0:c512,c768      u0_a160        992  2610   352   13774808  68460 0                   0 S  19   0      -   0  ta 00:00:00 binder:992_1
+u:r:priv_app:s0:c512,c768      u0_a160        992  2619   352   13774808  68460 0                   0 S  19   0      -   0  ta 00:00:00 binder:992_5
+u:r:priv_app:s0:c512,c768      u0_a176       1097  1097   352   13705020  40140 0                   0 S  19   0      -   0  bg 00:00:00 oadcastreceiver
+u:r:priv_app:s0:c512,c768      u0_a176       1097  1111   352   13705020  40140 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a176       1097  1112   352   13705020  40140 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a176       1097  1113   352   13705020  40140 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a176       1097  1114   352   13705020  40140 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a176       1097  1115   352   13705020  40140 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a176       1097  1116   352   13705020  40140 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a176       1097  1117   352   13705020  40140 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a176       1097  1121   352   13705020  40140 0                   0 S  19   0      -   0  bg 00:00:00 binder:1097_1
+u:r:priv_app:s0:c512,c768      u0_a176       1097  1123   352   13705020  40140 0                   0 S  19   0      -   0  bg 00:00:00 binder:1097_2
+u:r:priv_app:s0:c512,c768      u0_a176       1097  1138   352   13705020  40140 0                   0 S  19   0      -   0  bg 00:00:00 binder:1097_3
+u:r:priv_app:s0:c512,c768      u0_a176       1097  1159   352   13705020  40140 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a176       1097  1188   352   13705020  40140 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a176       1097  1312   352   13705020  40140 0                   0 S  19   0      -   0  bg 00:00:00 binder:1097_4
+u:r:priv_app:s0:c512,c768      u0_a176       1097  4142   352   13705020  40140 0                   0 S   9  10      -   0  bg 00:00:00 AsyncTask #1
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1219   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:01 .gms.persistent
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1227   352   14179232 116212 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1228   352   14179232 116212 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1229   352   14179232 116212 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1230   352   14179232 116212 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1231   352   14179232 116212 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1232   352   14179232 116212 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1233   352   14179232 116212 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1234   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 binder:1219_1
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1235   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 binder:1219_2
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1279   352   14179232 116212 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1288   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 FileObserver
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1304   352   14179232 116212 0                   0 S  10   9      -   0  fg 00:00:00 GlobalDispatchi
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1307   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 GlobalScheduler
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1311   352   14179232 116212 0                   0 S  10   9      -   0  fg 00:00:00 GoogleApiHandle
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1313   352   14179232 116212 0                   0 S  10   9      -   0  fg 00:00:02 highpool[3]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1316   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 binder:1219_3
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1317   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 binder:1219_4
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1318   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 ice] processing
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1319   352   14179232 116212 0                   0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1320   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 -Executor] idle
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1545   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 FlpThread
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1595   352   14179232 116212 0                   0 S   9  10      -   0  fg 00:00:00 OkHttpClientTra
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1618   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 WifiManagerThre
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1619   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 binder:1219_5
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1704   352   14179232 116212 0                   0 S   9  10      -   0  fg 00:00:00 lowpool[2]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1730   352   14179232 116212 0                   0 S  10   9      -   0  fg 00:00:00 highpool[4]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  1767   352   14179232 116212 0                   0 S   9  10      -   0  fg 00:00:00 android.bg
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  2047   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 binder:1219_6
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  2080   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 binder:1219_7
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  2112   352   14179232 116212 0                   0 S  10   9      -   0  fg 00:00:00 GoogleLocationS
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  2654   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 binder:1219_8
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  2655   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 binder:1219_9
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  2862   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 binder:1219_A
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  2876   352   14179232 116212 0                   0 R  19   0      -   0  fg 00:00:00 binder:1219_B
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  2917   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 binder:1219_C
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  2930   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 DG
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3150   352   14179232 116212 0                   0 S   9  10      -   0  fg 00:00:00 lowpool[6]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3175   352   14179232 116212 0                   0 R  10   9      -   0  fg 00:00:04 highpool[5]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3201   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 binder:1219_D
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3210   352   14179232 116212 0                   0 S   9  10      -   0  fg 00:00:00 lowpool[8]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3234   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 ConnectivityThr
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3283   352   14179232 116212 0                   0 S   9  10      -   0  fg 00:00:00 netscheduler-qu
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3507   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 OkHttp Connecti
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3510   352   14179232 116212 0                   0 S   9  10      -   0  fg 00:00:00 OkHttpClientTra
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3511   352   14179232 116212 0                   0 R   9  10      -   0  fg 00:00:05 lowpool[12]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3513   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 Okio Watchdog
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3520   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 grpc-timer-0
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3521   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 grpc-default-ex
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3602   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 OkHttp Connecti
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3643   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 binder:1219_E
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3711   352   14179232 116212 0                   0 S   9  10      -   0  fg 00:00:00 NearbyDiscovery
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3728   352   14179232 116212 0                   0 S   9  10      -   0  fg 00:00:00 NearbyMessages
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3759   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 NearbyDirectMai
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3784   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 eevt
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3833   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 binder:1219_F
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3856   352   14179232 116212 0                   0 S  10   9      -   0  fg 00:00:00 GoogleApiHandle
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  3857   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 TFLiteCounters-
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  4143   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 CronetInit
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  4144   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 ThreadPoolServi
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  4145   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 ThreadPoolForeg
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  4146   352   14179232 116212 0                   0 S   9  10      -   0  fg 00:00:00 ChromiumNet
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  4155   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 ThreadPoolForeg
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  4156   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 ThreadPoolForeg
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  4177   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 Network File Th
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  4454   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 -Executor] idle
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  4455   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 -Executor] idle
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  4456   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 -Executor] idle
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  4457   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 -Executor] idle
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  4492   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 binder:1219_10
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  4650   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 ProcessStablePh
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  4653   352   14179232 116212 0                   0 S  10   9      -   0  fg 00:00:00 GoogleApiHandle
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  4716   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 henotype.UPDATE
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  5004   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 -Executor] idle
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  5028   352   14179232 116212 0                   0 S   9  10      -   0  fg 00:00:00 lowpool[16]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  5041   352   14179232 116212 0                   0 S  19   0      -   0  fg 00:00:00 pool-464-thread
+u:r:gmscore_app:s0:c512,c768   u0_a130       1219  5045   352   14179232 116212 0                   0 R  10   9      -   0  fg 00:00:00 highpool[6]
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1240 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 ssioncontroller
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1245 352 13795376 48944 0          0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1248 352 13795376 48944 0          0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1249 352 13795376 48944 0          0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1250 352 13795376 48944 0          0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1251 352 13795376 48944 0          0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1252 352 13795376 48944 0          0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1253 352 13795376 48944 0          0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1255 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 binder:1240_1
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1256 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 binder:1240_2
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1260 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 binder:1240_3
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1283 352 13795376 48944 0          0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1292 352 13795376 48944 0          0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1293 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 DefaultDispatch
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1294 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 DefaultDispatch
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1295 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 DefaultDispatch
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1303 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 pool-2-thread-1
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1314 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 pool-2-thread-2
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1399 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 pool-2-thread-3
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1401 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 pool-2-thread-4
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1402 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 pool-2-thread-5
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1405 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 pool-2-thread-6
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1409 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 pool-2-thread-7
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1410 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 pool-2-thread-8
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 1666 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 binder:1240_4
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 4399 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 DefaultDispatch
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 4670 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 RoleControllerS
+u:r:permissioncontroller_app:s0:c181,c256,c512,c768 u0_a181 1240 5009 352 13795376 48944 0          0 S  19   0      -   0  fg 00:00:00 binder:1240_5
+u:r:kernel:s0                  root          1263  1263     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:01 kworker/u9:3-fscrypt_read_queue
+u:r:kernel:s0                  root          1264  1264     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/u9:4-fscrypt_read_queue
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1335   352   13769356  55792 0                   0 S  19   0      -   0  bg 00:00:00 .apps.wellbeing
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1340   352   13769356  55792 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1345   352   13769356  55792 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1346   352   13769356  55792 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1347   352   13769356  55792 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1348   352   13769356  55792 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1349   352   13769356  55792 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1350   352   13769356  55792 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1354   352   13769356  55792 0                   0 S  19   0      -   0  bg 00:00:00 binder:1335_1
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1355   352   13769356  55792 0                   0 S  19   0      -   0  bg 00:00:00 binder:1335_2
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1357   352   13769356  55792 0                   0 S  19   0      -   0  bg 00:00:00 binder:1335_3
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1359   352   13769356  55792 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1378   352   13769356  55792 0                   0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1381   352   13769356  55792 0                   0 S  19   0      -   0  bg 00:00:00 Scheduler Threa
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1382   352   13769356  55792 0                   0 S   9  10      -   0  bg 00:00:01 BG Thread #0
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1384   352   13769356  55792 0                   0 S   9  10      -   0  bg 00:00:00 BG Thread #1
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1386   352   13769356  55792 0                   0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1388   352   13769356  55792 0                   0 S  19   0      -   0  bg 00:00:00 Lite Thread #0
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1389   352   13769356  55792 0                   0 S   9  10      -   0  bg 00:00:00 BG Thread #2
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1390   352   13769356  55792 0                   0 S   9  10      -   0  bg 00:00:00 BG Thread #3
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1394   352   13769356  55792 0                   0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1400   352   13769356  55792 0                   0 S  19   0      -   0  bg 00:00:00 Lite Thread #1
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1397   352   13769356  55792 0                   0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1582   352   13769356  55792 0                   0 S  19   0      -   0  bg 00:00:00 Lite Thread #0
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1770   352   13769356  55792 0                   0 S  19   0      -   0  bg 00:00:00 ConnectivityThr
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1876   352   13769356  55792 0                   0 S   9  10      -   0  bg 00:00:00 android.bg
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1986   352   13769356  55792 0                   0 S   0  19      -   0  bg 00:00:00 GmsDynamite
+u:r:priv_app:s0:c512,c768      u0_a129       1335  1989   352   13769356  55792 0                   0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a129       1335  2737   352   13769356  55792 0                   0 S  19   0      -   0  bg 00:00:00 binder:1335_4
+u:r:priv_app:s0:c512,c768      u0_a129       1335  2740   352   13769356  55792 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a129       1335  3122   352   13769356  55792 0                   0 S  19   0      -   0  bg 00:00:00 binder:1335_5
+u:r:priv_app:s0:c512,c768      u0_a129       1335  3269   352   13769356  55792 0                   0 S  19   0      -   0  bg 00:00:00 binder:1335_6
+u:r:priv_app:s0:c512,c768      u0_a129       1335  3851   352   13769356  55792 0                   0 S  19   0      -   0  bg 00:00:00 binder:1335_7
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1356 352 13978100 59356 0                  0 S  29 -10      -   0  ta 00:00:00 putmethod.latin
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1364 352 13978100 59356 0                  0 S  39 -20      -   0  ta 00:00:00 Signal Catcher
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1365 352 13978100 59356 0                  0 S  39 -20      -   0  ta 00:00:00 perfetto_hprof_
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1366 352 13978100 59356 0                  0 S  10   9      -   0  ta 00:00:00 Jit thread pool
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1367 352 13978100 59356 0                  0 S  15   4      -   0  ta 00:00:00 HeapTaskDaemon
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1368 352 13978100 59356 0                  0 S  15   4      -   0  ta 00:00:00 ReferenceQueueD
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1369 352 13978100 59356 0                  0 S  15   4      -   0  ta 00:00:00 FinalizerDaemon
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1370 352 13978100 59356 0                  0 S  15   4      -   0  ta 00:00:00 FinalizerWatchd
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1371 352 13978100 59356 0                  0 S  19   0      -   0  ta 00:00:00 binder:1356_1
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1372 352 13978100 59356 0                  0 S  19   0      -   0  ta 00:00:00 binder:1356_2
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1373 352 13978100 59356 0                  0 S  19   0      -   0  ta 00:00:00 binder:1356_3
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1376 352 13978100 59356 0                  0 S  10   9      -   0  ta 00:00:00 Profile Saver
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1398 352 13978100 59356 0                  0 S  21  -2      -   0  ta 00:00:00 queued-work-loo
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1404 352 13978100 59356 0                  0 S  19   0      -   0  ta 00:00:00 ImeScheduler-0
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1500 352 13978100 59356 0                  0 S   9  10      -   0  ta 00:00:00 ExeSeq-P10-1
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1505 352 13978100 59356 0                  0 S   9  10      -   0  ta 00:00:00 ExeSeq-P10-1
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1522 352 13978100 59356 0                  0 S  19   0      -   0  ta 00:00:00 Light-P0-1
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1525 352 13978100 59356 0                  0 S  19   0      -   0  ta 00:00:00 Light-P0-2
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1598 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-1
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1609 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-2
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1612 352 13978100 59356 0                  0 S  29 -10      -   0  ta 00:00:00 RenderThread
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1817 352 13978100 59356 0                  0 S   9  10      -   0  ta 00:00:00 Back-P10-1
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1820 352 13978100 59356 0                  0 S  10   9      -   0  ta 00:00:00 GoogleApiHandle
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1821 352 13978100 59356 0                  0 S   9  10      -   0  ta 00:00:00 Back-P10-2
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1824 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 sp-control-1
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1825 352 13978100 59356 0                  0 S   9  10      -   0  ta 00:00:00 DFacilitator-1
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1830 352 13978100 59356 0                  0 S   9  10      -   0  ta 00:00:00 Back-P10-3
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1832 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Primes-1
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1833 352 13978100 59356 0                  0 S  27  -8      -   0  ta 00:00:00 Primes-nativecr
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1845 352 13978100 59356 0                  0 S   9  10      -   0  ta 00:00:00 Back-P10-4
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1851 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 ExeSeq-P11-1
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1865 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-3
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1866 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-4
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1867 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-5
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1868 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-6
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1869 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-7
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1870 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-8
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1871 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-9
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1872 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-10
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1873 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-11
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1874 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-12
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1891 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-13
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1892 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-14
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1893 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-15
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1894 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-16
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1895 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-17
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1896 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Block-P11-18
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1929 352 13978100 59356 0                  0 S   0  19      -   0  ta 00:00:00 GmsDynamite
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 1994 352 13978100 59356 0                  0 S  19   0      -   0  ta 00:00:00 CronetInit
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 2002 352 13978100 59356 0                  0 S  19   0      -   0  ta 00:00:00 ThreadPoolServi
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 2003 352 13978100 59356 0                  0 S  19   0      -   0  ta 00:00:00 ThreadPoolForeg
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 2016 352 13978100 59356 0                  0 S   9  10      -   0  ta 00:00:00 ChromiumNet
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 2044 352 13978100 59356 0                  0 S  19   0      -   0  ta 00:00:00 ThreadPoolForeg
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 2045 352 13978100 59356 0                  0 S  19   0      -   0  ta 00:00:00 ThreadPoolForeg
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 2084 352 13978100 59356 0                  0 S  19   0      -   0  ta 00:00:00 Network File Th
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 2106 352 13978100 59356 0                  0 S  19   0      -   0  ta 00:00:00 AutoCloseableTr
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 2107 352 13978100 59356 0                  0 S   9  10      -   0  ta 00:00:00 UserFeatureCach
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 2110 352 13978100 59356 0                  0 S   9  10      -   0  ta 00:00:00 UFCache-1
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 2127 352 13978100 59356 0                  0 S   9  10      -   0  ta 00:00:00 SplitInstallSer
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 2564 352 13978100 59356 0                  0 S  19   0      -   0  ta 00:00:00 binder:1356_4
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 2683 352 13978100 59356 0                  0 S   8  11      -   0  ta 00:00:00 Primes-2
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 2685 352 13978100 59356 0                  0 S  19   0      -   0  ta 00:00:00 ProcessStablePh
+u:r:untrusted_app_32:s0:c145,c256,c512,c768 u0_a145 1356 2986 352 13978100 59356 0                  0 S  19   0      -   0  ta 00:00:00 DecoderWrapper-
+u:r:priv_app:s0:c512,c768      u0_a189       1396  1396   352   13740728  40100 0                   0 S  19   0      -   0  bg 00:00:00 elockcontroller
+u:r:priv_app:s0:c512,c768      u0_a189       1396  1418   352   13740728  40100 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a189       1396  1419   352   13740728  40100 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a189       1396  1420   352   13740728  40100 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a189       1396  1421   352   13740728  40100 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a189       1396  1422   352   13740728  40100 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a189       1396  1423   352   13740728  40100 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a189       1396  1424   352   13740728  40100 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a189       1396  1425   352   13740728  40100 0                   0 S  19   0      -   0  bg 00:00:00 binder:1396_1
+u:r:priv_app:s0:c512,c768      u0_a189       1396  1427   352   13740728  40100 0                   0 S  19   0      -   0  bg 00:00:00 binder:1396_2
+u:r:priv_app:s0:c512,c768      u0_a189       1396  1446   352   13740728  40100 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a189       1396  1461   352   13740728  40100 0                   0 S  19   0      -   0  bg 00:00:00 binder:1396_3
+u:r:priv_app:s0:c512,c768      u0_a189       1396  4211   352   13740728  40100 0                   0 S  19   0      -   0  bg 00:00:00 binder:1396_4
+u:r:priv_app:s0:c512,c768      u0_a189       1396  4243   352   13740728  40100 0                   0 S  19   0      -   0  bg 00:00:00 pool-3-thread-1
+u:r:priv_app:s0:c512,c768      u0_a189       1396  4257   352   13740728  40100 0                   0 S  19   0      -   0  bg 00:00:00 WM.task-1
+u:r:priv_app:s0:c512,c768      u0_a189       1396  4280   352   13740728  40100 0                   0 S  19   0      -   0  bg 00:00:00 WM.task-2
+u:r:priv_app:s0:c512,c768      u0_a189       1396  4289   352   13740728  40100 0                   0 S  19   0      -   0  bg 00:00:00 ConnectivityThr
+u:r:priv_app:s0:c512,c768      u0_a189       1396  4293   352   13740728  40100 0                   0 S  19   0      -   0  bg 00:00:00 WM.task-3
+u:r:priv_app:s0:c512,c768      u0_a189       1396  4306   352   13740728  40100 0                   0 S  19   0      -   0  bg 00:00:00 androidx.work-1
+u:r:priv_app:s0:c512,c768      u0_a189       1396  4310   352   13740728  40100 0                   0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:priv_app:s0:c512,c768      u0_a189       1396  4428   352   13740728  40100 0                   0 S  19   0      -   0  bg 00:00:00 grpc-timer-0
+u:r:priv_app:s0:c512,c768      u0_a189       1396  4431   352   13740728  40100 0                   0 S  19   0      -   0  bg 00:00:00 grpc-default-ex
+u:r:priv_app:s0:c512,c768      u0_a189       1396  4433   352   13740728  40100 0                   0 S  19   0      -   0  bg 00:00:00 grpc-okhttp-0
+u:r:priv_app:s0:c512,c768      u0_a189       1396  4434   352   13740728  40100 0                   0 S  19   0      -   0  bg 00:00:00 grpc-okhttp-1
+u:r:priv_app:s0:c512,c768      u0_a189       1396  4442   352   13740728  40100 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a189       1396  4491   352   13740728  40100 0                   0 S  19   0      -   0  bg 00:00:00 binder:1396_5
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1428 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 rs.media.module
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1434 352 13796772 55024 0                 0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1436 352 13796772 55024 0                 0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1437 352 13796772 55024 0                 0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1438 352 13796772 55024 0                 0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1439 352 13796772 55024 0                 0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1440 352 13796772 55024 0                 0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1441 352 13796772 55024 0                 0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1442 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 binder:1428_1
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1443 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 binder:1428_2
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1460 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 binder:1428_3
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1506 352 13796772 55024 0                 0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1532 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 ent.InfoHandler
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1539 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 nt.EventHandler
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1558 352 13796772 55024 0                 0 S   9  10      -   0  fg 00:00:00 ackgroundThread
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1594 352 13796772 55024 0                 0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1604 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 CCodecWatchdog
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1605 352 13796772 55024 0                 0 S  35 -16      -   0  fg 00:00:00 CodecLooper
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1606 352 13796772 55024 0                 0 S  35 -16      -   0  fg 00:00:00 CodecLooper
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1607 352 13796772 55024 0                 0 S  35 -16      -   0  fg 00:00:00 HwBinder:1428_1
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1638 352 13796772 55024 0                 0 S  21  -2      -   0  fg 00:00:00 fg
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1706 352 13796772 55024 0                 0 S   9  10      -   0  fg 00:00:00 android.bg
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1783 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 emulated;0
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1792 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 emulated;0
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1793 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 Thread-8
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 1800 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 Thread-7
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 2129 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 public:253,80
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 2134 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 public:253,80
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 2135 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 Thread-4
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 2178 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 Thread-5
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 2342 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 binder:1428_4
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 2733 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 Thread-6
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 3226 352 13796772 55024 0                 0 S   9  10      -   0  fg 00:00:00 AsyncTask #1
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 3737 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 Thread-9
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 3970 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 Thread-10
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 3975 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 Thread-11
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 5087 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 Thread-12
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 5092 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 Thread-13
+u:r:mediaprovider_app:s0:c169,c256,c512,c768 u0_a169 1428 5111 352 13796772 55024 0                 0 S  19   0      -   0  fg 00:00:00 Thread-14
+u:r:kernel:s0                  root          1444  1444     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:01 kworker/3:3H-kverityd
+u:r:untrusted_app:s0:c110,c256,c512,c768 u0_a110 1447 1447 352  13691484  37132 0                   0 S  19   0      -   0  bg 00:00:00 id.printspooler
+u:r:untrusted_app:s0:c110,c256,c512,c768 u0_a110 1447 1452 352  13691484  37132 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:untrusted_app:s0:c110,c256,c512,c768 u0_a110 1447 1463 352  13691484  37132 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:untrusted_app:s0:c110,c256,c512,c768 u0_a110 1447 1464 352  13691484  37132 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:untrusted_app:s0:c110,c256,c512,c768 u0_a110 1447 1465 352  13691484  37132 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:untrusted_app:s0:c110,c256,c512,c768 u0_a110 1447 1466 352  13691484  37132 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:untrusted_app:s0:c110,c256,c512,c768 u0_a110 1447 1467 352  13691484  37132 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:untrusted_app:s0:c110,c256,c512,c768 u0_a110 1447 1468 352  13691484  37132 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:untrusted_app:s0:c110,c256,c512,c768 u0_a110 1447 1469 352  13691484  37132 0                   0 S  19   0      -   0  bg 00:00:00 binder:1447_1
+u:r:untrusted_app:s0:c110,c256,c512,c768 u0_a110 1447 1503 352  13691484  37132 0                   0 S  19   0      -   0  bg 00:00:00 binder:1447_2
+u:r:untrusted_app:s0:c110,c256,c512,c768 u0_a110 1447 1530 352  13691484  37132 0                   0 S  19   0      -   0  bg 00:00:00 binder:1447_3
+u:r:untrusted_app:s0:c110,c256,c512,c768 u0_a110 1447 1536 352  13691484  37132 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:untrusted_app:s0:c110,c256,c512,c768 u0_a110 1447 2308 352  13691484  37132 0                   0 S   9  10      -   0  bg 00:00:00 AsyncTask #1
+u:r:untrusted_app:s0:c110,c256,c512,c768 u0_a110 1447 2349 352  13691484  37132 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:untrusted_app:s0:c110,c256,c512,c768 u0_a110 1447 5142 352  13691484  37132 0                   0 S  19   0      -   0  bg 00:00:00 binder:1447_4
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1470   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 ogle.android.as
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1478   352   14107820  55420 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1479   352   14107820  55420 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1484   352   14107820  55420 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1485   352   14107820  55420 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1487   352   14107820  55420 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1488   352   14107820  55420 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1489   352   14107820  55420 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1490   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 binder:1470_1
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1498   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 binder:1470_2
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1502   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 binder:1470_3
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1510   352   14107820  55420 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1599   352   14107820  55420 0                   0 S   9  10      -   0  fg 00:00:00 BG Thread #0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1603   352   14107820  55420 0                   0 S   9  10      -   0  fg 00:00:00 android.bg
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1610   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 aiai-speech-rs-
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1620   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 aiai-app-predic
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1621   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 arch_disk_io_0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1631   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 WM.task-1
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1640   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 arch_disk_io_1
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1654   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 arch_disk_io_2
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1656   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 arch_disk_io_3
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1764   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 WM.task-2
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1765   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 superpacks-cont
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1768   352   14107820  55420 0                   0 S   0  19      -   0  fg 00:00:00 aiai-speech-rs-
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1769   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 WM.task-3
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1791   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 aiai-normal-sha
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1827   352   14107820  55420 0                   0 S   9  10      -   0  fg 00:00:00 Background #0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1828   352   14107820  55420 0                   0 S   0  19      -   0  fg 00:00:00 aiai-min-shared
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1829   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 binder:1470_4
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1853   352   14107820  55420 0                   0 S   0  19      -   0  fg 00:00:00 aiai-brella-0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1856   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 grpc-timer-0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1881   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 DefaultDispatch
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1882   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 DefaultDispatch
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1974   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 CameraManagerGl
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1978   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 binder:1470_5
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1979   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 binder:1470_6
+u:r:priv_app:s0:c512,c768      u0_a118       1470  1997   352   14107820  55420 0                   0 S   0  19      -   0  fg 00:00:00 aiai-sp-0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2025   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 aiai-nls-0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2049   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 aiai-tc-0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2056   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 aiai-captions-l
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2117   352   14107820  55420 0                   0 S   0  19      -   0  fg 00:00:00 aiai-vc-0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2148   352   14107820  55420 0                   0 S   0  19      -   0  fg 00:00:00 aiai-cc-datasha
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2153   352   14107820  55420 0                   0 S   0  19      -   0  fg 00:00:00 aiai-pecan-0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2155   352   14107820  55420 0                   0 S   0  19      -   0  fg 00:00:00 aiai-autofill-0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2168   352   14107820  55420 0                   0 S   0  19      -   0  fg 00:00:00 aiai-chronicle-
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2192   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 aiai-notificati
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2201   352   14107820  55420 0                   0 S   9  10      -   0  fg 00:00:00 Background #1
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2236   352   14107820  55420 0                   0 S   9  10      -   0  fg 00:00:00 Background #2
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2237   352   14107820  55420 0                   0 S   0  19      -   0  fg 00:00:00 aiai-geller-0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2254   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 aiai-overview-0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2292   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 aiai-captions-r
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2316   352   14107820  55420 0                   0 S   0  19      -   0  fg 00:00:00 aiai-translate-
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2307   352   14107820  55420 0                   0 S   0  19      -   0  fg 00:00:00 aiai-fedass-0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2364   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 binder:1470_9
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2377   352   14107820  55420 0                   0 S   0  19      -   0  fg 00:00:00 greco
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2384   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2386   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 aiai-echo-searc
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2390   352   14107820  55420 0                   0 S   0  19      -   0  fg 00:00:00 greco
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2397   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 superpacks-serv
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2433   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 vkp-mediapipe-0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2434   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 vkp-mediapipe-1
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2436   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 ocr_det_0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2437   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 ocr_det_0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2438   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 ocr_det_0
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2439   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 ocr_segm
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2440   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 ocr_segm
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2441   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 ocr_segm
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2442   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 ocr_segm
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2443   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 ocr_segm
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2444   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 ocr_segm
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2665   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 binder:1470_A
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2748   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 aiai-echo-searc
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2814   352   14107820  55420 0                   0 S   9  10      -   0  fg 00:00:00 AsyncTask #1
+u:r:priv_app:s0:c512,c768      u0_a118       1470  2817   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 aiai-tulip-tts-
+u:r:priv_app:s0:c512,c768      u0_a118       1470  3169   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 binder:1470_B
+u:r:priv_app:s0:c512,c768      u0_a118       1470  3362   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 aiai-echo-searc
+u:r:priv_app:s0:c512,c768      u0_a118       1470  3363   352   14107820  55420 0                   0 S  21  -2      -   0  fg 00:00:00 aiai-echo-searc
+u:r:priv_app:s0:c512,c768      u0_a118       1470  3776   352   14107820  55420 0                   0 S  19   0      -   0  fg 00:00:00 WifiManagerThre
+u:r:priv_app:s0:c512,c768      u0_a130       1473  1473   352   13701196  47160 0                   0 S  19   0      -   0  bg 00:00:00 e.process.gapps
+u:r:priv_app:s0:c512,c768      u0_a130       1473  1486   352   13701196  47160 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a130       1473  1491   352   13701196  47160 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a130       1473  1492   352   13701196  47160 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a130       1473  1493   352   13701196  47160 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a130       1473  1494   352   13701196  47160 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a130       1473  1495   352   13701196  47160 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a130       1473  1496   352   13701196  47160 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a130       1473  1497   352   13701196  47160 0                   0 S  19   0      -   0  bg 00:00:00 binder:1473_1
+u:r:priv_app:s0:c512,c768      u0_a130       1473  1499   352   13701196  47160 0                   0 S  19   0      -   0  bg 00:00:00 binder:1473_2
+u:r:priv_app:s0:c512,c768      u0_a130       1473  1529   352   13701196  47160 0                   0 S  19   0      -   0  bg 00:00:00 binder:1473_3
+u:r:priv_app:s0:c512,c768      u0_a130       1473  1542   352   13701196  47160 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a130       1473  4091   352   13701196  47160 0                   0 S  19   0      -   0  bg 00:00:00 binder:1473_4
+u:r:priv_app:s0:c512,c768      u0_a130       1473  4494   352   13701196  47160 0                   0 S  19   0      -   0  bg 00:00:00 binder:1473_5
+u:r:priv_app:s0:c512,c768      u0_a130       1473  4678   352   13701196  47160 0                   0 S  19   0      -   0  bg 00:00:00 binder:1473_6
+u:r:priv_app:s0:c512,c768      u0_a130       1473  5015   352   13701196  47160 0                   0 S  19   0      -   0  bg 00:00:00 binder:1473_7
+u:r:priv_app:s0:c512,c768      u0_a130       1473  5068   352   13701196  47160 0                   0 S  19   0      -   0  bg 00:00:00 binder:1473_8
+u:r:priv_app:s0:c512,c768      u0_a130       1473  5179   352   13701196  47160 0                   0 S  19   0      -   0  bg 00:00:00 binder:1473_9
+u:r:priv_app:s0:c512,c768      u0_a130       1473  5181   352   13701196  47160 0                   0 S  19   0      -   0  bg 00:00:00 binder:1473_A
+u:r:priv_app:s0:c512,c768      u0_a130       1504  1504   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 ocess.gservices
+u:r:priv_app:s0:c512,c768      u0_a130       1504  1512   352   13708460  47564 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a130       1504  1514   352   13708460  47564 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a130       1504  1515   352   13708460  47564 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a130       1504  1516   352   13708460  47564 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a130       1504  1517   352   13708460  47564 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a130       1504  1518   352   13708460  47564 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a130       1504  1519   352   13708460  47564 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a130       1504  1520   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 binder:1504_1
+u:r:priv_app:s0:c512,c768      u0_a130       1504  1521   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 binder:1504_2
+u:r:priv_app:s0:c512,c768      u0_a130       1504  1534   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 binder:1504_3
+u:r:priv_app:s0:c512,c768      u0_a130       1504  1543   352   13708460  47564 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a130       1504  1580   352   13708460  47564 0                   0 S  10   9      -   0  fg 00:00:00 GoogleApiHandle
+u:r:priv_app:s0:c512,c768      u0_a130       1504  2861   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 binder:1504_4
+u:r:priv_app:s0:c512,c768      u0_a130       1504  2875   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 binder:1504_5
+u:r:priv_app:s0:c512,c768      u0_a130       1504  2918   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 binder:1504_6
+u:r:priv_app:s0:c512,c768      u0_a130       1504  3238   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 binder:1504_7
+u:r:priv_app:s0:c512,c768      u0_a130       1504  3353   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 binder:1504_8
+u:r:priv_app:s0:c512,c768      u0_a130       1504  3526   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 binder:1504_9
+u:r:priv_app:s0:c512,c768      u0_a130       1504  3645   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 binder:1504_A
+u:r:priv_app:s0:c512,c768      u0_a130       1504  3662   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 binder:1504_B
+u:r:priv_app:s0:c512,c768      u0_a130       1504  3719   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 binder:1504_C
+u:r:priv_app:s0:c512,c768      u0_a130       1504  3831   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 binder:1504_D
+u:r:priv_app:s0:c512,c768      u0_a130       1504  4626   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 binder:1504_E
+u:r:priv_app:s0:c512,c768      u0_a130       1504  4665   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 binder:1504_F
+u:r:priv_app:s0:c512,c768      u0_a130       1504  4666   352   13708460  47564 0                   0 S  19   0      -   0  fg 00:00:00 binder:1504_10
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1528   352   14553940  64328 0                   0 S  19   0      -   0  fg 00:00:00 hbox:interactor
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1551   352   14553940  64328 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1552   352   14553940  64328 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1553   352   14553940  64328 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1554   352   14553940  64328 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1555   352   14553940  64328 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1556   352   14553940  64328 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1557   352   14553940  64328 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1559   352   14553940  64328 0                   0 S  19   0      -   0  fg 00:00:00 binder:1528_1
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1560   352   14553940  64328 0                   0 S  19   0      -   0  fg 00:00:00 binder:1528_2
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1616   352   14553940  64328 0                   0 S  19   0      -   0  fg 00:00:00 binder:1528_3
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1727   352   14553940  64328 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1931   352   14553940  64328 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1936   352   14553940  64328 0                   0 S  10   9      -   0  fg 00:00:00 GoogleApiHandle
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1958   352   14553940  64328 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1959   352   14553940  64328 0                   0 S  19   0      -   0  fg 00:00:00 Lite Thread #0
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1969   352   14553940  64328 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1971   352   14553940  64328 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1976   352   14553940  64328 0                   0 S   9  10      -   0  fg 00:00:00 Scheduler Threa
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1980   352   14553940  64328 0                   0 S   8  11      -   0  fg 00:00:00 Primes-1
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1981   352   14553940  64328 0                   0 S  27  -8      -   0  fg 00:00:00 Primes-nativecr
+u:r:priv_app:s0:c512,c768      u0_a132       1528  1982   352   14553940  64328 0                   0 S   8  11      -   0  fg 00:00:00 Primes-2
+u:r:priv_app:s0:c512,c768      u0_a132       1528  2121   352   14553940  64328 0                   0 S   9  10      -   0  fg 00:00:00 BG Thread #0
+u:r:priv_app:s0:c512,c768      u0_a132       1528  2123   352   14553940  64328 0                   0 S   9  10      -   0  fg 00:00:00 BG Thread #1
+u:r:priv_app:s0:c512,c768      u0_a132       1528  2151   352   14553940  64328 0                   0 S   9  10      -   0  fg 00:00:00 BG Thread #2
+u:r:priv_app:s0:c512,c768      u0_a132       1528  2152   352   14553940  64328 0                   0 S   9  10      -   0  fg 00:00:00 BG Thread #3
+u:r:priv_app:s0:c512,c768      u0_a132       1528  2166   352   14553940  64328 0                   0 S  19   0      -   0  fg 00:00:00 Lite Thread #0
+u:r:priv_app:s0:c512,c768      u0_a132       1528  2171   352   14553940  64328 0                   0 S  19   0      -   0  fg 00:00:00 Lite Thread #1
+u:r:priv_app:s0:c512,c768      u0_a132       1528  2240   352   14553940  64328 0                   0 S   9  10      -   0  fg 00:00:00 android.bg
+u:r:priv_app:s0:c512,c768      u0_a132       1528  2808   352   14553940  64328 0                   0 S  19   0      -   0  fg 00:00:00 binder:1528_4
+u:r:priv_app:s0:c512,c768      u0_a132       1528  5436   352   14553940  64328 0                   0 S  19   0      -   0  fg 00:00:00 binder:1528_5
+u:r:priv_app:s0:c512,c768      u0_a132       1528  5485   352   14553940  64328 0                   0 S  19   0      -   0  fg 00:00:00 binder:1528_6
+u:r:priv_app:s0:c512,c768      u0_a132       1528  5660   352   14553940  64328 0                   0 S  19   0      -   0  fg 00:00:00 binder:1528_7
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1540   352   13807644  62320 0                   0 S  19   0      -   0  fg 00:00:00 s.messaging:rcs
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1567   352   13807644  62320 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1581   352   13807644  62320 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1584   352   13807644  62320 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1585   352   13807644  62320 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1588   352   13807644  62320 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1589   352   13807644  62320 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1590   352   13807644  62320 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1591   352   13807644  62320 0                   0 S  19   0      -   0  fg 00:00:00 binder:1540_1
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1592   352   13807644  62320 0                   0 S  19   0      -   0  fg 00:00:00 binder:1540_2
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1623   352   13807644  62320 0                   0 S  19   0      -   0  fg 00:00:00 binder:1540_3
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1681   352   13807644  62320 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1886   352   13807644  62320 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1887   352   13807644  62320 0                   0 S  10   9      -   0  fg 00:00:00 GoogleApiHandle
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1903   352   13807644  62320 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1905   352   13807644  62320 0                   0 S  19   0      -   0  fg 00:00:00 Scheduler Threa
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1907   352   13807644  62320 0                   0 S   9  10      -   0  fg 00:00:00 BG Thread #0
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1908   352   13807644  62320 0                   0 S  27  -8      -   0  fg 00:00:00 Primes-nativecr
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1915   352   13807644  62320 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a123       1540  1916   352   13807644  62320 0                   0 S   9  10      -   0  fg 00:00:00 BG Thread #1
+u:r:priv_app:s0:c512,c768      u0_a123       1540  2026   352   13807644  62320 0                   0 S   9  10      -   0  fg 00:00:00 BG Thread #2
+u:r:priv_app:s0:c512,c768      u0_a123       1540  2138   352   13807644  62320 0                   0 S   9  10      -   0  fg 00:00:00 pool-3-thread-1
+u:r:priv_app:s0:c512,c768      u0_a123       1540  2144   352   13807644  62320 0                   0 S   9  10      -   0  fg 00:00:00 BG Thread #3
+u:r:priv_app:s0:c512,c768      u0_a123       1540  2150   352   13807644  62320 0                   0 S  19   0      -   0  fg 00:00:00 ConnectivityThr
+u:r:priv_app:s0:c512,c768      u0_a123       1540  2177   352   13807644  62320 0                   0 S   9  10      -   0  fg 00:00:00 AsyncTask #1
+u:r:priv_app:s0:c512,c768      u0_a123       1540  2193   352   13807644  62320 0                   0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a123       1540  2347   352   13807644  62320 0                   0 S  19   0      -   0  fg 00:00:00 Lite Thread #0
+u:r:priv_app:s0:c512,c768      u0_a123       1540  2344   352   13807644  62320 0                   0 S  19   0      -   0  fg 00:00:00 DG
+u:r:priv_app:s0:c512,c768      u0_a123       1540  2378   352   13807644  62320 0                   0 S  19   0      -   0  fg 00:00:00 ProvisioningSta
+u:r:priv_app:s0:c512,c768      u0_a123       1540  2454   352   13807644  62320 0                   0 S  19   0      -   0  fg 00:00:00 SimStateTracker
+u:r:priv_app:s0:c512,c768      u0_a123       1540  2569   352   13807644  62320 0                   0 S  19   0      -   0  fg 00:00:00 RCS Engine Hand
+u:r:priv_app:s0:c512,c768      u0_a123       1540  2680   352   13807644  62320 0                   0 S  19   0      -   0  fg 00:00:00 binder:1540_4
+u:r:priv_app:s0:c512,c768      u0_a123       1540  3443   352   13807644  62320 0                   0 S  19   0      -   0  fg 00:00:00 binder:1540_5
+u:r:priv_app:s0:c512,c768      u0_a123       1540  3445   352   13807644  62320 0                   0 S  19   0      -   0  fg 00:00:00 binder:1540_6
+u:r:priv_app:s0:c512,c768      u0_a123       1540  5146   352   13807644  62320 0                   0 S  19   0      -   0  fg 00:00:00 binder:1540_7
+u:r:system_app:s0              system        1561  1561   352   13690132  47288 0                   0 S  19   0      -   0  fg 00:00:00 or.multidisplay
+u:r:system_app:s0              system        1561  1571   352   13690132  47288 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:system_app:s0              system        1561  1572   352   13690132  47288 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:system_app:s0              system        1561  1573   352   13690132  47288 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:system_app:s0              system        1561  1574   352   13690132  47288 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:system_app:s0              system        1561  1575   352   13690132  47288 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:system_app:s0              system        1561  1576   352   13690132  47288 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:system_app:s0              system        1561  1577   352   13690132  47288 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:system_app:s0              system        1561  1578   352   13690132  47288 0                   0 S  19   0      -   0  fg 00:00:00 binder:1561_1
+u:r:system_app:s0              system        1561  1583   352   13690132  47288 0                   0 S  19   0      -   0  fg 00:00:00 binder:1561_2
+u:r:system_app:s0              system        1561  1615   352   13690132  47288 0                   0 S  19   0      -   0  fg 00:00:00 binder:1561_3
+u:r:system_app:s0              system        1561  1653   352   13690132  47288 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:system_app:s0              system        1561  2798   352   13690132  47288 0                   0 S  19   0      -   0  fg 00:00:00 MultiDisplaySer
+u:r:system_app:s0              system        1561  2799   352   13690132  47288 0                   0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1624   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:01 android.vending
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1629   352   13977772  50172 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1642   352   13977772  50172 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1643   352   13977772  50172 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1646   352   13977772  50172 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1647   352   13977772  50172 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1648   352   13977772  50172 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1649   352   13977772  50172 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1650   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 binder:1624_1
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1652   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 binder:1624_2
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1724   352   13977772  50172 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1814   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 Monitor Thread 
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1857   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 LightweightExec
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1858   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 LightweightExec
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1859   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 LightweightExec
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1860   352   13977772  50172 0                   0 S  18   1      -   0  bg 00:00:01 BlockingExecuto
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1861   352   13977772  50172 0                   0 S  18   1      -   0  bg 00:00:00 BlockingExecuto
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1925   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 ProtoDataStore-
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1941   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 ValueStore-0
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1953   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 FileObserver
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1954   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 ValueStore-1
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1955   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 ValueStore-2
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1975   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 ValueStore-3
+u:r:priv_app:s0:c512,c768      u0_a131       1624  1983   352   13977772  50172 0                   0 S   8  11      -   0  bg 00:00:00 Primes-1
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2008   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:01 bgExecutor #0
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2030   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 SequenceEventBu
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2075   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 Scheduler Threa
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2124   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 bgExecutor #1
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2126   352   13977772  50172 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2132   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 CronetInit
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2145   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 FinskyApp
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2154   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 bgExecutor #2
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2161   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolServi
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2162   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2163   352   13977772  50172 0                   0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2164   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 ChromiumNet
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2182   352   13977772  50172 0                   0 S  18   1      -   0  bg 00:00:00 BlockingExecuto
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2183   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 bgExecutor #3
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2184   352   13977772  50172 0                   0 S  18   1      -   0  bg 00:00:00 BlockingExecuto
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2187   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2188   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2194   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 Network File Th
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2202   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 Thread-2
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2203   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 Thread-3
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2204   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 Thread-4
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2205   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 Thread-5
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2206   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 Thread-6
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2199   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 anmz
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2213   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 Thread-7
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2214   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 Thread-8
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2215   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 Thread-9
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2216   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 Thread-10
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2225   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 Thread-11
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2227   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 Db-scheduler_ma
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2229   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 tentative-gc-ru
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2232   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 FinskyEventLog
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2235   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 VerifyAppsDataS
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2241   352   13977772  50172 0                   0 S  18   1      -   0  bg 00:00:00 BlockingExecuto
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2281   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:01 -verify_apps.db
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2317   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 AsyncTask #1
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2318   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 binder:1624_3
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2468   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 SimChangeExecut
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2472   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 grpc-timer-0
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2531   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 OkHttp Connecti
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2548   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 Okio Watchdog
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2607   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 PhoneskySchedul
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2618   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 PackageInstalle
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2646   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 OkHttp Connecti
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2777   352   13977772  50172 0                   0 S   8  11      -   0  bg 00:00:00 Primes-2
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2779   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 ProcessStablePh
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2789   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 grpc-default-ex
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2802   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 grpc-default-ex
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2864   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 Db-notification
+u:r:priv_app:s0:c512,c768      u0_a131       1624  2868   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 RefQueueWorker@
+u:r:priv_app:s0:c512,c768      u0_a131       1624  3089   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 InstallQueueUsi
+u:r:priv_app:s0:c512,c768      u0_a131       1624  3094   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 InstallQueueDat
+u:r:priv_app:s0:c512,c768      u0_a131       1624  3598   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 errer_status.db
+u:r:priv_app:s0:c512,c768      u0_a131       1624  3618   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 OkHttp Connecti
+u:r:priv_app:s0:c512,c768      u0_a131       1624  3681   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 BackgroundThrea
+u:r:priv_app:s0:c512,c768      u0_a131       1624  3682   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 BackgroundThrea
+u:r:priv_app:s0:c512,c768      u0_a131       1624  3693   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 AssetModuleBack
+u:r:priv_app:s0:c512,c768      u0_a131       1624  3739   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 ExpressIntegrit
+u:r:priv_app:s0:c512,c768      u0_a131       1624  3755   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 DG
+u:r:priv_app:s0:c512,c768      u0_a131       1624  3764   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 anmz
+u:r:priv_app:s0:c512,c768      u0_a131       1624  3769   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 AsyncQueryWorke
+u:r:priv_app:s0:c512,c768      u0_a131       1624  3846   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 -auto_update.db
+u:r:priv_app:s0:c512,c768      u0_a131       1624  3928   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 Verification th
+u:r:priv_app:s0:c512,c768      u0_a131       1624  4093   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 binder:1624_4
+u:r:priv_app:s0:c512,c768      u0_a131       1624  4552   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 groundLogger.db
+u:r:priv_app:s0:c512,c768      u0_a131       1624  4558   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 grpc-shared-des
+u:r:priv_app:s0:c512,c768      u0_a131       1624  4559   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 esource_data.db
+u:r:priv_app:s0:c512,c768      u0_a131       1624  4561   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 /streamstore.db
+u:r:priv_app:s0:c512,c768      u0_a131       1624  4563   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 ller_data_v2.db
+u:r:priv_app:s0:c512,c768      u0_a131       1624  4564   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 task_manager.db
+u:r:priv_app:s0:c512,c768      u0_a131       1624  4565   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 fetcher_data.db
+u:r:priv_app:s0:c512,c768      u0_a131       1624  4567   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 data_fetcher.db
+u:r:priv_app:s0:c512,c768      u0_a131       1624  4568   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 ller_data_v2.db
+u:r:priv_app:s0:c512,c768      u0_a131       1624  4579   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 cquire_store.db
+u:r:priv_app:s0:c512,c768      u0_a131       1624  4615   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 grpc-default-ex
+u:r:priv_app:s0:c512,c768      u0_a131       1624  4648   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 Db-work_main.db
+u:r:priv_app:s0:c512,c768      u0_a131       1624  4652   352   13977772  50172 0                   0 S  27  -8      -   0  bg 00:00:00 process reaper
+u:r:priv_app:s0:c512,c768      u0_a131       1624  4679   352   13977772  50172 0                   0 S  19   0      -   0  bg 00:00:00 binder:1624_5
+u:r:priv_app:s0:c512,c768      u0_a131       1624  5472   352   13977772  50172 0                   0 S   9  10      -   0  bg 00:00:00 ance_summary.db
+u:r:priv_app:s0:c512,c768      u0_a83        1632  1632   352   13705604  48920 0                   0 S  19   0      -   0  bg 00:00:00 d.process.acore
+u:r:priv_app:s0:c512,c768      u0_a83        1632  1637   352   13705604  48920 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a83        1632  1658   352   13705604  48920 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a83        1632  1659   352   13705604  48920 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a83        1632  1660   352   13705604  48920 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a83        1632  1661   352   13705604  48920 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a83        1632  1662   352   13705604  48920 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a83        1632  1663   352   13705604  48920 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a83        1632  1664   352   13705604  48920 0                   0 S  19   0      -   0  bg 00:00:00 binder:1632_1
+u:r:priv_app:s0:c512,c768      u0_a83        1632  1665   352   13705604  48920 0                   0 S  19   0      -   0  bg 00:00:00 binder:1632_2
+u:r:priv_app:s0:c512,c768      u0_a83        1632  1718   352   13705604  48920 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a83        1632  1914   352   13705604  48920 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a83        1632  1999   352   13705604  48920 0                   0 S  19   0      -   0  bg 00:00:00 binder:1632_3
+u:r:priv_app:s0:c512,c768      u0_a83        1632  2000   352   13705604  48920 0                   0 S  19   0      -   0  bg 00:00:00 binder:1632_4
+u:r:priv_app:s0:c512,c768      u0_a83        1632  2805   352   13705604  48920 0                   0 S  19   0      -   0  bg 00:00:00 binder:1632_5
+u:r:priv_app:s0:c512,c768      u0_a83        1632  2812   352   13705604  48920 0                   0 S  19   0      -   0  bg 00:00:00 binder:1632_6
+u:r:priv_app:s0:c512,c768      u0_a83        1632  4477   352   13705604  48920 0                   0 S  19   0      -   0  bg 00:00:00 Worker-1
+u:r:priv_app:s0:c512,c768      u0_a83        1632  4499   352   13705604  48920 0                   0 S  19   0      -   0  bg 00:00:00 binder:1632_7
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1655 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 s.youtube.music
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1682 352 14779876 64940 0                  0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1692 352 14779876 64940 0                  0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1693 352 14779876 64940 0                  0 S  39 -20      -   0  bg 00:00:00 ADB-JDWP Connec
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1694 352 14779876 64940 0                  0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1695 352 14779876 64940 0                  0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1696 352 14779876 64940 0                  0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1697 352 14779876 64940 0                  0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1698 352 14779876 64940 0                  0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1701 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 binder:1655_1
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1703 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 binder:1655_2
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1736 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 binder:1655_3
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1803 352 14779876 64940 0                  0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1930 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 ScionFrontendAp
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1933 352 14779876 64940 0                  0 S   0  19      -   0  bg 00:00:00 GmsDynamite
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1939 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 Firebase-Messag
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1944 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 Firebase-Messag
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1946 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 Firebase Backgr
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 1942 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 FirebaseInstanc
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2010 352 14779876 64940 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2011 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #0
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2012 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 Scheduler Threa
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2013 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #1
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2014 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 yt-critical15-1
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2015 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 yt-critical15-2
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2017 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #2
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2031 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #3
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2032 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #4
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2036 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #5
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2053 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #6
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2055 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #7
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2059 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #8
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2076 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #9
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2078 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #11
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2081 352 14779876 64940 0                  0 S   8  11      -   0  bg 00:00:00 Primes-1
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2086 352 14779876 64940 0                  0 S   8  11      -   0  bg 00:00:00 Primes-2
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2095 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 ProcessStablePh
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2097 352 14779876 64940 0                  0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2102 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #10
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2103 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 CronetInit
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2128 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 WifiManagerThre
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2169 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 ThreadPoolServi
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2170 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2172 352 14779876 64940 0                  0 S  21  -2      -   0  bg 00:00:00 ChromiumNet
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2173 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #12
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2174 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 ConnectivityThr
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2175 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #13
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2180 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #15
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2176 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #14
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2185 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 ANRGuard-Thread
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2218 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 CsiReporter-0
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2223 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2226 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 Network File Th
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2228 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2238 352 14779876 64940 0                  0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2269 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 android.bg
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2272 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 yt-critical15-3
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2273 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 yt-critical15-4
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2274 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 Lite Thread #0
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2312 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 FeedbackLogger
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2335 352 14779876 64940 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2372 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 binder:1655_4
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2628 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 Lite Thread #0
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2641 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 Lite Thread #1
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2940 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-1
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2941 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-2
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2945 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 Verification th
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2946 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-3
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2949 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-4
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2950 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-5
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2951 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-6
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2952 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-7
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2953 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-8
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2958 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-9
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2959 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-10
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2960 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-11
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2961 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-12
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2962 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-13
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2963 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-14
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2964 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-15
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2965 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-16
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2966 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-17
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2967 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-18
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2968 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-19
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 2969 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 gads-20
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 3044 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 mediaReq18-1
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 3065 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 FrameworkPlayer
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 3088 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 ExoPlayer:Frame
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 3113 352 14779876 64940 0                  0 S  35 -16      -   0  bg 00:00:00 ExoPlayer:Playb
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 3181 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 AudioPortEventH
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 3198 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 unnamed
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 3220 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 Firebase Backgr
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 3223 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 pool-20-thread-
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 3231 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 Thread-28
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 3261 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 OkHttp Connecti
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 3288 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 pool-21-thread-
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 3294 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 pool-22-thread-
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 3305 352 14779876 64940 0                  0 S   9  10      -   0  bg 00:00:00 GAThread
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 3338 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 Okio Watchdog
+u:r:untrusted_app_32:s0:c143,c256,c512,c768 u0_a143 1655 3365 352 14779876 64940 0                  0 S  19   0      -   0  bg 00:00:00 MessengerIpcCli
+u:r:system_app:s0              system        1669  1669   352   13733220  38788 0                   0 S  19   0      -   0  bg 00:00:00 ndroid.keychain
+u:r:system_app:s0              system        1669  1675   352   13733220  38788 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:system_app:s0              system        1669  1684   352   13733220  38788 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:system_app:s0              system        1669  1685   352   13733220  38788 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:system_app:s0              system        1669  1686   352   13733220  38788 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:system_app:s0              system        1669  1687   352   13733220  38788 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:system_app:s0              system        1669  1688   352   13733220  38788 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:system_app:s0              system        1669  1689   352   13733220  38788 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:system_app:s0              system        1669  1690   352   13733220  38788 0                   0 S  19   0      -   0  bg 00:00:00 binder:1669_1
+u:r:system_app:s0              system        1669  1691   352   13733220  38788 0                   0 S  19   0      -   0  bg 00:00:00 binder:1669_2
+u:r:system_app:s0              system        1669  1816   352   13733220  38788 0                   0 S  19   0      -   0  bg 00:00:00 binder:1669_3
+u:r:system_app:s0              system        1669  1826   352   13733220  38788 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a88        1702  1702   352   13691168  40284 0                   0 S  19   0      -   0  bg 00:00:00 viders.calendar
+u:r:priv_app:s0:c512,c768      u0_a88        1702  1717   352   13691168  40284 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a88        1702  1735   352   13691168  40284 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a88        1702  1743   352   13691168  40284 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a88        1702  1752   352   13691168  40284 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a88        1702  1754   352   13691168  40284 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a88        1702  1755   352   13691168  40284 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a88        1702  1756   352   13691168  40284 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a88        1702  1763   352   13691168  40284 0                   0 S  19   0      -   0  bg 00:00:00 binder:1702_1
+u:r:priv_app:s0:c512,c768      u0_a88        1702  1780   352   13691168  40284 0                   0 S  19   0      -   0  bg 00:00:00 binder:1702_2
+u:r:priv_app:s0:c512,c768      u0_a88        1702  1807   352   13691168  40284 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a88        1702  2100   352   13691168  40284 0                   0 S  19   0      -   0  bg 00:00:00 binder:1702_3
+u:r:priv_app:s0:c512,c768      u0_a88        1702  4500   352   13691168  40284 0                   0 S  19   0      -   0  bg 00:00:00 binder:1702_4
+u:r:priv_app:s0:c512,c768      u0_a88        1702  4501   352   13691168  40284 0                   0 S  19   0      -   0  bg 00:00:00 binder:1702_5
+u:r:priv_app:s0:c512,c768      u0_a88        1702  4514   352   13691168  40284 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  1705   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 gle.android.gms
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  1712   352   14221300 108788 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  1737   352   14221300 108788 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  1738   352   14221300 108788 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  1739   352   14221300 108788 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  1740   352   14221300 108788 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  1741   352   14221300 108788 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  1742   352   14221300 108788 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  1744   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 binder:1705_1
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  1746   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 binder:1705_2
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  1750   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 binder:1705_3
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  1835   352   14221300 108788 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2077   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 FileObserver
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2198   352   14221300 108788 0                   0 S  10   9      -   0  fg 00:00:00 highpool[0]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2209   352   14221300 108788 0                   0 S  10   9      -   0  fg 00:00:00 GlobalDispatchi
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2210   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 GlobalScheduler
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2346   352   14221300 108788 0                   0 R  10   9      -   0  fg 00:00:00 highpool[1]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2366   352   14221300 108788 0                   0 S   9  10      -   0  fg 00:00:00 lowpool[1]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2392   352   14221300 108788 0                   0 S  10   9      -   0  fg 00:00:00 GoogleApiHandle
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2487   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 binder:1705_4
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2550   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 binder:1705_5
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2615   352   14221300 108788 0                   0 S  10   9      -   0  fg 00:00:00 highpool[2]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2616   352   14221300 108788 0                   0 R  10   9      -   0  fg 00:00:00 highpool[3]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2633   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 binder:1705_6
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2642   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 binder:1705_7
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2682   352   14221300 108788 0                   0 S   9  10      -   0  fg 00:00:01 lowpool[3]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2681   352   14221300 108788 0                   0 S   9  10      -   0  fg 00:00:00 lowpool[2]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2707   352   14221300 108788 0                   0 S   9  10      -   0  fg 00:00:00 Measurement Wor
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2728   352   14221300 108788 0                   0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2764   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 binder:1705_8
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2791   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 ice] processing
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2850   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 .BOOT_COMPLETED
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2874   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 pool-34-thread-
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2910   352   14221300 108788 0                   0 S  18   1      -   0  fg 00:00:00 binder:1705_9
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  2932   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 DG
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  3229   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 OkHttp Connecti
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  3282   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 Okio Watchdog
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  3337   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 arch_disk_io_0
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  3377   352   14221300 108788 0                   0 S   9  10      -   0  fg 00:00:00 AsyncTask #1
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  3384   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 binder:1705_A
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  3607   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 OkHttp Connecti
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  3713   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 binder:1705_B
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  3858   352   14221300 108788 0                   0 D   9  10      -   0  fg 00:00:01 lowpool[4]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4387   352   14221300 108788 0                   0 S   9  10      -   0  fg 00:00:00 Thread-28
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4388   352   14221300 108788 0                   0 S   9  10      -   0  fg 00:00:00 Thread-29
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4389   352   14221300 108788 0                   0 S   9  10      -   0  fg 00:00:00 Thread-30
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4390   352   14221300 108788 0                   0 S   9  10      -   0  fg 00:00:00 Thread-31
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4391   352   14221300 108788 0                   0 S   9  10      -   0  fg 00:00:00 Thread-32
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4449   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 WNLOAD_COMPLETE
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4450   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 -Executor] idle
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4474   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 -Executor] idle
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4497   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 pool-104-thread
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4527   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 binder:1705_C
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4607   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 -Executor] idle
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4625   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 binder:1705_D
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4647   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 ModuleProviderH
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4657   352   14221300 108788 0                   0 S  10   9      -   0  fg 00:00:00 GoogleApiHandle
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4658   352   14221300 108788 0                   0 S  10   9      -   0  fg 00:00:00 MLHandler
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4669   352   14221300 108788 0                   0 S  10   9      -   0  fg 00:00:00 GoogleApiHandle
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4674   352   14221300 108788 0                   0 S  10   9      -   0  fg 00:00:00 MLHandler
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4701   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 CronetInit
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4702   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 ThreadPoolServi
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4703   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 ThreadPoolForeg
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4704   352   14221300 108788 0                   0 S   9  10      -   0  fg 00:00:01 ChromiumNet
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4705   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 ThreadPoolForeg
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4706   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 ThreadPoolForeg
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4707   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 Network File Th
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4711   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 binder:1705_E
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4728   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 binder:1705_F
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4730   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 binder:1705_10
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4906   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 ConnectivityThr
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  4976   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 LIT-TimeoutSche
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  5019   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 pool-179-thread
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  5031   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 WifiManagerThre
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  5100   352   14221300 108788 0                   0 S  19   0      -   0  fg 00:00:00 ThreadPoolForeg
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  5110   352   14221300 108788 0                   0 S   9  10      -   0  fg 00:00:00 lowpool[5]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  5119   352   14221300 108788 0                   0 S   9  10      -   0  fg 00:00:00 lowpool[6]
+u:r:gmscore_app:s0:c512,c768   u0_a130       1705  5413   352   14221300 108788 0                   0 S   9  10      -   0  fg 00:00:00 lowpool[7]
+u:r:kernel:s0                  root          1720  1720     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/3:4H-kverityd
+u:r:kernel:s0                  root          1722  1722     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/3:5H-kverityd
+u:r:priv_app:s0:c512,c768      u0_a132       1725  1725   352   31807340 125128 0                   0 S  29 -10      -   0  ta 00:00:02 earchbox:search
+u:r:priv_app:s0:c512,c768      u0_a132       1725  1761   352   31807340 125128 0                   0 S  39 -20      -   0  ta 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a132       1725  1762   352   31807340 125128 0                   0 S  39 -20      -   0  ta 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a132       1725  1774   352   31807340 125128 0                   0 S  10   9      -   0  ta 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a132       1725  1775   352   31807340 125128 0                   0 S  15   4      -   0  ta 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a132       1725  1776   352   31807340 125128 0                   0 S  15   4      -   0  ta 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a132       1725  1777   352   31807340 125128 0                   0 S  15   4      -   0  ta 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a132       1725  1778   352   31807340 125128 0                   0 S  15   4      -   0  ta 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a132       1725  1779   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 binder:1725_1
+u:r:priv_app:s0:c512,c768      u0_a132       1725  1789   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 binder:1725_2
+u:r:priv_app:s0:c512,c768      u0_a132       1725  1855   352   31807340 125128 0                   0 S  10   9      -   0  ta 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a132       1725  1885   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 binder:1725_3
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2050   352   31807340 125128 0                   0 S   8  11      -   0  ta 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2051   352   31807340 125128 0                   0 S  10   9      -   0  ta 00:00:00 GoogleApiHandle
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2085   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 Lite Thread #0
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2088   352   31807340 125128 0                   0 S   8  11      -   0  ta 00:00:00 Primes-1
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2089   352   31807340 125128 0                   0 S  27  -8      -   0  ta 00:00:00 Primes-nativecr
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2090   352   31807340 125128 0                   0 S   8  11      -   0  ta 00:00:00 Primes-2
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2091   352   31807340 125128 0                   0 S   9  10      -   0  ta 00:00:00 BG Thread #0
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2108   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 Scheduler Threa
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2116   352   31807340 125128 0                   0 S   9  10      -   0  ta 00:00:00 BG Thread #1
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2119   352   31807340 125128 0                   0 R   9  10      -   0  ta 00:00:00 BG Thread #2
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2120   352   31807340 125128 0                   0 S   9  10      -   0  ta 00:00:00 BG Thread #3
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2125   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 SharedPreferenc
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2130   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 Lite Thread #0
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2133   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 Lite Thread #1
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2140   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 SharedPreferenc
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2165   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 SharedPreferenc
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2189   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 binder:1725_4
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2230   352   31807340 125128 0                   0 S   8  11      -   0  ta 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2242   352   31807340 125128 0                   0 S  21  -2      -   0  ta 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2267   352   31807340 125128 0                   0 S  29 -10      -   0  ta 00:00:00 RenderThread
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2275   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 WifiManagerThre
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2276   352   31807340 125128 0                   0 S   0  19      -   0  ta 00:00:00 GmsDynamite
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2305   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 ConnectivityThr
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2369   352   31807340 125128 0                   0 S   9  10      -   0  ta 00:00:00 android.bg
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2488   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 CookieMonsterCl
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2489   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 CookieMonsterBa
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2540   352   31807340 125128 0                   0 S   8  11      -   0  ta 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2541   352   31807340 125128 0                   0 S   8  11      -   0  ta 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2547   352   31807340 125128 0                   0 S   8  11      -   0  ta 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2551   352   31807340 125128 0                   0 S   8  11      -   0  ta 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2553   352   31807340 125128 0                   0 S   8  11      -   0  ta 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2555   352   31807340 125128 0                   0 S   8  11      -   0  ta 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2557   352   31807340 125128 0                   0 S   8  11      -   0  ta 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2560   352   31807340 125128 0                   0 S   8  11      -   0  ta 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2561   352   31807340 125128 0                   0 S   8  11      -   0  ta 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2562   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 ProtoDataStore-
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2566   352   31807340 125128 0                   0 S   8  11      -   0  ta 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2575   352   31807340 125128 0                   0 S   8  11      -   0  ta 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2606   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 CronetInit
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2611   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 ThreadPoolServi
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2612   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 ThreadPoolForeg
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2617   352   31807340 125128 0                   0 S  21  -2      -   0  ta 00:00:00 ChromiumNet
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2651   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 binder:1725_5
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2656   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 ThreadPoolForeg
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2657   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 ThreadPoolForeg
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2664   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 ExoPlayer:Frame
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2696   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 Network File Th
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2702   352   31807340 125128 0                   0 S  35 -16      -   0  ta 00:00:00 ExoPlayer:Playb
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2745   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 binder:1725_6
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2751   352   31807340 125128 0                   0 S  21  -2      -   0  ta 00:00:00 EventBus0
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2754   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 TimerThread0
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2758   352   31807340 125128 0                   0 S   9  10      -   0  ta 00:00:00 glide-active-re
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2775   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 UserFacingBlock
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2778   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 SurfaceSyncGrou
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2792   352   31807340 125128 0                   0 S  21  -2      -   0  ta 00:00:00 hwuiTask0
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2793   352   31807340 125128 0                   0 S  21  -2      -   0  ta 00:00:00 hwuiTask1
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2800   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 SharedPreferenc
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2878   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 binder:1725_3
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2911   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 binder:1725_7
+u:r:priv_app:s0:c512,c768      u0_a132       1725  2916   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 binder:1725_8
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3268   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 binder:1725_9
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3270   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 binder:1725_A
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3272   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 binder:1725_B
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3570   352   31807340 125128 0                   0 S  10   9      -   0  ta 00:00:00 glide-disk-cach
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3584   352   31807340 125128 0                   0 S  10   9      -   0  ta 00:00:00 glide-source-th
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3591   352   31807340 125128 0                   0 S  10   9      -   0  ta 00:00:00 glide-source-th
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3592   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 CronetInit
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3593   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 ThreadPoolServi
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3594   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 ThreadPoolForeg
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3595   352   31807340 125128 0                   0 S  21  -2      -   0  ta 00:00:00 ChromiumNet
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3596   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 ThreadPoolForeg
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3597   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 ThreadPoolForeg
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3608   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 Cookies thread0
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3621   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 Network File Th
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3656   352   31807340 125128 0                   0 S  10   9      -   0  ta 00:00:00 glide-animation
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3657   352   31807340 125128 0                   0 S  10   9      -   0  ta 00:00:00 glide-animation
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3749   352   31807340 125128 0                   0 S  10   9      -   0  ta 00:00:00 glide-source-th
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3750   352   31807340 125128 0                   0 S  10   9      -   0  ta 00:00:00 glide-source-th
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3844   352   31807340 125128 0                   0 S   9  10      -   0  ta 00:00:00 arch_disk_io_0
+u:r:priv_app:s0:c512,c768      u0_a132       1725  3899   352   31807340 125128 0                   0 S   9  10      -   0  ta 00:00:00 arch_disk_io_1
+u:r:priv_app:s0:c512,c768      u0_a132       1725  4107   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 mdh-standalone-
+u:r:priv_app:s0:c512,c768      u0_a132       1725  4510   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 UserFacingBlock
+u:r:priv_app:s0:c512,c768      u0_a132       1725  4511   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 UserFacingBlock
+u:r:priv_app:s0:c512,c768      u0_a132       1725  4512   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 UserFacingBlock
+u:r:priv_app:s0:c512,c768      u0_a132       1725  4517   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 UserFacingBlock
+u:r:priv_app:s0:c512,c768      u0_a132       1725  4520   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 UserFacingBlock
+u:r:priv_app:s0:c512,c768      u0_a132       1725  4519   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 UserFacingBlock
+u:r:priv_app:s0:c512,c768      u0_a132       1725  4555   352   31807340 125128 0                   0 S   9  10      -   0  ta 00:00:00 arch_disk_io_2
+u:r:priv_app:s0:c512,c768      u0_a132       1725  5073   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 GAC_Executor[0]
+u:r:priv_app:s0:c512,c768      u0_a132       1725  5074   352   31807340 125128 0                   0 S  19   0      -   0  ta 00:00:00 GAC_Executor[1]
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 1766 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 android.youtube
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 1788 352 14772316 65080 0                  0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 1790 352 14772316 65080 0                  0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 1794 352 14772316 65080 0                  0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 1795 352 14772316 65080 0                  0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 1796 352 14772316 65080 0                  0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 1797 352 14772316 65080 0                  0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 1798 352 14772316 65080 0                  0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 1799 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 binder:1766_1
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 1801 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 binder:1766_2
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 1812 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 binder:1766_3
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 1884 352 14772316 65080 0                  0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2179 352 14772316 65080 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2234 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #0
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2244 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 Scheduler Threa
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2262 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 yt-critical Thr
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2263 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 yt-critical Thr
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2264 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 yt-critical Thr
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2266 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 yt-critical Thr
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2279 352 14772316 65080 0                  0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2280 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #1
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2283 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #2
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2284 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #3
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2285 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #4
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2286 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #5
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2287 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #6
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2288 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 WifiManagerThre
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2290 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #7
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2291 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #8
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2293 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 cronet-ui-inner
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2294 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 cronet-ui-inner
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2295 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 cronet-ui-inner
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2296 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 cronet-ui-inner
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2297 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 cronetPrio-ui-i
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2298 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 cronet-bg-inner
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2299 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 cronet-bg-inner
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2300 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 cronet-bg-inner
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2301 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 cronet-bg-inner
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2302 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 cronetPrio-bg-i
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2303 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #9
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2304 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #10
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2306 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #11
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2309 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #12
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2313 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #13
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2319 352 14772316 65080 0                  0 S   0  19      -   0  bg 00:00:00 GmsDynamite
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2321 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 ConnectivityThr
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2327 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 cronet-netReque
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2332 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 cronet-netReque
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2334 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 cronet-netReque
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2340 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 cronet-netReque
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2361 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 cronetPrio-netR
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2373 352 14772316 65080 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2381 352 14772316 65080 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2396 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 Lite Thread #0
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2427 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 mediaReq11-1
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2462 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 gads-1
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2465 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 gads-3
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2469 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 FrameworkPlayer
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2476 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 Verification th
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2502 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 binder:1766_4
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2539 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 ExoPlayer:Frame
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2568 352 14772316 65080 0                  0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2576 352 14772316 65080 0                  0 S  35 -16      -   0  bg 00:00:00 ExoPlayer:Playb
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2670 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 glide-active-re
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2684 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 CronetInit
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2692 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 CsiReporter-0
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2703 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 ThreadPoolServi
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2704 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2705 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 ChromiumNet
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2716 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2717 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2769 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 FileObserver
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2771 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 Network File Th
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2833 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 ScionFrontendAp
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2835 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 Firebase-Messag
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2836 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 Firebase-Messag
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2837 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 Firebase Backgr
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2845 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 FirebaseInstanc
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2866 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 Lite Thread #0
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2870 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 Firebase Backgr
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2909 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #14
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2914 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 OkHttp Connecti
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2980 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 Lite Thread #1
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2984 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 Okio Watchdog
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2994 352 14772316 65080 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 2997 352 14772316 65080 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #15
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 3038 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 MessengerIpcCli
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 3271 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 binder:1766_5
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 3610 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 pool-28-thread-
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 3649 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 Firebase-Messag
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 5437 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 ProcessStablePh
+u:r:untrusted_app_32:s0:c150,c256,c512,c768 u0_a150 1766 5466 352 14772316 65080 0                  0 S  19   0      -   0  bg 00:00:00 binder:1766_6
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1819   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 .apps.messaging
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1843   352   14160020 104036 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1844   352   14160020 104036 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1846   352   14160020 104036 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1847   352   14160020 104036 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1848   352   14160020 104036 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1849   352   14160020 104036 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1850   352   14160020 104036 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1854   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 binder:1819_1
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1883   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 binder:1819_2
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1901   352   14160020 104036 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1943   352   14160020 104036 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1945   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 BG Thread #0
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1947   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 BG Thread #1
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1948   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 BG Thread #2
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1949   352   14160020 104036 0                   0 S  10   9      -   0  fg 00:00:00 GoogleApiHandle
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1956   352   14160020 104036 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1961   352   14160020 104036 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1962   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 Scheduler Threa
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1964   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 BG Thread #3
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1965   352   14160020 104036 0                   0 S  27  -8      -   0  fg 00:00:00 Primes-nativecr
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1967   352   14160020 104036 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a123       1819  1968   352   14160020 104036 0                   0 S   8  11      -   0  fg 00:00:01 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a123       1819  2113   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 AsyncTask #1
+u:r:priv_app:s0:c512,c768      u0_a123       1819  2137   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 Lite Thread #0
+u:r:priv_app:s0:c512,c768      u0_a123       1819  2282   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 Lite Thread #1
+u:r:priv_app:s0:c512,c768      u0_a123       1819  2314   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 binder:1819_3
+u:r:priv_app:s0:c512,c768      u0_a123       1819  2323   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 Lite Thread #0
+u:r:priv_app:s0:c512,c768      u0_a123       1819  2324   352   14160020 104036 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a123       1819  2333   352   14160020 104036 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a123       1819  2336   352   14160020 104036 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a123       1819  2339   352   14160020 104036 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a123       1819  2375   352   14160020 104036 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a123       1819  2368   352   14160020 104036 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a123       1819  2367   352   14160020 104036 0                   0 S   8  11      -   0  fg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a123       1819  2385   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 ConnectivityThr
+u:r:priv_app:s0:c512,c768      u0_a123       1819  2873   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 OkHttp Connecti
+u:r:priv_app:s0:c512,c768      u0_a123       1819  2894   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 Okio Watchdog
+u:r:priv_app:s0:c512,c768      u0_a123       1819  2897   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 binder:1819_4
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3341   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 SimStateTracker
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3358   352   14160020 104036 0                   0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3398   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 Firebase-Messag
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3399   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 Firebase-Messag
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3400   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 Firebase Backgr
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3413   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 FirebaseInstanc
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3418   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 Firebase Backgr
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3425   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 OkHttp Connecti
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3428   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 Okio Watchdog
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3444   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 binder:1819_5
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3447   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 MessengerIpcCli
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3543   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 DG
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3550   352   14160020 104036 0                   0 S   0  19      -   0  fg 00:00:00 GmsDynamite
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3573   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 CronetInit
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3574   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 ThreadPoolServi
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3575   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 ThreadPoolForeg
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3578   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 ThreadPoolForeg
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3579   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 ThreadPoolForeg
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3582   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 ChromiumNet
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3585   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 grpc-timer-0
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3650   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 Network File Th
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3660   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 grpc-default-ex
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3801   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 OkHttp Dispatch
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3807   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 OkHttp Connecti
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3809   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 OkHttp Dispatch
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3812   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 OkHttp Connecti
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3813   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 OkHttp Dispatch
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3824   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 OkHttp Connecti
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3853   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 binder:1819_6
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3878   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 OkHttp Dispatch
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3884   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 OkHttp Connecti
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3887   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 OkHttp Dispatch
+u:r:priv_app:s0:c512,c768      u0_a123       1819  3891   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 OkHttp Connecti
+u:r:priv_app:s0:c512,c768      u0_a123       1819  4691   352   14160020 104036 0                   0 S   9  10      -   0  fg 00:00:00 android.bg
+u:r:priv_app:s0:c512,c768      u0_a123       1819  4727   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 binder:1819_7
+u:r:priv_app:s0:c512,c768      u0_a123       1819  5405   352   14160020 104036 0                   0 S  19   0      -   0  fg 00:00:00 binder:1819_8
+u:r:priv_app:s0:c512,c768      u0_a126       1875  1875   352   13693600  49628 0                   0 S  19   0      -   0  bg 00:00:00 .android.as.oss
+u:r:priv_app:s0:c512,c768      u0_a126       1875  1913   352   13693600  49628 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a126       1875  1917   352   13693600  49628 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a126       1875  1918   352   13693600  49628 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a126       1875  1919   352   13693600  49628 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a126       1875  1920   352   13693600  49628 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a126       1875  1921   352   13693600  49628 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a126       1875  1922   352   13693600  49628 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a126       1875  1923   352   13693600  49628 0                   0 S  19   0      -   0  bg 00:00:00 binder:1875_1
+u:r:priv_app:s0:c512,c768      u0_a126       1875  1924   352   13693600  49628 0                   0 S  19   0      -   0  bg 00:00:00 binder:1875_2
+u:r:priv_app:s0:c512,c768      u0_a126       1875  2035   352   13693600  49628 0                   0 S  19   0      -   0  bg 00:00:00 binder:1875_3
+u:r:priv_app:s0:c512,c768      u0_a126       1875  2104   352   13693600  49628 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a126       1875  2383   352   13693600  49628 0                   0 S  19   0      -   0  bg 00:00:00 grpc-timer-0
+u:r:priv_app:s0:c512,c768      u0_a126       1875  5669   352   13693600  49628 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:system_app:s0              system        2052  2052   352   13689444  38372 0                   0 S  19   0      -   0  bg 00:00:00 .localtransport
+u:r:system_app:s0              system        2052  2065   352   13689444  38372 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:system_app:s0              system        2052  2066   352   13689444  38372 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:system_app:s0              system        2052  2067   352   13689444  38372 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:system_app:s0              system        2052  2068   352   13689444  38372 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:system_app:s0              system        2052  2069   352   13689444  38372 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:system_app:s0              system        2052  2070   352   13689444  38372 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:system_app:s0              system        2052  2071   352   13689444  38372 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:system_app:s0              system        2052  2072   352   13689444  38372 0                   0 S  19   0      -   0  bg 00:00:00 binder:2052_1
+u:r:system_app:s0              system        2052  2073   352   13689444  38372 0                   0 S  19   0      -   0  bg 00:00:00 binder:2052_2
+u:r:system_app:s0              system        2052  2074   352   13689444  38372 0                   0 S  19   0      -   0  bg 00:00:00 binder:2052_3
+u:r:system_app:s0              system        2052  2092   352   13689444  38372 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:system_app:s0              system        2052  2207   352   13689444  38372 0                   0 S  19   0      -   0  bg 00:00:00 binder:2052_4
+u:r:system_app:s0              system        2052  2208   352   13689444  38372 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 2243 352 13750800 39884 0                  0 S  19   0      -   0  bg 00:00:00 droid.deskclock
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 2251 352 13750800 39884 0                  0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 2253 352 13750800 39884 0                  0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 2255 352 13750800 39884 0                  0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 2256 352 13750800 39884 0                  0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 2257 352 13750800 39884 0                  0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 2258 352 13750800 39884 0                  0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 2259 352 13750800 39884 0                  0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 2260 352 13750800 39884 0                  0 S  19   0      -   0  bg 00:00:00 binder:2243_1
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 2261 352 13750800 39884 0                  0 S  19   0      -   0  bg 00:00:00 binder:2243_2
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 2414 352 13750800 39884 0                  0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 2497 352 13750800 39884 0                  0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 2614 352 13750800 39884 0                  0 S  19   0      -   0  bg 00:00:00 binder:2243_3
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 2653 352 13750800 39884 0                  0 S   8  11      -   0  bg 00:00:00 Primes-1
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 2658 352 13750800 39884 0                  0 S  19   0      -   0  bg 00:00:00 Analytics Threa
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 2659 352 13750800 39884 0                  0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 3121 352 13750800 39884 0                  0 S   8  11      -   0  bg 00:00:00 Primes-2
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 3124 352 13750800 39884 0                  0 S  19   0      -   0  bg 00:00:00 Alarm
+u:r:untrusted_app_32:s0:c146,c256,c512,c768 u0_a146 2243 3127 352 13750800 39884 0                  0 S  19   0      -   0  bg 00:00:00 ProcessStablePh
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2289 352  30675364  41716 0                   0 S  23  -4      -   0  bg 00:00:01 .android.chrome
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2331 352  30675364  41716 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2345 352  30675364  41716 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2356 352  30675364  41716 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2357 352  30675364  41716 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2358 352  30675364  41716 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2359 352  30675364  41716 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2360 352  30675364  41716 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2362 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 binder:2289_1
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2380 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 binder:2289_2
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2395 352  30675364  41716 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2741 352  30675364  41716 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2750 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 SAFE_BROWSING_U
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2781 352  30675364  41716 0                   0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2796 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 binder:2289_3
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2807 352  30675364  41716 0                   0 S   0  19      -   0  bg 00:00:00 GmsDynamite
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2841 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 HangWatcher
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2844 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolServi
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2846 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2847 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2896 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2898 352  30675364  41716 0                   0 S  23  -4      -   0  bg 00:00:00 Chrome_IOThread
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2899 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 MemoryInfra
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 2912 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 binder:2289_4
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 3000 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 3001 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 3002 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 3003 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 AudioThread
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 3004 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 VideoCaptureThr
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 3005 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 NetworkService
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 3006 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolSingl
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 3030 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolSingl
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 3172 352  30675364  41716 0                   0 S   9  10      -   0  bg 00:00:00 android.bg
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 3197 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolSingl
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 3354 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 binder:2289_5
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 3364 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 NetworkStatusLi
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 3864 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 Chrome_ProcessL
+u:r:untrusted_app:s0:c133,c256,c512,c768 u0_a133 2289 3982 352  30675364  41716 0                   0 S  19   0      -   0  bg 00:00:00 binder:2289_6
+u:r:kernel:s0                  root          2409  2409     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/3:6H-kverityd
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 2500 2500 352  13702224  38780 0                   0 S  19   0      -   0  bg 00:00:00 webview_service
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 2500 2509 352  13702224  38780 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 2500 2510 352  13702224  38780 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 2500 2512 352  13702224  38780 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 2500 2513 352  13702224  38780 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 2500 2534 352  13702224  38780 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 2500 2535 352  13702224  38780 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 2500 2536 352  13702224  38780 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 2500 2537 352  13702224  38780 0                   0 S  19   0      -   0  bg 00:00:00 binder:2500_1
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 2500 2538 352  13702224  38780 0                   0 S  19   0      -   0  bg 00:00:00 binder:2500_2
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 2500 2605 352  13702224  38780 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 2500 2852 352  13702224  38780 0                   0 S  19   0      -   0  bg 00:00:00 binder:2500_3
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 2500 2853 352  13702224  38780 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 2500 2858 352  13702224  38780 0                   0 S  19   0      -   0  bg 00:00:00 seed_holder
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 2500 5143 352  13702224  38780 0                   0 S  19   0      -   0  bg 00:00:00 binder:2500_4
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2567   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 ding:background
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2574   352   13776408  46312 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2579   352   13776408  46312 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2580   352   13776408  46312 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2581   352   13776408  46312 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2582   352   13776408  46312 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2583   352   13776408  46312 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2584   352   13776408  46312 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2585   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 binder:2567_1
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2589   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 binder:2567_2
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2648   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 binder:2567_3
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2660   352   13776408  46312 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2694   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 Monitor Thread 
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2695   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 ProtoDataStore-
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2697   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 ValueStore-0
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2698   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 FileObserver
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2699   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 ValueStore-1
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2700   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 ValueStore-2
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2706   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 ValueStore-3
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2806   352   13776408  46312 0                   0 S   9  10      -   0  bg 00:00:00 Db-download_ser
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2824   352   13776408  46312 0                   0 S   9  10      -   0  bg 00:00:00 DownloadService
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2926   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 ConnectivityThr
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2942   352   13776408  46312 0                   0 S   9  10      -   0  bg 00:00:00 Db-scheduler_ba
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2948   352   13776408  46312 0                   0 S   9  10      -   0  bg 00:00:00 bgExecutor #0
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2992   352   13776408  46312 0                   0 S   9  10      -   0  bg 00:00:00 bgExecutor #1
+u:r:priv_app:s0:c512,c768      u0_a131       2567  2998   352   13776408  46312 0                   0 S   9  10      -   0  bg 00:00:00 bgExecutor #2
+u:r:priv_app:s0:c512,c768      u0_a131       2567  3007   352   13776408  46312 0                   0 S   9  10      -   0  bg 00:00:00 bgExecutor #3
+u:r:priv_app:s0:c512,c768      u0_a131       2567  3257   352   13776408  46312 0                   0 S   9  10      -   0  bg 00:00:00 PhoneskySchedul
+u:r:priv_app:s0:c512,c768      u0_a131       2567  3260   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 LightweightExec
+u:r:priv_app:s0:c512,c768      u0_a131       2567  3280   352   13776408  46312 0                   0 S  18   1      -   0  bg 00:00:00 BlockingExecuto
+u:r:priv_app:s0:c512,c768      u0_a131       2567  3281   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 Scheduler Threa
+u:r:priv_app:s0:c512,c768      u0_a131       2567  3350   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 OkHttp Connecti
+u:r:priv_app:s0:c512,c768      u0_a131       2567  3356   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 Okio Watchdog
+u:r:priv_app:s0:c512,c768      u0_a131       2567  3440   352   13776408  46312 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a131       2567  3514   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 binder:2567_4
+u:r:priv_app:s0:c512,c768      u0_a131       2567  3622   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 LightweightExec
+u:r:priv_app:s0:c512,c768      u0_a131       2567  3644   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 LightweightExec
+u:r:priv_app:s0:c512,c768      u0_a131       2567  3754   352   13776408  46312 0                   0 S   9  10      -   0  bg 00:00:00 anmz
+u:r:priv_app:s0:c512,c768      u0_a131       2567  4576   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 binder:2567_5
+u:r:priv_app:s0:c512,c768      u0_a131       2567  4601   352   13776408  46312 0                   0 S  19   0      -   0  bg 00:00:00 OkHttp Connecti
+u:r:priv_app:s0:c512,c768      u0_a156       2590  2590   352   13766436  37984 0                   0 S  19   0      -   0  bg 00:00:00 .apps.wallpaper
+u:r:priv_app:s0:c512,c768      u0_a156       2590  2596   352   13766436  37984 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a156       2590  2597   352   13766436  37984 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a156       2590  2598   352   13766436  37984 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a156       2590  2599   352   13766436  37984 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a156       2590  2600   352   13766436  37984 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a156       2590  2601   352   13766436  37984 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a156       2590  2602   352   13766436  37984 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a156       2590  2603   352   13766436  37984 0                   0 S  19   0      -   0  bg 00:00:00 binder:2590_1
+u:r:priv_app:s0:c512,c768      u0_a156       2590  2613   352   13766436  37984 0                   0 S  19   0      -   0  bg 00:00:00 binder:2590_2
+u:r:priv_app:s0:c512,c768      u0_a156       2590  2671   352   13766436  37984 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a156       2590  2724   352   13766436  37984 0                   0 S  19   0      -   0  bg 00:00:00 binder:2590_3
+u:r:priv_app:s0:c512,c768      u0_a156       2590  2725   352   13766436  37984 0                   0 S  19   0      -   0  bg 00:00:00 binder:2590_4
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2620 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 gle.android.tts
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2625 352 13980400 45124 0                  0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2632 352 13980400 45124 0                  0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2634 352 13980400 45124 0                  0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2635 352 13980400 45124 0                  0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2636 352 13980400 45124 0                  0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2637 352 13980400 45124 0                  0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2638 352 13980400 45124 0                  0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2639 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 binder:2620_1
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2647 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 binder:2620_2
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2677 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 binder:2620_3
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2687 352 13980400 45124 0                  0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2709 352 13980400 45124 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2710 352 13980400 45124 0                  0 S   9  10      -   0  bg 00:00:01 BG Thread #0
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2711 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 Scheduler Threa
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2726 352 13980400 45124 0                  0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2735 352 13980400 45124 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2739 352 13980400 45124 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2743 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 voice-downloade
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2746 352 13980400 45124 0                  0 S   8  11      -   0  bg 00:00:01 Blocking Thread
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2747 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 superpacks-cont
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2813 352 13980400 45124 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #1
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2823 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 superpacks-task
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2825 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 OkHttp Dispatch
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2893 352 13980400 45124 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2900 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 p dl.google.com
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2901 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 OkHttp Connecti
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2902 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 Okio Watchdog
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2904 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 ogle.com Writer
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 2908 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 OkHttp Http2Con
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 3170 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 binder:2620_4
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 3184 352 13980400 45124 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #2
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 3185 352 13980400 45124 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #3
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 3186 352 13980400 45124 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 3237 352 13980400 45124 0                  0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 3388 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 Lite Thread #0
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 3389 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 Lite Thread #1
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 4007 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 Lite Thread #0
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 4106 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 CronetInit
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 4108 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 ThreadPoolServi
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 4109 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 4110 352 13980400 45124 0                  0 S  21  -2      -   0  bg 00:00:02 ChromiumNet
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 4111 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 4112 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 4113 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 Network File Th
+u:r:untrusted_app_32:s0:c151,c256,c512,c768 u0_a151 2620 4328 352 13980400 45124 0                  0 S  19   0      -   0  bg 00:00:00 binder:2620_5
+u:r:priv_app:s0:c512,c768      u0_a121       2749  2749   352   13697008  47220 0                   0 S  19   0      -   0  fg 00:00:00 gearhead:shared
+u:r:priv_app:s0:c512,c768      u0_a121       2749  2763   352   13697008  47220 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a121       2749  2765   352   13697008  47220 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a121       2749  2766   352   13697008  47220 0                   0 S  39 -20      -   0  fg 00:00:00 ADB-JDWP Connec
+u:r:priv_app:s0:c512,c768      u0_a121       2749  2767   352   13697008  47220 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a121       2749  2768   352   13697008  47220 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a121       2749  2772   352   13697008  47220 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a121       2749  2773   352   13697008  47220 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a121       2749  2774   352   13697008  47220 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a121       2749  2776   352   13697008  47220 0                   0 S  19   0      -   0  fg 00:00:00 binder:2749_1
+u:r:priv_app:s0:c512,c768      u0_a121       2749  2780   352   13697008  47220 0                   0 S  19   0      -   0  fg 00:00:00 binder:2749_2
+u:r:priv_app:s0:c512,c768      u0_a121       2749  2795   352   13697008  47220 0                   0 S  19   0      -   0  fg 00:00:00 binder:2749_3
+u:r:priv_app:s0:c512,c768      u0_a121       2749  2801   352   13697008  47220 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a121       2749  2943   352   13697008  47220 0                   0 R  10   9      -   0  fg 00:00:00 GoogleApiHandle
+u:r:priv_app:s0:c512,c768      u0_a121       2749  3193   352   13697008  47220 0                   0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a121       2749  4392   352   13697008  47220 0                   0 S  19   0      -   0  fg 00:00:00 binder:2749_4
+u:r:priv_app:s0:c512,c768      u0_a121       2749  5661   352   13697008  47220 0                   0 S  19   0      -   0  fg 00:00:00 ProcessStablePh
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 2877 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 ogle.android.gm
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 2883 352 14777680 60688 0                  0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 2884 352 14777680 60688 0                  0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 2885 352 14777680 60688 0                  0 S  39 -20      -   0  bg 00:00:00 ADB-JDWP Connec
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 2886 352 14777680 60688 0                  0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 2887 352 14777680 60688 0                  0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 2888 352 14777680 60688 0                  0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 2889 352 14777680 60688 0                  0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 2890 352 14777680 60688 0                  0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 2891 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 binder:2877_1
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 2892 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 binder:2877_2
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 2913 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 binder:2877_3
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 2921 352 14777680 60688 0                  0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 2972 352 14777680 60688 0                  0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3011 352 14777680 60688 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3017 352 14777680 60688 0                  0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3026 352 14777680 60688 0                  0 S   8  11      -   0  bg 00:00:00 Primes-1
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3027 352 14777680 60688 0                  0 S   8  11      -   0  bg 00:00:00 Primes-2
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3028 352 14777680 60688 0                  0 S  27  -8      -   0  bg 00:00:00 Primes-nativecr
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3032 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 Lite Thread #0
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3033 352 14777680 60688 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3034 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #0
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3035 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #1
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3048 352 14777680 60688 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3052 352 14777680 60688 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3053 352 14777680 60688 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3054 352 14777680 60688 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3061 352 14777680 60688 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3062 352 14777680 60688 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3073 352 14777680 60688 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3074 352 14777680 60688 0                  0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3075 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #2
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3077 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 Scheduler Threa
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3082 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 BG Thread #3
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3092 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 BackgroundSingl
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3098 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 ProtoDataStore-
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3104 352 14777680 60688 0                  0 S   0  19      -   0  bg 00:00:00 GmsDynamite
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3152 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 Lite Thread #0
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3164 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 Firebase-Messag
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3165 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 Firebase-Messag
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3166 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 Firebase Backgr
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3177 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 Lite Thread #1
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3196 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 FirebaseInstanc
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3215 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 AsyncTask #3
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3227 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 Firebase Backgr
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3228 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 gm counters ini
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3248 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 OkHttp Connecti
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3273 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 Okio Watchdog
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3274 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 EmailNotificati
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3289 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 arch_disk_io_0
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3295 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 MessengerIpcCli
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3527 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 binder:2877_4
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3577 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 arch_disk_io_1
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3845 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 MailIntentServi
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3863 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 BaseWidgetProvi
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3865 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 android.bg
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 3866 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 pool-10-thread-
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 4281 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 GoogleMailSwitc
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 4336 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 EmailBroadcastP
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 4400 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 arch_disk_io_2
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 4401 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 CronetInit
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 4417 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 ThreadPoolServi
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 4418 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 4424 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 4425 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 4427 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 ChromiumNet
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 4429 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 Network File Th
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 4446 352 14777680 60688 0                  0 S   9  10      -   0  bg 00:00:00 arch_disk_io_3
+u:r:untrusted_app_32:s0:c148,c256,c512,c768 u0_a148 2877 4493 352 14777680 60688 0                  0 S  19   0      -   0  bg 00:00:00 binder:2877_5
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 2934 352  13941640  59492 0                   0 S  19   0      -   0  bg 00:00:00 ndroid.contacts
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 2939 352  13941640  59492 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 2970 352  13941640  59492 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 2971 352  13941640  59492 0                   0 S  39 -20      -   0  bg 00:00:00 ADB-JDWP Connec
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 2973 352  13941640  59492 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 2974 352  13941640  59492 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 2975 352  13941640  59492 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 2976 352  13941640  59492 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 2977 352  13941640  59492 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 2978 352  13941640  59492 0                   0 S  19   0      -   0  bg 00:00:00 binder:2934_1
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 2979 352  13941640  59492 0                   0 S  19   0      -   0  bg 00:00:00 binder:2934_2
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 2987 352  13941640  59492 0                   0 S  19   0      -   0  bg 00:00:00 binder:2934_3
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 2989 352  13941640  59492 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3010 352  13941640  59492 0                   0 S   0  19      -   0  bg 00:00:00 Primes-1
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3022 352  13941640  59492 0                   0 S  19   0      -   0  bg 00:00:00 Scheduling thre
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3031 352  13941640  59492 0                   0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3037 352  13941640  59492 0                   0 S  19   0      -   0  bg 00:00:00 ProcessStablePh
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3040 352  13941640  59492 0                   0 S  19   0      -   0  bg 00:00:00 Lite Thread #0
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3041 352  13941640  59492 0                   0 S   9  10      -   0  bg 00:00:00 BG Thread #0
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3043 352  13941640  59492 0                   0 S  19   0      -   0  bg 00:00:00 Lite Thread #1
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3046 352  13941640  59492 0                   0 S   9  10      -   0  bg 00:00:00 BG Thread #1
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3047 352  13941640  59492 0                   0 S   9  10      -   0  bg 00:00:00 BG Thread #2
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3049 352  13941640  59492 0                   0 S   9  10      -   0  bg 00:00:00 BG Thread #3
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3051 352  13941640  59492 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3253 352  13941640  59492 0                   0 S   9  10      -   0  bg 00:00:00 AsyncTask #1
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3265 352  13941640  59492 0                   0 S  19   0      -   0  bg 00:00:00 arch_disk_io_0
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3386 352  13941640  59492 0                   0 S  19   0      -   0  bg 00:00:00 binder:2934_4
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3471 352  13941640  59492 0                   0 S  19   0      -   0  bg 00:00:00 DefaultDispatch
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3472 352  13941640  59492 0                   0 S  19   0      -   0  bg 00:00:00 DefaultDispatch
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 3528 352  13941640  59492 0                   0 S  19   0      -   0  bg 00:00:00 arch_disk_io_1
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 4013 352  13941640  59492 0                   0 S  19   0      -   0  bg 00:00:00 binder:2934_5
+u:r:untrusted_app:s0:c142,c256,c512,c768 u0_a142 2934 4504 352  13941640  59492 0                   0 S  19   0      -   0  bg 00:00:00 binder:2934_6
+u:r:shell:s0                   shell         3014  3014   429   10781316   1356 sigsuspend          0 S  19   0      -   0  fg 00:00:00 sh
+u:r:shell:s0                   shell         3016  3016  3014   10835488   2288 __skb_wait_for_more_packets 0 S 19 0 -   0  fg 00:00:01 logcat
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3045   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:00 id.gms.unstable
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3063   352   14027884  55412 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3064   352   14027884  55412 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3066   352   14027884  55412 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3067   352   14027884  55412 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3068   352   14027884  55412 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3069   352   14027884  55412 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3070   352   14027884  55412 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3071   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:01 binder:3045_1
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3072   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:00 binder:3045_2
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3178   352   14027884  55412 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3290   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:00 FileObserver
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3325   352   14027884  55412 0                   0 S  10   9      -   0  bg 00:00:00 highpool[0]
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3326   352   14027884  55412 0                   0 S  10   9      -   0  bg 00:00:00 GlobalDispatchi
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3327   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:00 GlobalScheduler
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3349   352   14027884  55412 0                   0 S   9  10      -   0  bg 00:00:00 lowpool[0]
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3371   352   14027884  55412 0                   0 S  10   9      -   0  bg 00:00:00 highpool[1]
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3376   352   14027884  55412 0                   0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3379   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:00 binder:3045_3
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3385   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:01 binder:3045_4
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3391   352   14027884  55412 0                   0 S  10   9      -   0  bg 00:00:00 highpool[2]
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3393   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:00 CronetInit
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3394   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolServi
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3395   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3397   352   14027884  55412 0                   0 S   9  10      -   0  bg 00:00:00 ChromiumNet
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3401   352   14027884  55412 0                   0 S  10   9      -   0  bg 00:00:00 highpool[3]
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3407   352   14027884  55412 0                   0 S   9  10      -   0  bg 00:00:00 lowpool[1]
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3408   352   14027884  55412 0                   0 S   9  10      -   0  bg 00:00:00 lowpool[2]
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3419   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3420   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:00 ThreadPoolForeg
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3435   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:00 Network File Th
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3442   352   14027884  55412 0                   0 S   9  10      -   0  bg 00:00:00 lowpool[3]
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3446   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:00 binder:3045_5
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3503   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:00 Verification th
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3576   352   14027884  55412 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3720   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:00 binder:3045_6
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3834   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:00 binder:3045_7
+u:r:gmscore_app:s0:c512,c768   u0_a130       3045  3835   352   14027884  55412 0                   0 S  19   0      -   0  bg 00:00:00 binder:3045_8
+u:r:shell:s0                   shell         3081  3081   429   10814084   1348 sigsuspend          0 S  19   0      -   0  fg 00:00:00 sh
+u:r:shell:s0                   shell         3086  3086  3081   10806816   2276 __skb_wait_for_more_packets 0 S 19 0 -   0  fg 00:00:00 logcat
+u:r:shell:s0                   shell         3103  3103   429   10803844   1616 sigsuspend          0 S  19   0      -   0  fg 00:00:00 sh
+u:r:shell:s0                   shell         3108  3108  3103   10821152   2272 __skb_wait_for_more_packets 0 S 19 0 -   0  fg 00:00:00 logcat
+u:r:shell:s0                   shell         3116  3116   429   10797700   1360 sigsuspend          0 S  19   0      -   0  fg 00:00:00 sh
+u:r:shell:s0                   shell         3123  3123  3116   10804808   2104 __skb_wait_for_more_packets 0 S 19 0 -   0  fg 00:00:00 logcat
+u:r:shell:s0                   shell         3130  3130   429   10820228   1340 sigsuspend          0 S  19   0      -   0  fg 00:00:00 sh
+u:r:shell:s0                   shell         3133  3133  3130   10784068   1428 __skb_wait_for_more_packets 0 S 19 0 -   0  fg 00:00:00 logcat
+u:r:shell:s0                   shell         3139  3139   429   10816132   1352 sigsuspend          0 S  19   0      -   0  fg 00:00:00 sh
+u:r:shell:s0                   shell         3144  3144  3139   10800452   1508 __skb_wait_for_more_packets 0 S 19 0 -   0  fg 00:00:00 logcat
+u:r:priv_app:s0:c512,c768      u0_a125       3309  3309   352   13694944  39112 0                   0 S  19   0      -   0  bg 00:00:00 viceentitlement
+u:r:priv_app:s0:c512,c768      u0_a125       3309  3314   352   13694944  39112 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a125       3309  3328   352   13694944  39112 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a125       3309  3329   352   13694944  39112 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a125       3309  3330   352   13694944  39112 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a125       3309  3331   352   13694944  39112 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a125       3309  3332   352   13694944  39112 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a125       3309  3333   352   13694944  39112 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a125       3309  3335   352   13694944  39112 0                   0 S  19   0      -   0  bg 00:00:00 binder:3309_1
+u:r:priv_app:s0:c512,c768      u0_a125       3309  3336   352   13694944  39112 0                   0 S  19   0      -   0  bg 00:00:00 binder:3309_2
+u:r:priv_app:s0:c512,c768      u0_a125       3309  3343   352   13694944  39112 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a125       3309  3405   352   13694944  39112 0                   0 S  19   0      -   0  bg 00:00:00 binder:3309_3
+u:r:priv_app:s0:c512,c768      u0_a125       3309  4180   352   13694944  39112 0                   0 S   9  10      -   0  bg 00:00:00 AsyncTask #1
+u:r:priv_app:s0:c512,c768      u0_a125       3309  4209   352   13694944  39112 0                   0 S  19   0      -   0  bg 00:00:00 binder:3309_4
+u:r:priv_app:s0:c512,c768      u0_a125       3309  4220   352   13694944  39112 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:platform_app:s0:c512,c768  u0_a107       3448  3448   352   13686668  38340 0                   0 S  19   0      -   0  bg 00:00:00 rrierdefaultapp
+u:r:platform_app:s0:c512,c768  u0_a107       3448  3453   352   13686668  38340 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:platform_app:s0:c512,c768  u0_a107       3448  3460   352   13686668  38340 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:platform_app:s0:c512,c768  u0_a107       3448  3461   352   13686668  38340 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:platform_app:s0:c512,c768  u0_a107       3448  3462   352   13686668  38340 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:platform_app:s0:c512,c768  u0_a107       3448  3463   352   13686668  38340 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:platform_app:s0:c512,c768  u0_a107       3448  3464   352   13686668  38340 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:platform_app:s0:c512,c768  u0_a107       3448  3465   352   13686668  38340 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:platform_app:s0:c512,c768  u0_a107       3448  3466   352   13686668  38340 0                   0 S  19   0      -   0  bg 00:00:00 binder:3448_1
+u:r:platform_app:s0:c512,c768  u0_a107       3448  3467   352   13686668  38340 0                   0 S  19   0      -   0  bg 00:00:00 binder:3448_2
+u:r:platform_app:s0:c512,c768  u0_a107       3448  3487   352   13686668  38340 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3525   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 android.rkpdapp
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3533   352   13705328  39992 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3534   352   13705328  39992 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3535   352   13705328  39992 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3536   352   13705328  39992 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3537   352   13705328  39992 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3538   352   13705328  39992 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3539   352   13705328  39992 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3540   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 binder:3525_1
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3541   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 binder:3525_2
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3547   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 binder:3525_3
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3549   352   13705328  39992 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3553   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 WM.task-1
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3667   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 ConnectivityThr
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3669   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 WM.task-2
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3670   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 WM.task-3
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3671   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 androidx.work-1
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3673   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 pool-2-thread-1
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3676   352   13705328  39992 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3680   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 OkHttp Connecti
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3684   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 Okio Watchdog
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3700   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 pool-2-thread-2
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3701   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 pool-2-thread-3
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3717   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 pool-2-thread-4
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  3782   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 binder:3525_4
+u:r:rkpdapp:s0:c512,c768       u0_a184       3525  4436   352   13705328  39992 0                   0 S  19   0      -   0  bg 00:00:00 androidx.work-2
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3554   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 gs.intelligence
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3559   352   13974616  83568 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3560   352   13974616  83568 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3562   352   13974616  83568 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3563   352   13974616  83568 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3564   352   13974616  83568 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3565   352   13974616  83568 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3566   352   13974616  83568 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3568   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 binder:3554_1
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3571   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 binder:3554_2
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3580   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 binder:3554_3
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3587   352   13974616  83568 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3590   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 WM.task-1
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3609   352   13974616  83568 0                   0 S  10   9      -   0  fg 00:00:00 GoogleApiHandle
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3672   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 WM.task-2
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3691   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 WifiManagerThre
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3714   352   13974616  83568 0                   0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3716   352   13974616  83568 0                   0 S   9  10      -   0  fg 00:00:00 rvcDelegateImpl
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3718   352   13974616  83568 0                   0 S   9  10      -   0  fg 00:00:00 AsyncTask #1
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3723   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-2-thread-1
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3724   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 arch_disk_io_0
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3748   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-3-thread-1
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3762   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 arch_disk_io_1
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3763   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 arch_disk_io_2
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3775   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 arch_disk_io_3
+u:r:priv_app:s0:c512,c768      u0_a116       3554  3778   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 binder:3554_4
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4530   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 binder:3554_5
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4562   352   13974616  83568 0                   0 S   9  10      -   0  fg 00:00:00 android.bg
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4590   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:01 IndexHandlerThr
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4595   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-5-thread-1
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4596   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-5-thread-2
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4597   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-5-thread-3
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4598   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-5-thread-4
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4599   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-5-thread-5
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4600   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-5-thread-6
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4633   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 Lite Thread #0
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4646   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 Lite Thread #1
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4710   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 binder:3554_6
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4741   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-5-thread-7
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4742   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-5-thread-8
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4745   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-5-thread-9
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4749   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-5-thread-1
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4751   352   13974616  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-5-thread-1
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4752   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-5-thread-1
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4755   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-5-thread-1
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4756   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-5-thread-1
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4761   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-5-thread-1
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4905   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 binder:3554_7
+u:r:priv_app:s0:c512,c768      u0_a116       3554  4916   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 binder:3554_8
+u:r:priv_app:s0:c512,c768      u0_a116       3554  5005   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 binder:3554_9
+u:r:priv_app:s0:c512,c768      u0_a116       3554  5040   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-6-thread-1
+u:r:priv_app:s0:c512,c768      u0_a116       3554  5235   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 binder:3554_A
+u:r:priv_app:s0:c512,c768      u0_a116       3554  5379   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-8-thread-1
+u:r:priv_app:s0:c512,c768      u0_a116       3554  5467   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 ProcessStablePh
+u:r:priv_app:s0:c512,c768      u0_a116       3554  5479   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-10-thread-
+u:r:priv_app:s0:c512,c768      u0_a116       3554  5480   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-10-thread-
+u:r:priv_app:s0:c512,c768      u0_a116       3554  5481   352   13974652  83568 0                   0 S   0  19      -   0  fg 00:00:00 GmsDynamite
+u:r:priv_app:s0:c512,c768      u0_a116       3554  5486   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-10-thread-
+u:r:priv_app:s0:c512,c768      u0_a116       3554  5487   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 pool-10-thread-
+u:r:priv_app:s0:c512,c768      u0_a116       3554  5500   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 ProcessStablePh
+u:r:priv_app:s0:c512,c768      u0_a116       3554  5511   352   13974652  83568 0                   0 S  10   9      -   0  fg 00:00:00 GoogleApiHandle
+u:r:priv_app:s0:c512,c768      u0_a116       3554  5635   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 brella-pds-0
+u:r:priv_app:s0:c512,c768      u0_a116       3554  5640   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 AsyncTask #6
+u:r:priv_app:s0:c512,c768      u0_a116       3554  5671   352   13974652  83568 0                   0 S  19   0      -   0  fg 00:00:00 binder:3554_B
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3612   352   13820092  44724 0                   0 S  19   0      -   0  bg 00:00:00 ng:quick_launch
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3630   352   13820092  44724 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3631   352   13820092  44724 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3632   352   13820092  44724 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3633   352   13820092  44724 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3634   352   13820092  44724 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3635   352   13820092  44724 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3636   352   13820092  44724 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3637   352   13820092  44724 0                   0 S  19   0      -   0  bg 00:00:00 binder:3612_1
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3639   352   13820092  44724 0                   0 S  19   0      -   0  bg 00:00:00 binder:3612_2
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3647   352   13820092  44724 0                   0 S  19   0      -   0  bg 00:00:00 binder:3612_3
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3652   352   13820092  44724 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3658   352   13820092  44716 0                   0 S  19   0      -   0  bg 00:00:00 Monitor Thread 
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3659   352   13820092  44696 0                   0 S  19   0      -   0  bg 00:00:00 ProtoDataStore-
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3661   352   13820092  44684 0                   0 S  19   0      -   0  bg 00:00:00 ValueStore-0
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3663   352   13820092  44664 0                   0 S  19   0      -   0  bg 00:00:00 FileObserver
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3664   352   13820092  44632 0                   0 S  19   0      -   0  bg 00:00:00 ValueStore-1
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3665   352   13820092  44632 0                   0 S  19   0      -   0  bg 00:00:00 ValueStore-2
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3666   352   13820092  44632 0                   0 S  19   0      -   0  bg 00:00:00 ValueStore-3
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3688   352   13820092  44632 0                   0 S  19   0      -   0  bg 00:00:00 Scheduler Threa
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3689   352   13820092  44548 0                   0 S  19   0      -   0  bg 00:00:00 LightweightExec
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3690   352   13820092  44488 0                   0 S   9  10      -   0  bg 00:00:00 bgExecutor #0
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3692   352   13820092  44444 0                   0 S  19   0      -   0  bg 00:00:00 LightweightExec
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3696   352   13820092  44428 0                   0 S  19   0      -   0  bg 00:00:00 LightweightExec
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3697   352   13820092  44420 0                   0 S   9  10      -   0  bg 00:00:00 bgExecutor #1
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3702   352   13820092  44384 0                   0 S   9  10      -   0  bg 00:00:00 bgExecutor #2
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3703   352   13820092  44384 0                   0 S  18   1      -   0  bg 00:00:00 BlockingExecuto
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3707   352   13820092  44384 0                   0 S  19   0      -   0  bg 00:00:00 OkHttp Connecti
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3710   352   13820092  44384 0                   0 S  19   0      -   0  bg 00:00:00 Okio Watchdog
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3715   352   13820092  44384 0                   0 S   9  10      -   0  bg 00:00:00 bgExecutor #3
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3756   352   13820092  44312 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a131       3612  3761   352   13820092  44312 0                   0 S   9  10      -   0  bg 00:00:00 anmz
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3783   352   13930336  58516 0                   0 S  19   0      -   0  bg 00:00:00 .android.dialer
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3790   352   13930336  58516 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3791   352   13930336  58516 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3792   352   13930336  58508 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3793   352   13930336  58508 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3794   352   13930336  58508 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3795   352   13930336  58508 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3796   352   13930336  58504 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3797   352   13930336  58496 0                   0 S  19   0      -   0  bg 00:00:00 binder:3783_1
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3799   352   13930336  58484 0                   0 S  19   0      -   0  bg 00:00:00 binder:3783_2
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3806   352   13930336  58484 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3816   352   13930336  58484 0                   0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3817   352   13930336  58484 0                   0 S  19   0      -   0  bg 00:00:00 Scheduler Threa
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3818   352   13930336  58484 0                   0 S   9  10      -   0  bg 00:00:00 BG Thread #0
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3819   352   13930336  58484 0                   0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3820   352   13930336  58484 0                   0 S   9  10      -   0  bg 00:00:00 BG Thread #1
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3821   352   13930336  58484 0                   0 S  19   0      -   0  bg 00:00:00 Lite Thread #0
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3822   352   13930336  58484 0                   0 S   9  10      -   0  bg 00:00:00 BG Thread #2
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3823   352   13930336  58484 0                   0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3825   352   13930336  58484 0                   0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3826   352   13930336  58484 0                   0 S  19   0      -   0  bg 00:00:00 Lite Thread #1
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3827   352   13930336  58484 0                   0 S   9  10      -   0  bg 00:00:00 BG Thread #3
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3828   352   13930336  58484 0                   0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3832   352   13930336  58484 0                   0 S  19   0      -   0  bg 00:00:00 Lite Thread #0
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3836   352   13930336  58484 0                   0 S  19   0      -   0  bg 00:00:00 binder:3783_3
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3847   352   13930336  58484 0                   0 S  19   0      -   0  bg 00:00:00 binder:3783_4
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3848   352   13930336  58484 0                   0 S  19   0      -   0  bg 00:00:00 binder:3783_5
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3850   352   13930336  58484 0                   0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3852   352   13930336  58484 0                   0 S  19   0      -   0  bg 00:00:00 binder:3783_6
+u:r:priv_app:s0:c512,c768      u0_a122       3783  3971   352   13930336  58484 0                   0 S  19   0      -   0  bg 00:00:00 ConnectivityThr
+u:r:priv_app:s0:c512,c768      u0_a122       3783  4006   352   13930336  58484 0                   0 S  19   0      -   0  bg 00:00:00 DG
+u:r:priv_app:s0:c512,c768      u0_a122       3783  4042   352   13930336  58484 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a122       3783  4094   352   13930336  58484 0                   0 S  19   0      -   0  bg 00:00:00 AsyncQueryWorke
+u:r:priv_app:s0:c512,c768      u0_a122       3783  4101   352   13930336  58484 0                   0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a122       3783  4102   352   13930336  58484 0                   0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:traceur_app:s0:c115,c256,c512,c768 u0_a115 3981 3981  352   13693204  39672 0                   0 S  19   0      -   0  bg 00:00:00 android.traceur
+u:r:traceur_app:s0:c115,c256,c512,c768 u0_a115 3981 3987  352   13693204  39672 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:traceur_app:s0:c115,c256,c512,c768 u0_a115 3981 3988  352   13693204  39672 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:traceur_app:s0:c115,c256,c512,c768 u0_a115 3981 3994  352   13693204  39672 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:traceur_app:s0:c115,c256,c512,c768 u0_a115 3981 3995  352   13693204  39672 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:traceur_app:s0:c115,c256,c512,c768 u0_a115 3981 3996  352   13693204  39668 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:traceur_app:s0:c115,c256,c512,c768 u0_a115 3981 3997  352   13693204  39668 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:traceur_app:s0:c115,c256,c512,c768 u0_a115 3981 3998  352   13693204  39668 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:traceur_app:s0:c115,c256,c512,c768 u0_a115 3981 3999  352   13693204  39668 0                   0 S  19   0      -   0  bg 00:00:00 binder:3981_1
+u:r:traceur_app:s0:c115,c256,c512,c768 u0_a115 3981 4008  352   13693204  39668 0                   0 S  19   0      -   0  bg 00:00:00 binder:3981_2
+u:r:traceur_app:s0:c115,c256,c512,c768 u0_a115 3981 4011  352   13693204  39668 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:traceur_app:s0:c115,c256,c512,c768 u0_a115 3981 4748  352   13693204  39668 0                   0 S  19   0      -   0  bg 00:00:00 binder:3981_3
+u:r:priv_app:s0:c512,c768      u0_a124       4023  4023   352   13686576  37504 0                   0 S  19   0      -   0  bg 00:00:00 timeinitializer
+u:r:priv_app:s0:c512,c768      u0_a124       4023  4028   352   13686576  37504 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a124       4023  4029   352   13686576  37504 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a124       4023  4030   352   13686576  37504 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a124       4023  4031   352   13686576  37504 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a124       4023  4032   352   13686576  37504 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a124       4023  4033   352   13686576  37504 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a124       4023  4034   352   13686576  37504 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a124       4023  4035   352   13686576  37504 0                   0 S  19   0      -   0  bg 00:00:00 binder:4023_1
+u:r:priv_app:s0:c512,c768      u0_a124       4023  4036   352   13686576  37504 0                   0 S  19   0      -   0  bg 00:00:00 binder:4023_2
+u:r:priv_app:s0:c512,c768      u0_a124       4023  4041   352   13686576  37504 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:platform_app:s0:c512,c768  u0_a85        4046  4046   352   13687460  38712 0                   0 S  19   0      -   0  bg 00:00:00 externalstorage
+u:r:platform_app:s0:c512,c768  u0_a85        4046  4051   352   13687460  38712 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:platform_app:s0:c512,c768  u0_a85        4046  4052   352   13687460  38712 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:platform_app:s0:c512,c768  u0_a85        4046  4053   352   13687460  38712 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:platform_app:s0:c512,c768  u0_a85        4046  4054   352   13687460  38712 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:platform_app:s0:c512,c768  u0_a85        4046  4055   352   13687460  38712 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:platform_app:s0:c512,c768  u0_a85        4046  4056   352   13687460  38712 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:platform_app:s0:c512,c768  u0_a85        4046  4057   352   13687460  38712 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:platform_app:s0:c512,c768  u0_a85        4046  4058   352   13687460  38712 0                   0 S  19   0      -   0  bg 00:00:00 binder:4046_1
+u:r:platform_app:s0:c512,c768  u0_a85        4046  4062   352   13687460  38712 0                   0 S  19   0      -   0  bg 00:00:00 binder:4046_2
+u:r:platform_app:s0:c512,c768  u0_a85        4046  4064   352   13687460  38712 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:platform_app:s0:c512,c768  u0_a85        4046  4085   352   13687460  38712 0                   0 S  19   0      -   0  bg 00:00:00 binder:4046_3
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  4067   352   13698796  53024 0                   0 S  19   0      -   0  bg 00:00:00 d.process.media
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  4075   352   13698796  53024 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  4076   352   13698796  53024 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  4077   352   13698796  53024 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  4078   352   13698796  53024 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  4079   352   13698796  53024 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  4080   352   13698796  53024 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  4081   352   13698796  53024 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  4082   352   13698796  53024 0                   0 S  19   0      -   0  bg 00:00:00 binder:4067_1
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  4083   352   13698796  53024 0                   0 S  19   0      -   0  bg 00:00:00 binder:4067_2
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  4087   352   13698796  53024 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  4100   352   13698796  53024 0                   0 S  19   0      -   0  bg 00:00:00 binder:4067_3
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  4103   352   13698796  53024 0                   0 S   9  10      -   0  bg 00:00:00 sAsyncHandlerTh
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  4495   352   13698796  53024 0                   0 S  19   0      -   0  bg 00:00:00 binder:4067_4
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  5016   352   13698796  53024 0                   0 S  19   0      -   0  bg 00:00:00 binder:4067_5
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  5025   352   13698796  53024 0                   0 S  19   0      -   0  bg 00:00:00 OkHttp Connecti
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  5026   352   13698796  53024 0                   0 S  19   0      -   0  bg 00:00:00 Okio Watchdog
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  5033   352   13698796  53024 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:mediaprovider:s0:c512,c768 u0_a82        4067  5064   352   13698796  53024 0                   0 S  19   0      -   0  bg 00:00:00 OkHttp Connecti
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4120   352   13793164  40904 0                   0 S  19   0      -   0  bg 00:00:00 t_app_installer
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4125   352   13793164  40904 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4126   352   13793164  40904 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4127   352   13793164  40904 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4128   352   13793164  40904 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4129   352   13793164  40904 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4130   352   13793164  40904 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4131   352   13793164  40904 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4132   352   13793164  40904 0                   0 S  19   0      -   0  bg 00:00:00 binder:4120_1
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4133   352   13793164  40904 0                   0 S  19   0      -   0  bg 00:00:00 binder:4120_2
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4136   352   13793164  40904 0                   0 S  19   0      -   0  bg 00:00:00 binder:4120_3
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4139   352   13793164  40904 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4149   352   13793164  40904 0                   0 S   9  10      -   0  bg 00:00:00 bg-1
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4151   352   13793164  40904 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4152   352   13793164  40904 0                   0 S  19   0      -   0  bg 00:00:00 RxSchedulerPurg
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4153   352   13793164  40904 0                   0 S  19   0      -   0  bg 00:00:00 RxCachedWorkerP
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4157   352   13793164  40904 0                   0 S   9  10      -   0  bg 00:00:00 bg-2
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4179   352   13793164  40904 0                   0 S  18   1      -   0  bg 00:00:00 GmsConnection
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4181   352   13793164  40904 0                   0 S  19   0      -   0  bg 00:00:00 GAC_Executor[0]
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4207   352   13793164  40904 0                   0 S   9  10      -   0  bg 00:00:00 bg-3
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4208   352   13793164  40904 0                   0 S   9  10      -   0  bg 00:00:00 bg-4
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4246   352   13793164  40904 0                   0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4252   352   13793164  40904 0                   0 S  19   0      -   0  bg 00:00:00 GAC_Executor[1]
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4305   352   13793164  40904 0                   0 S   9  10      -   0  bg 00:00:00 AsyncTask #3
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4307   352   13793164  40904 0                   0 S  18   1      -   0  bg 00:00:00 fg-1
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4308   352   13793164  40904 0                   0 S  19   0      -   0  bg 00:00:00 binder:4120_4
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4327   352   13793164  40904 0                   0 S   9  10      -   0  bg 00:00:00 anmz
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4346   352   13793164  40904 0                   0 S  19   0      -   0  bg 00:00:00 OkHttp Connecti
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4366   352   13793164  40904 0                   0 S  19   0      -   0  bg 00:00:00 Okio Watchdog
+u:r:priv_app:s0:c512,c768      u0_a131       4120  4732   352   13793164  40904 0                   0 S  19   0      -   0  bg 00:00:00 binder:4120_5
+u:r:untrusted_app:s0:c139,c256,c512,c768 u0_a139 4148 4148 352  14368636  38780 0                   0 S  19   0      -   0  bg 00:00:00 android.camera2
+u:r:untrusted_app:s0:c139,c256,c512,c768 u0_a139 4148 4162 352  14368636  38780 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:untrusted_app:s0:c139,c256,c512,c768 u0_a139 4148 4163 352  14368636  38780 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:untrusted_app:s0:c139,c256,c512,c768 u0_a139 4148 4168 352  14368636  38780 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:untrusted_app:s0:c139,c256,c512,c768 u0_a139 4148 4169 352  14368636  38780 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:untrusted_app:s0:c139,c256,c512,c768 u0_a139 4148 4170 352  14368636  38780 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:untrusted_app:s0:c139,c256,c512,c768 u0_a139 4148 4171 352  14368636  38780 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:untrusted_app:s0:c139,c256,c512,c768 u0_a139 4148 4172 352  14368636  38780 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:untrusted_app:s0:c139,c256,c512,c768 u0_a139 4148 4173 352  14368636  38780 0                   0 S  19   0      -   0  bg 00:00:00 binder:4148_1
+u:r:untrusted_app:s0:c139,c256,c512,c768 u0_a139 4148 4174 352  14368636  38780 0                   0 S  19   0      -   0  bg 00:00:00 binder:4148_2
+u:r:untrusted_app:s0:c139,c256,c512,c768 u0_a139 4148 4178 352  14368636  38780 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:system_app:s0              system        4175  4175   352   13687556  37592 0                   0 S  19   0      -   0  bg 00:00:00 droid.dynsystem
+u:r:system_app:s0              system        4175  4186   352   13687556  37592 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:system_app:s0              system        4175  4187   352   13687556  37592 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:system_app:s0              system        4175  4188   352   13687556  37592 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:system_app:s0              system        4175  4189   352   13687556  37592 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:system_app:s0              system        4175  4190   352   13687556  37592 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:system_app:s0              system        4175  4191   352   13687556  37592 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:system_app:s0              system        4175  4192   352   13687556  37592 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:system_app:s0              system        4175  4193   352   13687556  37592 0                   0 S  19   0      -   0  bg 00:00:00 binder:4175_1
+u:r:system_app:s0              system        4175  4194   352   13687556  37592 0                   0 S  19   0      -   0  bg 00:00:00 binder:4175_2
+u:r:system_app:s0              system        4175  4203   352   13687556  37592 0                   0 S  19   0      -   0  bg 00:00:00 binder:4175_3
+u:r:system_app:s0              system        4175  4206   352   13687556  37592 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:system_app:s0              system        4210  4210   352   13688524  38816 0                   0 S  19   0      -   0  bg 00:00:00 ystem:dynsystem
+u:r:system_app:s0              system        4210  4218   352   13688524  38816 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:system_app:s0              system        4210  4219   352   13688524  38816 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:system_app:s0              system        4210  4226   352   13688524  38816 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:system_app:s0              system        4210  4227   352   13688524  38816 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:system_app:s0              system        4210  4228   352   13688524  38816 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:system_app:s0              system        4210  4229   352   13688524  38816 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:system_app:s0              system        4210  4230   352   13688524  38816 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:system_app:s0              system        4210  4231   352   13688524  38816 0                   0 S  19   0      -   0  bg 00:00:00 binder:4210_1
+u:r:system_app:s0              system        4210  4242   352   13688524  38816 0                   0 S  19   0      -   0  bg 00:00:00 binder:4210_2
+u:r:system_app:s0              system        4210  4248   352   13688524  38816 0                   0 S  19   0      -   0  bg 00:00:00 binder:4210_3
+u:r:system_app:s0              system        4210  4250   352   13688524  38816 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:system_app:s0              system        4210  4256   352   13688524  38816 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:platform_app:s0:c512,c768  u0_a86        4213  4213   352   13692788  37904 0                   0 S  19   0      -   0  bg 00:00:00 gedprovisioning
+u:r:platform_app:s0:c512,c768  u0_a86        4213  4225   352   13692788  37904 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:platform_app:s0:c512,c768  u0_a86        4213  4232   352   13692788  37904 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:platform_app:s0:c512,c768  u0_a86        4213  4236   352   13692788  37904 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:platform_app:s0:c512,c768  u0_a86        4213  4237   352   13692788  37904 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:platform_app:s0:c512,c768  u0_a86        4213  4238   352   13692788  37904 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:platform_app:s0:c512,c768  u0_a86        4213  4239   352   13692788  37904 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:platform_app:s0:c512,c768  u0_a86        4213  4240   352   13692788  37904 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:platform_app:s0:c512,c768  u0_a86        4213  4244   352   13692788  37904 0                   0 S  19   0      -   0  bg 00:00:00 binder:4213_1
+u:r:platform_app:s0:c512,c768  u0_a86        4213  4245   352   13692788  37904 0                   0 S  19   0      -   0  bg 00:00:00 binder:4213_2
+u:r:platform_app:s0:c512,c768  u0_a86        4213  4249   352   13692788  37904 0                   0 S  19   0      -   0  bg 00:00:00 binder:4213_3
+u:r:platform_app:s0:c512,c768  u0_a86        4213  4255   352   13692788  37904 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:shell:s0                   shell         4258  4258   352   13688164  37768 0                   0 S  19   0      -   0  bg 00:00:00 m.android.shell
+u:r:shell:s0                   shell         4258  4263   352   13688164  37768 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:shell:s0                   shell         4258  4265   352   13688164  37768 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:shell:s0                   shell         4258  4266   352   13688164  37768 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:shell:s0                   shell         4258  4267   352   13688164  37768 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:shell:s0                   shell         4258  4268   352   13688164  37768 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:shell:s0                   shell         4258  4269   352   13688164  37768 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:shell:s0                   shell         4258  4270   352   13688164  37768 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:shell:s0                   shell         4258  4271   352   13688164  37768 0                   0 S  19   0      -   0  bg 00:00:00 binder:4258_1
+u:r:shell:s0                   shell         4258  4272   352   13688164  37768 0                   0 S  19   0      -   0  bg 00:00:00 binder:4258_2
+u:r:shell:s0                   shell         4258  4277   352   13688164  37768 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:shell:s0                   shell         4258  4290   352   13688164  37768 0                   0 S   9  10      -   0  bg 00:00:00 AsyncTask #1
+u:r:priv_app:s0:c512,c768      u0_a127       4279  4279   352   13693576  49856 0                   0 S  19   0      -   0  bg 00:00:00 d.configupdater
+u:r:priv_app:s0:c512,c768      u0_a127       4279  4294   352   13693576  49856 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a127       4279  4295   352   13693576  49856 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a127       4279  4296   352   13693576  49856 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a127       4279  4297   352   13693576  49856 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a127       4279  4298   352   13693576  49856 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a127       4279  4299   352   13693576  49856 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a127       4279  4300   352   13693576  49856 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a127       4279  4301   352   13693576  49856 0                   0 S  19   0      -   0  bg 00:00:00 binder:4279_1
+u:r:priv_app:s0:c512,c768      u0_a127       4279  4302   352   13693576  49856 0                   0 S  19   0      -   0  bg 00:00:00 binder:4279_2
+u:r:priv_app:s0:c512,c768      u0_a127       4279  4304   352   13693576  49856 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a127       4279  4954   352   13693576  49856 0                   0 S  19   0      -   0  bg 00:00:00 binder:4279_3
+u:r:priv_app:s0:c512,c768      u0_a127       4279  4955   352   13693576  49856 0                   0 S   9  10      -   0  bg 00:00:00 AsyncTask #1
+u:r:priv_app:s0:c512,c768      u0_a127       4279  4956   352   13693576  49856 0                   0 S  19   0      -   0  bg 00:00:00 binder:4279_4
+u:r:priv_app:s0:c512,c768      u0_a127       4279  4957   352   13693576  49856 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a127       4279  5218   352   13693576  49856 0                   0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:priv_app:s0:c512,c768      u0_a93        4309  4309   352   13689056  36972 0                   0 S  19   0      -   0  bg 00:00:00 ackageinstaller
+u:r:priv_app:s0:c512,c768      u0_a93        4309  4315   352   13689056  36972 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a93        4309  4316   352   13689056  36972 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a93        4309  4317   352   13689056  36972 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a93        4309  4318   352   13689056  36972 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a93        4309  4319   352   13689056  36972 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a93        4309  4320   352   13689056  36972 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a93        4309  4321   352   13689056  36972 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a93        4309  4322   352   13689056  36972 0                   0 S  19   0      -   0  bg 00:00:00 binder:4309_1
+u:r:priv_app:s0:c512,c768      u0_a93        4309  4323   352   13689056  36972 0                   0 S  19   0      -   0  bg 00:00:00 binder:4309_2
+u:r:priv_app:s0:c512,c768      u0_a93        4309  4333   352   13689056  36972 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a117       4347  4347   352   13712208  40940 0                   0 S  19   0      -   0  bg 00:00:00 id.partnersetup
+u:r:priv_app:s0:c512,c768      u0_a117       4347  4352   352   13712208  40940 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a117       4347  4355   352   13712208  40940 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a117       4347  4356   352   13712208  40940 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a117       4347  4357   352   13712208  40940 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a117       4347  4358   352   13712208  40940 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a117       4347  4359   352   13712208  40940 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a117       4347  4360   352   13712208  40940 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a117       4347  4361   352   13712208  40940 0                   0 S  19   0      -   0  bg 00:00:00 binder:4347_1
+u:r:priv_app:s0:c512,c768      u0_a117       4347  4363   352   13712208  40940 0                   0 S  19   0      -   0  bg 00:00:00 binder:4347_2
+u:r:priv_app:s0:c512,c768      u0_a117       4347  4371   352   13712208  40940 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a117       4347  4439   352   13712208  40940 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a117       4347  4462   352   13712208  40940 0                   0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:priv_app:s0:c512,c768      u0_a117       4347  4623   352   13712208  40940 0                   0 S  19   0      -   0  bg 00:00:00 binder:4347_3
+u:r:priv_app:s0:c512,c768      u0_a117       4347  4634   352   13712208  40940 0                   0 S  19   0      -   0  bg 00:00:00 binder:4347_4
+u:r:priv_app:s0:c512,c768      u0_a117       4347  4731   352   13712208  40940 0                   0 S  19   0      -   0  bg 00:00:00 binder:4347_5
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4404   352   13721492  48816 0                   0 S  19   0      -   0  fg 00:00:00 .adservices.api
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4410   352   13721492  48816 0                   0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4411   352   13721492  48816 0                   0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4412   352   13721492  48816 0                   0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4413   352   13721492  48816 0                   0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4414   352   13721492  48816 0                   0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4415   352   13721492  48816 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4416   352   13721492  48816 0                   0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4419   352   13721492  48816 0                   0 S  19   0      -   0  fg 00:00:00 binder:4404_1
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4422   352   13721492  48816 0                   0 S  19   0      -   0  fg 00:00:00 binder:4404_2
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4438   352   13721492  48816 0                   0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4478   352   13721492  48816 0                   0 S  19   0      -   0  fg 00:00:00 background-1
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4484   352   13721492  48816 0                   0 S  19   0      -   0  fg 00:00:00 pool-3-thread-1
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4485   352   13721492  48816 0                   0 S  19   0      -   0  fg 00:00:00 binder:4404_3
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4486   352   13721492  48816 0                   0 S  19   0      -   0  fg 00:00:00 pool-3-thread-2
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4487   352   13721492  48816 0                   0 S  19   0      -   0  fg 00:00:00 pool-3-thread-3
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4488   352   13721492  48816 0                   0 S  19   0      -   0  fg 00:00:00 pool-3-thread-4
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4489   352   13721492  48816 0                   0 S  19   0      -   0  fg 00:00:00 binder:4404_4
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4490   352   13721492  48816 0                   0 S  19   0      -   0  fg 00:00:00 pool-3-thread-5
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4498   352   13721492  48816 0                   0 S  19   0      -   0  fg 00:00:00 background-2
+u:r:priv_app:s0:c512,c768      u0_a182       4404  4680   352   13721492  48816 0                   0 S  19   0      -   0  fg 00:00:00 binder:4404_5
+u:r:platform_app:s0:c512,c768  u0_a158       4743  4743   352   13696716  40788 0                   0 S  19   0      -   0  bg 00:00:00 droid.emergency
+u:r:platform_app:s0:c512,c768  u0_a158       4743  4766   352   13696716  40788 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:platform_app:s0:c512,c768  u0_a158       4743  4768   352   13696716  40788 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:platform_app:s0:c512,c768  u0_a158       4743  4769   352   13696716  40788 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:platform_app:s0:c512,c768  u0_a158       4743  4770   352   13696716  40788 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:platform_app:s0:c512,c768  u0_a158       4743  4771   352   13696716  40788 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:platform_app:s0:c512,c768  u0_a158       4743  4772   352   13696716  40788 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:platform_app:s0:c512,c768  u0_a158       4743  4773   352   13696716  40788 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:platform_app:s0:c512,c768  u0_a158       4743  4780   352   13696716  40788 0                   0 S  19   0      -   0  bg 00:00:00 binder:4743_1
+u:r:platform_app:s0:c512,c768  u0_a158       4743  4781   352   13696716  40788 0                   0 S  19   0      -   0  bg 00:00:00 binder:4743_2
+u:r:platform_app:s0:c512,c768  u0_a158       4743  4836   352   13696716  40788 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4794   352   13948352  60632 0                   0 S  19   0      -   0  bg 00:00:00 .android.gms.ui
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4801   352   13948352  60632 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4802   352   13948352  60632 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4803   352   13948352  60632 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4804   352   13948352  60632 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4805   352   13948352  60632 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4806   352   13948352  60632 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4807   352   13948352  60632 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4808   352   13948352  60632 0                   0 S  19   0      -   0  bg 00:00:00 binder:4794_1
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4817   352   13948352  60632 0                   0 S  19   0      -   0  bg 00:00:00 binder:4794_2
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4824   352   13948352  60632 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4907   352   13948352  60632 0                   0 S  19   0      -   0  bg 00:00:00 FileObserver
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4908   352   13948352  60632 0                   0 S  19   0      -   0  bg 00:00:00 binder:4794_3
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4909   352   13948352  60632 0                   0 S  19   0      -   0  bg 00:00:00 binder:4794_4
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4912   352   13948352  60632 0                   0 S  19   0      -   0  bg 00:00:00 pool-7-thread-1
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4927   352   13948352  60632 0                   0 S  10   9      -   0  bg 00:00:00 highpool[0]
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4928   352   13948352  60632 0                   0 S  19   0      -   0  bg 00:00:00 GlobalScheduler
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4929   352   13948352  60632 0                   0 S  10   9      -   0  bg 00:00:00 GlobalDispatchi
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4931   352   13948352  60632 0                   0 S  19   0      -   0  bg 00:00:00 ice] processing
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4932   352   13948352  60632 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4938   352   13948352  60632 0                   0 S  10   9      -   0  bg 00:00:00 highpool[1]
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4939   352   13948352  60632 0                   0 S  10   9      -   0  bg 00:00:00 highpool[2]
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4940   352   13948352  60632 0                   0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4942   352   13948352  60632 0                   0 S  10   9      -   0  bg 00:00:00 highpool[3]
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4947   352   13948352  60632 0                   0 S  19   0      -   0  bg 00:00:00 pool-17-thread-
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  4952   352   13948352  60632 0                   0 S  19   0      -   0  bg 00:00:00 binder:4794_5
+u:r:gmscore_app:s0:c512,c768   u0_a130       4794  5017   352   13948352  60632 0                   0 S  19   0      -   0  bg 00:00:00 binder:4794_6
+u:r:priv_app:s0:c512,c768      u0_a177       4828  4828   352   13698604  40560 0                   0 S  19   0      -   0  bg 00:00:00 nect.controller
+u:r:priv_app:s0:c512,c768      u0_a177       4828  4853   352   13698604  40560 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a177       4828  4854   352   13698604  40560 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a177       4828  4857   352   13698604  40560 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a177       4828  4858   352   13698604  40560 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a177       4828  4859   352   13698604  40560 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a177       4828  4860   352   13698604  40560 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a177       4828  4861   352   13698604  40560 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a177       4828  4862   352   13698604  40560 0                   0 S  19   0      -   0  bg 00:00:00 binder:4828_1
+u:r:priv_app:s0:c512,c768      u0_a177       4828  4863   352   13698604  40560 0                   0 S  19   0      -   0  bg 00:00:00 binder:4828_2
+u:r:priv_app:s0:c512,c768      u0_a177       4828  4874   352   13698604  40560 0                   0 S  19   0      -   0  bg 00:00:00 binder:4828_3
+u:r:priv_app:s0:c512,c768      u0_a177       4828  4891   352   13698604  40560 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a177       4828  5010   352   13698604  40560 0                   0 S  19   0      -   0  bg 00:00:00 binder:4828_4
+u:r:shell:s0                   shell         5085  5085   429   10810236   2044 unix_stream_read_generic 0 S 19 0    -   0  fg 00:00:00 bugreportz
+u:r:dumpstate:s0               shell         5088  5088     1   10868592   5272 0                   0 S  39 -20      -   0  fg 00:00:00 dumpstate
+u:r:dumpstate:s0               shell         5088  5488     1   10868592   5272 0                   0 S  39 -20      -   0  fg 00:00:00 dumpstate_1
+u:r:dumpstate:s0               shell         5088  5489     1   10868592   5272 0                   0 S  39 -20      -   0  fg 00:00:00 dumpstate_2
+u:r:dumpstate:s0               shell         5088  5490     1   10868592   5272 0                   0 S  39 -20      -   0  fg 00:00:00 dumpstate_3
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5127 352 14507648 72412 0                  0 S  19   0      -   0  fg 00:00:00 oid.apps.photos
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5132 352 14507648 72412 0                  0 S  39 -20      -   0  fg 00:00:00 Signal Catcher
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5134 352 14507648 72412 0                  0 S  39 -20      -   0  fg 00:00:00 perfetto_hprof_
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5137 352 14507648 72412 0                  0 S  10   9      -   0  fg 00:00:00 Jit thread pool
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5138 352 14507648 72412 0                  0 S  15   4      -   0  fg 00:00:00 HeapTaskDaemon
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5139 352 14507648 72412 0                  0 S  15   4      -   0  fg 00:00:00 ReferenceQueueD
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5140 352 14507648 72412 0                  0 S  15   4      -   0  fg 00:00:00 FinalizerDaemon
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5141 352 14507648 72412 0                  0 S  15   4      -   0  fg 00:00:00 FinalizerWatchd
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5145 352 14507648 72412 0                  0 S  19   0      -   0  fg 00:00:00 binder:5127_1
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5147 352 14507648 72412 0                  0 S  19   0      -   0  fg 00:00:00 binder:5127_2
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5151 352 14507648 72412 0                  0 S  10   9      -   0  fg 00:00:00 Profile Saver
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5160 352 14507648 72412 0                  0 S   9  10      -   0  fg 00:00:00 ptz-scheduled
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5161 352 14507648 72412 0                  0 S   0  19      -   0  fg 00:00:00 Primes-1
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5163 352 14507648 72412 0                  0 S   9  10      -   0  fg 00:00:00 ptz-ui-1
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5180 352 14507648 72412 0                  0 S   9  10      -   0  fg 00:00:00 ptz-ui-2
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5183 352 14507648 72412 0                  0 S   9  10      -   0  fg 00:00:00 glide-active-re
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5185 352 14507648 72412 0                  0 S  19   0      -   0  fg 00:00:00 ConnectivityThr
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5193 352 14507648 72412 0                  0 S  19   0      -   0  fg 00:00:00 binder:5127_3
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5194 352 14507648 72412 0                  0 S  10   9      -   0  fg 00:00:00 GoogleApiHandle
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5202 352 14507648 72412 0                  0 S  19   0      -   0  fg 00:00:00 binder:5127_4
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5210 352 14507648 72412 0                  0 S   9  10      -   0  fg 00:00:00 ptz-ui-3
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5211 352 14507648 72412 0                  0 S   9  10      -   0  fg 00:00:00 ptz-ui-4
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5212 352 14507648 72412 0                  0 S  21  -2      -   0  fg 00:00:00 queued-work-loo
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5216 352 14507648 72412 0                  0 S   0  19      -   0  fg 00:00:00 GmsDynamite
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5242 352 14507648 72412 0                  0 S   8  11      -   0  fg 00:00:00 ptz-fgd-1
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5439 352 14507648 72412 0                  0 S  19   0      -   0  fg 00:00:00 ProcessStablePh
+u:r:untrusted_app_32:s0:c154,c256,c512,c768 u0_a154 5127 5465 352 14507648 72412 0                  0 S  19   0      -   0  fg 00:00:00 binder:5127_5
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5184   352   14575904  96676 0                   0 S  19   0      -   0  bg 00:00:00 equicksearchbox
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5191   352   14575904  96676 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5195   352   14575904  96676 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5196   352   14575904  96676 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5197   352   14575904  96676 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5198   352   14575904  96676 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5199   352   14575904  96676 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5200   352   14575904  96676 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5203   352   14575904  96676 0                   0 S  19   0      -   0  bg 00:00:00 binder:5184_1
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5204   352   14575904  96676 0                   0 S  19   0      -   0  bg 00:00:00 binder:5184_2
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5206   352   14575904  96676 0                   0 S  19   0      -   0  bg 00:00:00 binder:5184_3
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5214   352   14575904  96676 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5222   352   14575904  96676 0                   0 S   9  10      -   0  bg 00:00:00 pool-3-thread-1
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5224   352   14575904  96676 0                   0 S  21  -2      -   0  bg 00:00:00 queued-work-loo
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5226   352   14575904  96676 0                   0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5227   352   14575904  96676 0                   0 S  10   9      -   0  bg 00:00:00 GoogleApiHandle
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5233   352   14575904  96676 0                   0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5234   352   14575904  96676 0                   0 S  19   0      -   0  bg 00:00:00 Lite Thread #0
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5236   352   14575904  96676 0                   0 S   8  11      -   0  bg 00:00:00 Blocking Thread
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5237   352   14575904  96676 0                   0 S   8  11      -   0  bg 00:00:00 Primes-1
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5238   352   14575904  96676 0                   0 S  27  -8      -   0  bg 00:00:00 Primes-nativecr
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5239   352   14575904  96676 0                   0 S   8  11      -   0  bg 00:00:00 Primes-2
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5327   352   14575904  96676 0                   0 S  19   0      -   0  bg 00:00:00 Scheduler Threa
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5404   352   14575904  96676 0                   0 S  19   0      -   0  bg 00:00:00 binder:5184_4
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5473   352   14575904  96676 0                   0 S   9  10      -   0  bg 00:00:00 BG Thread #0
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5474   352   14575904  96676 0                   0 S   9  10      -   0  bg 00:00:00 BG Thread #1
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5475   352   14575904  96676 0                   0 S   9  10      -   0  bg 00:00:00 BG Thread #2
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5476   352   14575904  96676 0                   0 S  19   0      -   0  bg 00:00:00 Lite Thread #0
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5477   352   14575904  96676 0                   0 S   9  10      -   0  bg 00:00:00 BG Thread #3
+u:r:priv_app:s0:c512,c768      u0_a132       5184  5478   352   14575904  96676 0                   0 S  19   0      -   0  bg 00:00:00 Lite Thread #1
+u:r:kernel:s0                  root          5254  5254     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/3:7H-kverityd
+u:r:kernel:s0                  root          5255  5255     2          0      0 0                   0 I  39 -20      -   0  fg 00:00:00 kworker/3:8H-kverityd
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 5441 5441 352  13699208  57092 0                   0 S  19   0      -   0  bg 00:00:00 android.webview
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 5441 5442 352  13699208  57092 0                   0 S  39 -20      -   0  bg 00:00:00 Runtime worker 
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 5441 5443 352  13699208  57092 0                   0 S  39 -20      -   0  bg 00:00:00 Runtime worker 
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 5441 5444 352  13699208  57092 0                   0 S  39 -20      -   0  bg 00:00:00 Runtime worker 
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 5441 5445 352  13699208  57092 0                   0 S  39 -20      -   0  bg 00:00:00 Runtime worker 
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 5441 5446 352  13699208  57092 0                   0 S  39 -20      -   0  bg 00:00:00 Signal Catcher
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 5441 5447 352  13699208  57092 0                   0 S  39 -20      -   0  bg 00:00:00 perfetto_hprof_
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 5441 5448 352  13699208  57092 0                   0 S  10   9      -   0  bg 00:00:00 Jit thread pool
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 5441 5449 352  13699208  57092 0                   0 S  15   4      -   0  bg 00:00:00 HeapTaskDaemon
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 5441 5450 352  13699208  57092 0                   0 S  15   4      -   0  bg 00:00:00 ReferenceQueueD
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 5441 5451 352  13699208  57092 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerDaemon
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 5441 5452 352  13699208  57092 0                   0 S  15   4      -   0  bg 00:00:00 FinalizerWatchd
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 5441 5454 352  13699208  57048 0                   0 S  19   0      -   0  bg 00:00:00 binder:5441_1
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 5441 5455 352  13699208  57048 0                   0 S  19   0      -   0  bg 00:00:00 binder:5441_2
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 5441 5458 352  13699208  57048 0                   0 S  19   0      -   0  bg 00:00:00 binder:5441_3
+u:r:untrusted_app:s0:c135,c256,c512,c768 u0_a135 5441 5459 352  13699208  57048 0                   0 S  10   9      -   0  bg 00:00:00 Profile Saver
+u:r:incident:s0                shell         5492  5492  5088   10777464   3512 pipe_wait_readable  0 S  39 -20      -   0  fg 00:00:00 binder:5492_2
+u:r:incident:s0                shell         5492  5496  5088   10777464   3512 binder_ioctl_write_read 0 S 39 -20   -   0  fg 00:00:00 binder:5492_1
+u:r:incident:s0                shell         5492  5497  5088   10777464   3512 binder_ioctl_write_read 0 S 39 -20   -   0  fg 00:00:00 binder:5492_3
+u:r:incident:s0                shell         5492  5508  5088   10777464   3512 binder_ioctl_write_read 0 S 39 -20   -   0  fg 00:00:00 binder:5492_4
+u:r:hal_dumpstate_default:s0   nobody        5502  5502     1   10869500   5396 0                   0 S  19   0      -   0  fg 00:00:00 android.hardwar
+u:r:incidentd:s0               incidentd     5554  5554   461          0      0 0                   0 R  19   0      -   0  fg 00:00:00 Shutdown thread
+u:r:incident_helper:s0         incidentd     5555  5555   461   10781808   2948 0                   0 S  19   0      -   0  fg 00:00:00 incident_helper
+u:r:dumpstate:s0               shell         5631  5631  5088          0      0 0                   0 Z  39 -20      -   0  fg 00:00:00 lshal
+u:r:dumpstate:s0               shell         5656  5656  5088   10870756   7044 0                   0 R  39 -20      -   0  fg 00:00:00 ps
+------ 0.736s was the duration of 'PROCESSES AND THREADS' ------


### PR DESCRIPTION
Some dumpstates have process information after the logcat sections, so additional pass is needed to make sure LogRecords are properly configured.

Fixes #279