### PR TITLE
Increase type safety of Field class

### DIFF
--- a/logmodel/src/main/java/name/mlopatkin/andlogview/logmodel/DataSource.java
+++ b/logmodel/src/main/java/name/mlopatkin/andlogview/logmodel/DataSource.java
@@ -57,7 +57,7 @@ public interface DataSource {
     /**
      * @return the set of fields available in LogRecords that are produced by this data source
      */
-    Set<Field> getAvailableFields();
+    Set<Field<?>> getAvailableFields();
 
     /**
      * Resets internal data structures and resends all available records into

--- a/logmodel/src/testFixtures/java/name/mlopatkin/andlogview/logmodel/AssertLogRecord.java
+++ b/logmodel/src/testFixtures/java/name/mlopatkin/andlogview/logmodel/AssertLogRecord.java
@@ -26,7 +26,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
-import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
  */
 @CanIgnoreReturnValue
 public class AssertLogRecord {
-    private final Set<Field> checkedFields = EnumSet.noneOf(Field.class);
+    private final Set<Field<?>> checkedFields = new HashSet<>();
     private final LogRecord item;
 
     private AssertLogRecord(LogRecord item) {

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/Format.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/Format.java
@@ -23,9 +23,7 @@ import com.google.common.collect.ImmutableSet;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.Arrays;
 import java.util.Comparator;
-import java.util.EnumSet;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -48,20 +46,18 @@ public enum Format {
     private final @Nullable String formatName;
     @SuppressWarnings("ImmutableEnumChecker")
     private final @Nullable Function<LogcatParseEventsHandler, RegexLogcatParserDelegate> parserFactory;
-    private final ImmutableSet<Field> availableFields;
+    private final ImmutableSet<Field<?>> availableFields;
 
     Format(
             @Nullable String cmdFormatName,
             @Nullable Function<LogcatParseEventsHandler, RegexLogcatParserDelegate> parserFactory,
-            Field... availableFields) {
+            Field<?>... availableFields) {
         this.formatName = cmdFormatName;
         this.parserFactory = parserFactory;
-        EnumSet<Field> fieldSet = EnumSet.noneOf(Field.class);
-        fieldSet.addAll(Arrays.asList(availableFields));
-        this.availableFields = ImmutableSet.copyOf(fieldSet);
+        this.availableFields = ImmutableSet.copyOf(availableFields);
     }
 
-    Format(@Nullable String formatName, Field... availableFields) {
+    Format(@Nullable String formatName, Field<?>... availableFields) {
         this(formatName, null, availableFields);
     }
 
@@ -78,7 +74,7 @@ public enum Format {
         return formatName;
     }
 
-    public final Set<Field> getAvailableFields() {
+    public final Set<Field<?>> getAvailableFields() {
         return availableFields;
     }
 

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/LogcatPushParser.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/LogcatPushParser.java
@@ -45,7 +45,7 @@ public class LogcatPushParser<H extends LogcatParseEventsHandler> extends Abstra
         super.close();
     }
 
-    public Set<Field> getAvailableFields() {
+    public Set<Field<?>> getAvailableFields() {
         return format.getAvailableFields();
     }
 }

--- a/parsers/src/testFixtures/java/name/mlopatkin/andlogview/parsers/logcat/LogcatEntryJsonModel.java
+++ b/parsers/src/testFixtures/java/name/mlopatkin/andlogview/parsers/logcat/LogcatEntryJsonModel.java
@@ -38,7 +38,7 @@ public class LogcatEntryJsonModel {
     private @Nullable String tag;
     private @Nullable String message;
 
-    public LogRecord buildRecord(Collection<Field> fields) {
+    public LogRecord buildRecord(Collection<Field<?>> fields) {
         assert fields.contains(Field.MESSAGE);
         LogRecordBuilder record = LogRecordUtils.logRecord(Objects.requireNonNull(message));
         if (fields.contains(Field.TIME)) {

--- a/search/logrecord/src/main/java/name/mlopatkin/andlogview/search/logrecord/OrSearcher.java
+++ b/search/logrecord/src/main/java/name/mlopatkin/andlogview/search/logrecord/OrSearcher.java
@@ -42,7 +42,7 @@ class OrSearcher implements RowSearchStrategy {
     }
 
     @Override
-    public void highlightColumn(LogRecord record, Field field, TextHighlighter columnHighlighter) {
+    public void highlightColumn(LogRecord record, Field<?> field, TextHighlighter columnHighlighter) {
         for (var s : searchers) {
             s.highlightColumn(record, field, columnHighlighter);
         }

--- a/search/logrecord/src/main/java/name/mlopatkin/andlogview/search/logrecord/RowSearchStrategy.java
+++ b/search/logrecord/src/main/java/name/mlopatkin/andlogview/search/logrecord/RowSearchStrategy.java
@@ -22,5 +22,5 @@ import name.mlopatkin.andlogview.search.text.TextHighlighter;
 import java.util.function.Predicate;
 
 public interface RowSearchStrategy extends Predicate<LogRecord> {
-    void highlightColumn(LogRecord record, Field field, TextHighlighter columnHighlighter);
+    void highlightColumn(LogRecord record, Field<?> field, TextHighlighter columnHighlighter);
 }

--- a/search/logrecord/src/main/java/name/mlopatkin/andlogview/search/logrecord/RowSearchStrategyFactory.java
+++ b/search/logrecord/src/main/java/name/mlopatkin/andlogview/search/logrecord/RowSearchStrategyFactory.java
@@ -22,10 +22,12 @@ import name.mlopatkin.andlogview.search.text.HighlightStrategy;
 import name.mlopatkin.andlogview.search.text.SearchStrategyFactory;
 
 import com.google.common.base.CharMatcher;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Grammar:
@@ -79,8 +81,8 @@ public final class RowSearchStrategyFactory {
 
     private static RowSearchStrategy prepareWithoutPrefix(String pattern) throws RequestCompilationException {
         HighlightStrategy strategy = SearchStrategyFactory.createHighlightStrategy(pattern);
-        Field[] searchableFields = {Field.APP_NAME, Field.MESSAGE, Field.TAG};
-        List<ValueSearcher> searches = new ArrayList<>(searchableFields.length);
+        Set<Field<?>> searchableFields = ImmutableSet.of(Field.APP_NAME, Field.MESSAGE, Field.TAG);
+        List<ValueSearcher> searches = new ArrayList<>(searchableFields.size());
         for (var field : searchableFields) {
             searches.add(new ValueSearcher(strategy, field));
         }

--- a/search/logrecord/src/main/java/name/mlopatkin/andlogview/search/logrecord/ValueSearcher.java
+++ b/search/logrecord/src/main/java/name/mlopatkin/andlogview/search/logrecord/ValueSearcher.java
@@ -23,9 +23,9 @@ import name.mlopatkin.andlogview.search.text.TextHighlighter;
 
 class ValueSearcher implements RowSearchStrategy {
     private final HighlightStrategy highlightStrategy;
-    private final Field field;
+    private final Field<?> field;
 
-    public ValueSearcher(HighlightStrategy highlightStrategy, Field field) {
+    public ValueSearcher(HighlightStrategy highlightStrategy, Field<?> field) {
         this.highlightStrategy = highlightStrategy;
         this.field = field;
     }
@@ -40,7 +40,7 @@ class ValueSearcher implements RowSearchStrategy {
     }
 
     @Override
-    public void highlightColumn(LogRecord record, Field field, TextHighlighter columnHighlighter) {
+    public void highlightColumn(LogRecord record, Field<?> field, TextHighlighter columnHighlighter) {
         if (this.field.equals(field)) {
             highlightStrategy.highlightOccurences(getValue(record), columnHighlighter);
         }

--- a/src/name/mlopatkin/andlogview/liblogcat/ddmlib/AdbDataSource.java
+++ b/src/name/mlopatkin/andlogview/liblogcat/ddmlib/AdbDataSource.java
@@ -164,8 +164,8 @@ public class AdbDataSource implements DataSource, BufferReceiver {
     }
 
     @Override
-    public Set<Field> getAvailableFields() {
-        return EnumSet.allOf(Field.class);
+    public Set<Field<?>> getAvailableFields() {
+        return Field.values();
     }
 
     @Override

--- a/src/name/mlopatkin/andlogview/liblogcat/file/DumpstateFileDataSource.java
+++ b/src/name/mlopatkin/andlogview/liblogcat/file/DumpstateFileDataSource.java
@@ -54,13 +54,13 @@ public final class DumpstateFileDataSource implements DataSource {
     private final SourceMetadata sourceMetadata;
 
     private final List<LogRecord> records;
-    private final Set<Field> availableFields;
+    private final Set<Field<?>> availableFields;
     private final EnumSet<Buffer> buffers;
     private final Map<Integer, String> converter;
 
     private @Nullable RecordListener<LogRecord> logcatListener;
 
-    private DumpstateFileDataSource(File file, List<LogRecord> records, Set<Field> availableFields,
+    private DumpstateFileDataSource(File file, List<LogRecord> records, Set<Field<?>> availableFields,
             EnumSet<Buffer> buffers, Map<Integer, String> converter) {
         this.fileName = file.getName();
         this.sourceMetadata = new FileSourceMetadata(file);
@@ -79,7 +79,7 @@ public final class DumpstateFileDataSource implements DataSource {
     }
 
     @Override
-    public Set<Field> getAvailableFields() {
+    public Set<Field<?>> getAvailableFields() {
         return availableFields;
     }
 
@@ -235,7 +235,7 @@ public final class DumpstateFileDataSource implements DataSource {
             }
             return new ImportResult(
                     new DumpstateFileDataSource(
-                            file, sorter.buildTimestampOrdered(), EnumSet.allOf(Field.class), availableBuffers,
+                            file, sorter.buildTimestampOrdered(), Field.values(), availableBuffers,
                             pidToProcessConverter),
                     problems);
         }

--- a/src/name/mlopatkin/andlogview/liblogcat/file/LogfileDataSource.java
+++ b/src/name/mlopatkin/andlogview/liblogcat/file/LogfileDataSource.java
@@ -46,13 +46,13 @@ import java.util.function.Function;
  */
 public class LogfileDataSource implements DataSource {
     private final String fileName;
-    private final Set<Field> availableFields;
+    private final Set<Field<?>> availableFields;
     private final List<LogRecord> records;
     private final SourceMetadata sourceMetadata;
 
     private @Nullable RecordListener<LogRecord> listener;
 
-    private LogfileDataSource(File file, Set<Field> availableFields, List<LogRecord> records) {
+    private LogfileDataSource(File file, Set<Field<?>> availableFields, List<LogRecord> records) {
         this.fileName = file.getName();
         this.availableFields = availableFields;
         // records may be huge, do not copy it needlessly
@@ -69,7 +69,7 @@ public class LogfileDataSource implements DataSource {
     }
 
     @Override
-    public Set<Field> getAvailableFields() {
+    public Set<Field<?>> getAvailableFields() {
         return availableFields;
     }
 

--- a/src/name/mlopatkin/andlogview/ui/logtable/Column.java
+++ b/src/name/mlopatkin/andlogview/ui/logtable/Column.java
@@ -63,7 +63,7 @@ public enum Column {
     // Message isn't toggleable so the user cannot disable everything.
     MESSAGE(Field.MESSAGE, "message", "Message", false);
 
-    private final @Nullable Field recordField;
+    private final @Nullable Field<?> recordField;
     private final String columnName;
     private final @Nullable String title;
     private final boolean toggleable;
@@ -87,7 +87,7 @@ public enum Column {
      * @param name short name that is used as a key in preferences
      * @param title user-visible title of the column (can be empty)
      */
-    Column(@Nullable Field recordField, String name, @Nullable String title) {
+    Column(@Nullable Field<?> recordField, String name, @Nullable String title) {
         this(recordField, name, title, true);
     }
 
@@ -99,7 +99,7 @@ public enum Column {
      * @param title user-visible title of the column (can be empty or null)
      * @param toggleable whether the visibility of the column can be toggled with popup menu
      */
-    Column(@Nullable Field recordField, String name, @Nullable String title, boolean toggleable) {
+    Column(@Nullable Field<?> recordField, String name, @Nullable String title, boolean toggleable) {
         this.recordField = recordField;
         this.columnName = name;
         this.title = title;
@@ -111,7 +111,7 @@ public enum Column {
      *
      * @return the record field
      */
-    public @Nullable Field getRecordField() {
+    public @Nullable Field<?> getRecordField() {
         return recordField;
     }
 
@@ -164,7 +164,7 @@ public enum Column {
         return columns;
     }
 
-    public static Set<Column> getColumnsForFields(Collection<Field> fields) {
+    public static Set<Column> getColumnsForFields(Collection<Field<?>> fields) {
         Set<Column> columns = EnumSet.noneOf(Column.class);
         for (Column column : Column.values()) {
             if (fields.contains(column.recordField)) {


### PR DESCRIPTION
Java enum cannot have subtypes as its constants or be a generic, but this is somewhat desirable for the Field constants. This commit rewrites the enum into a pre-Java-5 style class-with-constants implementation to achieve the necessary type safety. Not that it is strictly necessary...

Issue: n/a