### PR TITLE
Fix parsing of some tricky process and logcat sections

### DIFF
--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/dumpstate/DumpstateElements.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/dumpstate/DumpstateElements.java
@@ -109,7 +109,7 @@ final class DumpstateElements {
      * @return {@code true} if the section is a process list section
      */
     public static boolean isProcessSection(String sectionName) {
-        return "PROCESSES (ps -P)".equals(sectionName);
+        return "PROCESSES".equals(sectionName) || sectionName.startsWith("PROCESSES (");
     }
 
     /**
@@ -139,7 +139,8 @@ final class DumpstateElements {
     }
 
     private static boolean isLogcatSectionName(String sectionName, String bufferSectionNamePart) {
-        return sectionName.startsWith(bufferSectionNamePart + " LOG");
+        var nameWithBuffer = bufferSectionNamePart + " LOG";
+        return sectionName.equals(nameWithBuffer) || sectionName.startsWith(nameWithBuffer + " (");
     }
 
     /**

--- a/parsers/src/test/java/name/mlopatkin/andlogview/parsers/dumpstate/DumpstateElementsTest.java
+++ b/parsers/src/test/java/name/mlopatkin/andlogview/parsers/dumpstate/DumpstateElementsTest.java
@@ -129,7 +129,9 @@ class DumpstateElementsTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
-            "PROCESSES (ps -P)"
+            "PROCESSES (ps -P)",
+            "PROCESSES",
+            "PROCESSES (ps -P --abi)",
             // TODO(mlopatkin) This need more supported cases
     })
     void canDetermineProcessSection(String sectionName) {
@@ -141,7 +143,6 @@ class DumpstateElementsTest {
             "PROCRANK",
             "PROCESSES AND THREADS (ps -t -p -P)",
             "PROCESSES AND THREADS",
-            "PROCESSES", // TODO(mlopatkin) this should actually be supported
     })
     void canDetermineNotProcessSection(String sectionName) {
         assertThat(DumpstateElements.isProcessSection(sectionName)).isFalse();
@@ -169,6 +170,7 @@ class DumpstateElementsTest {
             "PROCESSES",
             "KERNEL LOG (dmesg)",
             "KERNEL LOG",
+            "EVENT LOG TAGS",
             "BINDER FAILED TRANSACTION LOG (/sys/kernel/debug/binder/failed_transaction_log)",
             "LAST RADIO LOG (parse_radio_log /proc/last_radio_log)"  // TODO(mlopatkin) Can we parse it?
     })

--- a/src/name/mlopatkin/andlogview/liblogcat/file/DumpstateFileDataSource.java
+++ b/src/name/mlopatkin/andlogview/liblogcat/file/DumpstateFileDataSource.java
@@ -148,7 +148,9 @@ public final class DumpstateFileDataSource implements DataSource {
 
                         @Override
                         public ParserControl unparseableLine(CharSequence line) {
-                            logger.debug("Failed to parse dumpstate logcat line: " + line);
+                            if (line.length() > 0) {
+                                logger.debug("Failed to parse dumpstate logcat line: " + line);
+                            }
                             return ParserControl.proceed();
                         }
                     });


### PR DESCRIPTION
* EVENT LOG TAGS section of ancient android versions was tripping over the parser, which attempted to read it as an event log
* PROCESSES section is reported to be very variable in the wild, though I don't have hands-on dumpstates with such logs.

Fixes #119