### PR TITLE
Remove unneeded CC workaround for main() task

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,11 +24,3 @@ include("parsers")
 include("search")
 include("search:logrecord")
 include("widgets")
-
-gradle.taskGraph.whenReady {
-    allTasks.forEach { task ->
-        if (task.name.endsWith(".main()") && task is JavaExec) {
-            task.notCompatibleWithConfigurationCache("IDEA-injected JavaExec task uses PipedInputStream")
-        }
-    }
-}


### PR DESCRIPTION
Gradle 8.7 now supports System.in natively and the workaround is no longer needed.