### PR TITLE
Make Index Filter order sensitive

### DIFF
--- a/base/src/main/java/name/mlopatkin/andlogview/base/collections/MyIterables.java
+++ b/base/src/main/java/name/mlopatkin/andlogview/base/collections/MyIterables.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.base.collections;
+
+import com.google.common.collect.AbstractIterator;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+public final class MyIterables {
+    private MyIterables() {}
+
+    /**
+     * Returns the iterable that produces items from {@code items} while {@code predicate} returns {@code true} for
+     * them.
+     *
+     * @param items the source of elements
+     * @param predicate the predicate to test items.
+     * @param <T> the type of elements
+     * @return the new iterator
+     */
+    public static <T> Iterable<T> takeWhile(Iterable<? extends T> items, Predicate<? super T> predicate) {
+        return new Iterable<>() {
+            @Override
+            public Iterator<T> iterator() {
+                return takeWhile(items.iterator(), predicate);
+            }
+        };
+    }
+
+
+    /**
+     * Returns the iterator that produces items from {@code iter} while {@code predicate} returns {@code true} for them.
+     *
+     * @param iter the source of elements
+     * @param predicate the predicate to test items.
+     * @param <T> the type of elements
+     * @return the new iterator
+     */
+    public static <T> Iterator<T> takeWhile(Iterator<? extends T> iter, Predicate<? super T> predicate) {
+        return new AbstractIterator<>() {
+            @Override
+            protected @Nullable T computeNext() {
+                if (iter.hasNext()) {
+                    var next = iter.next();
+                    return predicate.test(next) ? next : endOfData();
+                }
+                return endOfData();
+            }
+        };
+    }
+}

--- a/base/src/main/java/name/mlopatkin/andlogview/utils/events/LazySubject.java
+++ b/base/src/main/java/name/mlopatkin/andlogview/utils/events/LazySubject.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.utils.events;
+
+import name.mlopatkin.andlogview.thirdparty.observerlist.ObserverList;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Iterator;
+
+public class LazySubject<T> implements Iterable<T> {
+    private final ObserverList<T> observers = new ObserverList<>();
+    private final Runnable subscribeAction;
+    private final Runnable unsubscribeAction;
+
+    private final Observable<T> observable = new Observable<T>() {
+        @Override
+        public void addObserver(T observer) {
+            if (observers.isEmpty()) {
+                subscribeAction.run();
+            }
+            observers.addObserver(observer);
+        }
+
+        @Override
+        public void removeObserver(@Nullable T observer) {
+            if (observers.isEmpty()) {
+                return;
+            }
+            observers.removeObserver(observer);
+            if (observers.isEmpty()) {
+                unsubscribeAction.run();
+            }
+        }
+    };
+
+    public LazySubject(Runnable subscribeAction, Runnable unsubscribeAction) {
+        this.subscribeAction = subscribeAction;
+        this.unsubscribeAction = unsubscribeAction;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return observers.iterator();
+    }
+
+    public Observable<T> asObservable() {
+        return observable;
+    }
+}

--- a/filters/src/main/java/name/mlopatkin/andlogview/filters/ChildModelFilter.java
+++ b/filters/src/main/java/name/mlopatkin/andlogview/filters/ChildModelFilter.java
@@ -23,11 +23,11 @@ public interface ChildModelFilter extends Filter {
     // TODO {@link FilterModel} should know about these filters and may provide a "parent" model for it.
 
     /**
-     * Returns the child model of this filter.
+     * Returns the child model of this filter. It doesn't include the filters of the parent model.
      *
      * @return the model of this filter
      */
-    FilterModel getFilters();
+    FilterModel getChildren();
     // TODO(mlopatkin) FilterModel can subscribe to child model upon adding a filter and unsubscribe afterwards.
     //  This way, the notifications can still be sent from the main model, so clients do not have to care about watching
     //  for children and subscribing themselves.

--- a/filters/src/main/java/name/mlopatkin/andlogview/filters/CompoundFilterModel.java
+++ b/filters/src/main/java/name/mlopatkin/andlogview/filters/CompoundFilterModel.java
@@ -16,6 +16,7 @@
 
 package name.mlopatkin.andlogview.filters;
 
+import name.mlopatkin.andlogview.base.collections.MyIterables;
 import name.mlopatkin.andlogview.utils.events.LazySubject;
 import name.mlopatkin.andlogview.utils.events.Observable;
 
@@ -81,7 +82,7 @@ public class CompoundFilterModel implements FilterModel {
     @Override
     public Collection<? extends Filter> getFilters() {
         return ImmutableList.<Filter>builder()
-                .addAll(parent.getFilters().iterator())
+                .addAll(MyIterables.takeWhile(parent.getFilters().iterator(), f -> !filter.equals(f)))
                 .addAll(filter.getChildren().getFilters())
                 .build();
     }

--- a/filters/src/main/java/name/mlopatkin/andlogview/filters/CompoundFilterModel.java
+++ b/filters/src/main/java/name/mlopatkin/andlogview/filters/CompoundFilterModel.java
@@ -16,7 +16,6 @@
 
 package name.mlopatkin.andlogview.filters;
 
-import name.mlopatkin.andlogview.base.collections.MyIterables;
 import name.mlopatkin.andlogview.utils.events.LazySubject;
 import name.mlopatkin.andlogview.utils.events.Observable;
 
@@ -82,7 +81,7 @@ public class CompoundFilterModel implements FilterModel {
     @Override
     public Collection<? extends Filter> getFilters() {
         return ImmutableList.<Filter>builder()
-                .addAll(MyIterables.takeWhile(parent.getFilters().iterator(), f -> !filter.equals(f)))
+                .addAll(parent.getFilters())
                 .addAll(filter.getChildren().getFilters())
                 .build();
     }

--- a/filters/src/main/java/name/mlopatkin/andlogview/filters/CompoundFilterModel.java
+++ b/filters/src/main/java/name/mlopatkin/andlogview/filters/CompoundFilterModel.java
@@ -16,11 +16,10 @@
 
 package name.mlopatkin.andlogview.filters;
 
-import name.mlopatkin.andlogview.utils.events.CompoundObservable;
+import name.mlopatkin.andlogview.utils.events.LazySubject;
 import name.mlopatkin.andlogview.utils.events.Observable;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 
 import java.util.Collection;
 
@@ -28,23 +27,62 @@ import java.util.Collection;
  * A combination of several {@link FilterModel}.
  */
 public class CompoundFilterModel implements FilterModel {
-    private final FilterModel first;
-    private final FilterModel second;
-    private final Observable<FilterModel.Observer> observable;
+    private final FilterModel parent;
+    private final ChildModelFilter filter;
 
-    public CompoundFilterModel(FilterModel first, FilterModel second) {
-        this.first = first;
-        this.second = second;
-        this.observable = new CompoundObservable<>(first.asObservable(), second.asObservable());
+    private final Observer modelObserver = new Observer() {
+        @Override
+        public void onFilterAdded(FilterModel model, Filter newFilter) {
+            for (var obs : observers) {
+                obs.onFilterAdded(CompoundFilterModel.this, newFilter);
+            }
+        }
+
+        @Override
+        public void onFilterRemoved(FilterModel model, Filter removedFilter) {
+            for (var obs : observers) {
+                obs.onFilterRemoved(CompoundFilterModel.this, removedFilter);
+            }
+        }
+
+        @Override
+        public void onFilterReplaced(FilterModel model, Filter oldFilter, Filter newFilter) {
+            for (var obs : observers) {
+                obs.onFilterReplaced(CompoundFilterModel.this, oldFilter, newFilter);
+            }
+        }
+    };
+
+    private final LazySubject<Observer> observers = new LazySubject<>(
+            this::subscribeObservers,
+            this::unsubscribeObservers
+    );
+
+    public CompoundFilterModel(FilterModel parent, ChildModelFilter filter) {
+        this.parent = parent;
+        this.filter = filter;
+    }
+
+    private void subscribeObservers() {
+        parent.asObservable().addObserver(modelObserver);
+        filter.getChildren().asObservable().addObserver(modelObserver);
+    }
+
+    private void unsubscribeObservers() {
+        parent.asObservable().removeObserver(modelObserver);
+        filter.getChildren().asObservable().removeObserver(modelObserver);
     }
 
     @Override
     public Observable<Observer> asObservable() {
-        return observable;
+        return observers.asObservable();
     }
 
     @Override
     public Collection<? extends Filter> getFilters() {
-        return ImmutableList.copyOf(Iterables.concat(first.getFilters(), second.getFilters()));
+        return ImmutableList.<Filter>builder()
+                .addAll(parent.getFilters().iterator())
+                .addAll(filter.getChildren().getFilters())
+                .build();
     }
 }

--- a/filters/src/main/java/name/mlopatkin/andlogview/filters/FilterChain.java
+++ b/filters/src/main/java/name/mlopatkin/andlogview/filters/FilterChain.java
@@ -60,11 +60,9 @@ public class FilterChain implements AutoCloseable {
                 () -> MultimapBuilder.enumKeys(FilteringMode.class).hashSetValues().build()
         ));
 
-        // TODO(mlopatkin) the model supplied to the observer is invalid when change comes from the top-level filter
-        //  list
         subscription =
                 model.asObservable().addScopedObserver(new FiltersChangeObserver(
-                                ignored -> onFiltersChanged(model),
+                                this::onFiltersChanged,
                                 f -> transformFilter(f) == null
                         )
                 );

--- a/filters/src/main/java/name/mlopatkin/andlogview/filters/FilterModel.java
+++ b/filters/src/main/java/name/mlopatkin/andlogview/filters/FilterModel.java
@@ -34,7 +34,7 @@ public interface FilterModel {
          * @param model the origin of the notification
          * @param newFilter the new filter
          */
-        void onFilterAdded(FilterModel model, Filter newFilter);
+        default void onFilterAdded(FilterModel model, Filter newFilter) {}
 
         /**
          * Called after the filter is removed from the model.
@@ -42,7 +42,7 @@ public interface FilterModel {
          * @param model the origin of the notification
          * @param removedFilter the removed filter.
          */
-        void onFilterRemoved(FilterModel model, Filter removedFilter);
+        default void onFilterRemoved(FilterModel model, Filter removedFilter) {}
 
         /**
          * Called after the filter was replaced with other filter.
@@ -51,7 +51,32 @@ public interface FilterModel {
          * @param oldFilter the filter that was removed
          * @param newFilter the filter that was added instead of the {@code oldFilter}
          */
-        void onFilterReplaced(FilterModel model, Filter oldFilter, Filter newFilter);
+        default void onFilterReplaced(FilterModel model, Filter oldFilter, Filter newFilter) {
+            onFilterRemoved(model, oldFilter);
+            onFilterAdded(model, newFilter);
+        }
+
+        /**
+         * Called when a {@link ChildModelFilter} is added to this model. A new sub-model is created that contains
+         * filters from the origin model that are before the added child model filter. Filters from the child model of
+         * the filter are not part of the model. The returned sub model is live and broadcasts change notifications.
+         * The {@code filter} is not part of the sub model
+         *
+         * @param parentModel the origin of the notification
+         * @param subModel the sub model
+         * @param filter the child model filter that caused the sub model to be created
+         */
+        default void onSubModelCreated(FilterModel parentModel, FilterModel subModel, ChildModelFilter filter) {}
+
+        /**
+         * Called when a {@link ChildModelFilter} is removed from this model. The sub model is no longer active, an
+         * attempt to use it will cause an exception.
+         *
+         * @param parentModel the origin of the notification
+         * @param subModel the sub model
+         * @param filter the child model filter that was removed
+         */
+        default void onSubModelRemoved(FilterModel parentModel, FilterModel subModel, ChildModelFilter filter) {}
     }
 
     /**

--- a/filters/src/main/java/name/mlopatkin/andlogview/filters/MutableFilterModel.java
+++ b/filters/src/main/java/name/mlopatkin/andlogview/filters/MutableFilterModel.java
@@ -16,6 +16,8 @@
 
 package name.mlopatkin.andlogview.filters;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import java.util.Collection;
 
 /**
@@ -46,6 +48,14 @@ public interface MutableFilterModel extends FilterModel {
      * @throws IllegalArgumentException if the filter {@code toReplace} is not in the model
      */
     void replaceFilter(Filter toReplace, Filter newFilter);
+
+    /**
+     * Returns a sub-model for a give child model filter or {@code null} if the {@code filter} isn't part of this model.
+     * @param filter the filter to find a sub model for
+     * @return the sub model for the filter or null.
+     */
+    @Nullable
+    FilterModel findSubModel(ChildModelFilter filter);
 
     /**
      * Creates a new, empty FilterModel.

--- a/filters/src/test/java/name/mlopatkin/andlogview/filters/CompoundFilterModelTest.java
+++ b/filters/src/test/java/name/mlopatkin/andlogview/filters/CompoundFilterModelTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.filters;
+
+import static name.mlopatkin.andlogview.filters.FilterModelAssert.assertThatFilters;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+class CompoundFilterModelTest {
+    private final MutableFilterModel parent = MutableFilterModel.create();
+    private final TestFilter testFilter = filter();
+
+    @BeforeEach
+    void setUp() {
+        parent.addFilter(testFilter);
+    }
+
+    @Test
+    void filtersAddedAfterIndexDoNotShowInTheModel() {
+        var model = new CompoundFilterModel(parent, testFilter);
+        var hideFilter = ToggleFilter.hide(Predicates.alwaysFalse());
+
+        parent.addFilter(hideFilter);
+
+        assertThatFilters(model).doesNotContain(hideFilter);
+    }
+
+    private static TestFilter filter() {
+        return new TestFilter();
+    }
+
+    private static class TestFilter extends AbstractFilter<TestFilter> implements ChildModelFilter {
+        private final MutableFilterModel children = MutableFilterModel.create();
+
+        public TestFilter() {
+            this(ImmutableList.of(), true);
+        }
+
+        protected TestFilter(Collection<? extends Filter> children, boolean enabled) {
+            super(FilteringMode.WINDOW, enabled);
+            children.forEach(this.children::addFilter);
+        }
+
+        @Override
+        public MutableFilterModel getChildren() {
+            return children;
+        }
+
+        @Override
+        protected TestFilter copy(boolean enabled) {
+            return new TestFilter(children.getFilters(), enabled);
+        }
+    }
+}

--- a/filters/src/test/java/name/mlopatkin/andlogview/filters/CompoundFilterModelTest.java
+++ b/filters/src/test/java/name/mlopatkin/andlogview/filters/CompoundFilterModelTest.java
@@ -27,20 +27,17 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import com.google.common.collect.ImmutableList;
-
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Collection;
+import java.util.Objects;
 
 @ExtendWith(MockitoExtension.class)
 class CompoundFilterModelTest {
     private final MutableFilterModel parent = MutableFilterModel.create();
-    private final TestFilter testFilter = filter();
+    private final TestChildModelFilter testFilter = filter();
 
     @Mock
     FilterModel.Observer observer;
@@ -104,7 +101,6 @@ class CompoundFilterModelTest {
     }
 
     @Test
-    @Disabled
     void filtersAddedAfterIndexDoNotTriggerNotifications() {
         var model = createModel();
         model.asObservable().addObserver(observer);
@@ -116,7 +112,6 @@ class CompoundFilterModelTest {
     }
 
     @Test
-    @Disabled
     void filtersRemovedAfterIndexDoNotTriggerNotifications() {
         var hideFilter = hide(alwaysFalse());
         var model = createModel();
@@ -129,7 +124,6 @@ class CompoundFilterModelTest {
     }
 
     @Test
-    @Disabled
     void filtersReplacedAfterIndexDoNotTriggerNotifications() {
         var model = createModel();
         var hideFilter = hide(alwaysFalse());
@@ -172,33 +166,10 @@ class CompoundFilterModelTest {
 
     private CompoundFilterModel createModel() {
         parent.addFilter(testFilter);
-        return new CompoundFilterModel(parent, testFilter);
+        return new CompoundFilterModel(Objects.requireNonNull(parent.findSubModel(testFilter)), testFilter);
     }
 
-    private static TestFilter filter() {
-        return new TestFilter();
-    }
-
-    private static class TestFilter extends AbstractFilter<TestFilter> implements ChildModelFilter {
-        private final MutableFilterModel children = MutableFilterModel.create();
-
-        public TestFilter() {
-            this(ImmutableList.of(), true);
-        }
-
-        protected TestFilter(Collection<? extends Filter> children, boolean enabled) {
-            super(FilteringMode.WINDOW, enabled);
-            children.forEach(this.children::addFilter);
-        }
-
-        @Override
-        public MutableFilterModel getChildren() {
-            return children;
-        }
-
-        @Override
-        protected TestFilter copy(boolean enabled) {
-            return new TestFilter(children.getFilters(), enabled);
-        }
+    private static TestChildModelFilter filter() {
+        return Filters.childModelFilter();
     }
 }

--- a/filters/src/test/java/name/mlopatkin/andlogview/filters/MutableFilterModelTest.java
+++ b/filters/src/test/java/name/mlopatkin/andlogview/filters/MutableFilterModelTest.java
@@ -17,9 +17,13 @@
 package name.mlopatkin.andlogview.filters;
 
 import static name.mlopatkin.andlogview.filters.FilterModelAssert.assertThatFilters;
+import static name.mlopatkin.andlogview.filters.Filters.childModelFilter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -29,11 +33,14 @@ import com.google.common.collect.ImmutableList;
 import org.assertj.core.api.ListAssert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 @ExtendWith(MockitoExtension.class)
 class MutableFilterModelTest {
@@ -229,8 +236,277 @@ class MutableFilterModelTest {
         assertThatFilters(model).containsExactly(filter1, filter2);
     }
 
+    @Test
+    void addingChildModelFilterNotifiesObservers() {
+        var model = createModel();
+        model.asObservable().addObserver(observer);
+
+        var childrenFilter = childModelFilter();
+        model.addFilter(childrenFilter);
+
+        verify(observer).onFilterAdded(model, childrenFilter);
+        verify(observer).onSubModelCreated(eq(model), any(), eq(childrenFilter));
+    }
+
+    @Test
+    void removingChildModelFilterNotifiesObservers() {
+        var childrenFilter = childModelFilter();
+        var model = createModel(childrenFilter);
+        model.asObservable().addObserver(observer);
+
+        model.removeFilter(childrenFilter);
+
+        verify(observer).onFilterRemoved(model, childrenFilter);
+        verify(observer).onSubModelRemoved(eq(model), any(), eq(childrenFilter));
+    }
+
+    @Test
+    void replacingChildModelFilterNotifiesObservers() {
+        var childrenFilter1 = childModelFilter();
+        var model = createModel(childrenFilter1);
+        model.asObservable().addObserver(observer);
+
+        var childrenFilter2 = childModelFilter();
+        model.replaceFilter(childrenFilter1, childrenFilter2);
+
+        verify(observer).onFilterReplaced(model, childrenFilter1, childrenFilter2);
+        verify(observer).onSubModelRemoved(eq(model), any(), eq(childrenFilter1));
+        verify(observer).onSubModelCreated(eq(model), any(), eq(childrenFilter2));
+    }
+
+    @Test
+    void replacingChildModelFilterWithOtherNotifiesObservers() {
+        var childrenFilter1 = childModelFilter();
+        var model = createModel(childrenFilter1);
+        model.asObservable().addObserver(observer);
+
+        var filter2 = createFilter("filter2");
+        model.replaceFilter(childrenFilter1, filter2);
+
+        verify(observer).onFilterReplaced(model, childrenFilter1, filter2);
+        verify(observer).onSubModelRemoved(eq(model), any(), eq(childrenFilter1));
+    }
+
+    @Test
+    void replacingFilterWithChildModelFilterNotifiesObservers() {
+        var filter1 = createFilter("filter1");
+        var model = createModel(filter1);
+        model.asObservable().addObserver(observer);
+
+        var childrenFilter2 = childModelFilter();
+        model.replaceFilter(filter1, childrenFilter2);
+
+        verify(observer).onFilterReplaced(model, filter1, childrenFilter2);
+        verify(observer).onSubModelCreated(eq(model), any(), eq(childrenFilter2));
+    }
+
+    @Test
+    void sameInstanceOfSubmodelIsUsedWhenCreatingAndRemoving() {
+        var model = createModel();
+        model.asObservable().addObserver(observer);
+        var subModel = ArgumentCaptor.forClass(FilterModel.class);
+
+        var childrenFilter = childModelFilter();
+
+        model.addFilter(childrenFilter);
+        model.removeFilter(childrenFilter);
+
+        verify(observer).onSubModelCreated(eq(model), subModel.capture(), eq(childrenFilter));
+        verify(observer).onSubModelRemoved(eq(model), same(subModel.getValue()), eq(childrenFilter));
+    }
+
+    @Test
+    void submodelHasFilters() {
+        var filter1 = createFilter("filter1");
+        var model = createModel(filter1);
+        model.asObservable().addObserver(observer);
+        var subModel = ArgumentCaptor.forClass(FilterModel.class);
+
+        var childrenFilter = childModelFilter();
+        model.addFilter(childrenFilter);
+
+        verify(observer).onSubModelCreated(eq(model), subModel.capture(), eq(childrenFilter));
+
+        assertThatFilters(subModel.getValue()).containsExactly(filter1);
+    }
+
+    @Test
+    void canHaveMultipleSubmodels() {
+        var filter1 = createFilter("filter1");
+        var model = createModel(filter1);
+        model.asObservable().addObserver(observer);
+        var subModel = ArgumentCaptor.forClass(FilterModel.class);
+
+        var childrenFilter1 = childModelFilter();
+        model.addFilter(childrenFilter1);
+
+
+        verify(observer).onSubModelCreated(eq(model), subModel.capture(), eq(childrenFilter1));
+        var subModel1 = subModel.getValue();
+
+        var filter2 = createFilter("filter2");
+        var childrenFilter2 = childModelFilter();
+        model.addFilter(filter2);
+        model.addFilter(childrenFilter2);
+
+        verify(observer).onSubModelCreated(eq(model), subModel.capture(), eq(childrenFilter2));
+        var subModel2 = subModel.getValue();
+
+        assertThatFilters(subModel1).containsExactly(filter1);
+        assertThatFilters(subModel2).containsExactly(filter1, childrenFilter1, filter2);
+    }
+
+    @Test
+    void canGetModelForFilter() {
+        var model = createModel();
+        model.asObservable().addObserver(observer);
+
+        var childrenFilter = childModelFilter();
+        model.addFilter(childrenFilter);
+
+        var subModel = ArgumentCaptor.forClass(FilterModel.class);
+        verify(observer).onSubModelCreated(eq(model), subModel.capture(), eq(childrenFilter));
+
+        assertThat(subModel.getValue()).isSameAs(model.findSubModel(childrenFilter));
+    }
+
+    @Test
+    void noSubmodelForFilterNotInModel() {
+        var model = createModel();
+
+        var childrenFilter = childModelFilter();
+
+        assertThat(model.findSubModel(childrenFilter)).isNull();
+    }
+
+    @Test
+    void addingFiltersDoNotNotifyUnrelatedSubmodels() {
+        var childrenFilter = childModelFilter();
+        var model = createModel(childrenFilter);
+
+        Objects.requireNonNull(model.findSubModel(childrenFilter)).asObservable().addObserver(observer);
+
+        model.addFilter(createFilter("filter1"));
+
+        verify(observer, never()).onFilterAdded(any(), any());
+    }
+
+    @Test
+    void removingFiltersDoNotNotifyUnrelatedSubmodels() {
+        var childrenFilter = childModelFilter();
+        var filter1 = createFilter("filter1");
+        var model = createModel(childrenFilter, filter1);
+
+        Objects.requireNonNull(model.findSubModel(childrenFilter)).asObservable().addObserver(observer);
+
+        model.removeFilter(filter1);
+
+        verify(observer, never()).onFilterRemoved(any(), any());
+    }
+
+    @Test
+    void replacingFiltersDoNotNotifyUnrelatedSubmodels() {
+        var childrenFilter = childModelFilter();
+        var filter1 = createFilter("filter1");
+        var model = createModel(childrenFilter, filter1);
+
+        observeSubModelOf(model, childrenFilter);
+
+        model.replaceFilter(filter1, createFilter("filter2"));
+
+        verify(observer, never()).onFilterReplaced(any(), any(), any());
+    }
+
+    @Test
+    void removingFiltersNotifyRelatedSubmodelsOnly() {
+        var childrenFilter1 = childModelFilter();
+        var filter = createFilter("filter");
+        var childrenFilter2 = childModelFilter();
+
+        var model = createModel(childrenFilter1, filter, childrenFilter2);
+        var subModel1 = observeSubModelOf(model, childrenFilter1);
+        var subModel2 = observeSubModelOf(model, childrenFilter2);
+
+        model.removeFilter(filter);
+
+        verify(observer, never()).onFilterRemoved(subModel1, filter);
+        verify(observer).onFilterRemoved(subModel2, filter);
+
+        assertThatFilters(subModel2).containsExactly(childrenFilter1);
+    }
+
+    @Test
+    void replacingFiltersNotifyRelatedSubmodelsOnly() {
+        var childrenFilter1 = childModelFilter();
+        var filter = createFilter("filter");
+        var childrenFilter2 = childModelFilter();
+
+        var model = createModel(childrenFilter1, filter, childrenFilter2);
+        var subModel1 = observeSubModelOf(model, childrenFilter1);
+        var subModel2 = observeSubModelOf(model, childrenFilter2);
+
+        var otherFilter = createFilter("other");
+        model.replaceFilter(filter, otherFilter);
+
+        verify(observer, never()).onFilterReplaced(subModel1, filter, otherFilter);
+        verify(observer).onFilterReplaced(subModel2, filter, otherFilter);
+
+        assertThatFilters(subModel1).isEmpty();
+        assertThatFilters(subModel2).containsExactly(childrenFilter1, otherFilter);
+    }
+
+    @Test
+    void canRetrieveSubModelWhenAdding() {
+        var model = createModel();
+        var childrenFilter = childModelFilter();
+        model.asObservable().addObserver(new FilterModel.Observer() {
+            @Override
+            public void onFilterAdded(FilterModel src, Filter newFilter) {
+                assertThat(model.findSubModel(childrenFilter)).isNotNull();
+            }
+
+            @Override
+            public void onSubModelCreated(FilterModel parentModel, FilterModel subModel, ChildModelFilter filter) {
+                assertThat(model.findSubModel(childrenFilter)).isSameAs(subModel).isNotNull();
+            }
+        });
+
+        model.addFilter(childrenFilter);
+    }
+
+    @Test
+    void canRetrieveSubModelWhenReplacing() {
+        var filter1 = createFilter("filter1");
+        var model = createModel(filter1);
+        var childrenFilter = childModelFilter();
+        model.asObservable().addObserver(new FilterModel.Observer() {
+            @Override
+            public void onFilterReplaced(FilterModel src, Filter oldFilter, Filter newFilter) {
+                assertThat(newFilter).isSameAs(childrenFilter);
+                assertThat(model.findSubModel(childrenFilter)).isNotNull();
+            }
+
+            @Override
+            public void onSubModelCreated(FilterModel parentModel, FilterModel subModel, ChildModelFilter filter) {
+                assertThat(model.findSubModel(childrenFilter)).isSameAs(subModel).isNotNull();
+            }
+        });
+
+        model.replaceFilter(filter1, childrenFilter);
+    }
+
+    FilterModel observeSubModelOf(MutableFilterModel model, ChildModelFilter filter) {
+        var subModel = Objects.requireNonNull(model.findSubModel(filter));
+        subModel.asObservable().addObserver(observer);
+        return subModel;
+    }
+
     MutableFilterModel createModel() {
         return new FilterModelImpl();
+    }
+
+    MutableFilterModel createModel(Filter... filters) {
+        return new FilterModelImpl(Arrays.asList(filters));
     }
 
     Filter createFilter(String name) {

--- a/filters/src/testFixtures/java/name/mlopatkin/andlogview/filters/Filters.java
+++ b/filters/src/testFixtures/java/name/mlopatkin/andlogview/filters/Filters.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.filters;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Helpers to create filters in tests.
+ */
+public final class Filters {
+    private Filters() {}
+
+    public static TestChildModelFilter childModelFilter() {
+        return new TestChildModelFilter();
+    }
+
+    public static TestChildModelFilter childModelFilter(Filter... children) {
+        return new TestChildModelFilter(ImmutableList.copyOf(children), true);
+    }
+}

--- a/filters/src/testFixtures/java/name/mlopatkin/andlogview/filters/TestChildModelFilter.java
+++ b/filters/src/testFixtures/java/name/mlopatkin/andlogview/filters/TestChildModelFilter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.filters;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.Collection;
+
+public class TestChildModelFilter extends AbstractFilter<TestChildModelFilter> implements ChildModelFilter {
+    private final MutableFilterModel children = MutableFilterModel.create();
+
+    public TestChildModelFilter() {
+        this(ImmutableList.of(), true);
+    }
+
+    TestChildModelFilter(Collection<? extends Filter> children, boolean enabled) {
+        super(FilteringMode.WINDOW, enabled);
+        children.forEach(this.children::addFilter);
+    }
+
+    @Override
+    public MutableFilterModel getChildren() {
+        return children;
+    }
+
+    @Override
+    protected TestChildModelFilter copy(boolean enabled) {
+        return new TestChildModelFilter(children.getFilters(), enabled);
+    }
+}

--- a/src/name/mlopatkin/andlogview/ui/filterdialog/IndexWindowFilter.java
+++ b/src/name/mlopatkin/andlogview/ui/filterdialog/IndexWindowFilter.java
@@ -86,7 +86,7 @@ public class IndexWindowFilter extends AbstractFilter<IndexWindowFilter> impleme
     }
 
     @Override
-    public MutableFilterModel getFilters() {
+    public MutableFilterModel getChildren() {
         return model;
     }
 

--- a/src/name/mlopatkin/andlogview/ui/filters/IndexWindowFilterData.java
+++ b/src/name/mlopatkin/andlogview/ui/filters/IndexWindowFilterData.java
@@ -33,7 +33,7 @@ public class IndexWindowFilterData extends SavedFilterData {
         super(filter.isEnabled());
         this.filter = filter;
         this.filterData = filter.getData();
-        this.childFilters = codec().encode(filter.getFilters().getFilters());
+        this.childFilters = codec().encode(filter.getChildren().getFilters());
     }
 
     @Override

--- a/src/name/mlopatkin/andlogview/ui/indexfilter/IndexFilterController.java
+++ b/src/name/mlopatkin/andlogview/ui/indexfilter/IndexFilterController.java
@@ -54,7 +54,7 @@ public class IndexFilterController extends AbstractIndexController implements Au
         this.filterModel = parentFilterModel;
 
         this.filter = filter;
-        logModelFilter = new IndexFilter(new CompoundFilterModel(parentFilterModel, filter.getFilters()));
+        logModelFilter = new IndexFilter(new CompoundFilterModel(parentFilterModel, filter));
 
         IndexFrameDi.IndexFrameComponent component = DaggerIndexFrameDi_IndexFrameComponent.builder()
                 .logRecordTableModel(logModel)

--- a/src/name/mlopatkin/andlogview/ui/indexfilter/IndexFilterController.java
+++ b/src/name/mlopatkin/andlogview/ui/indexfilter/IndexFilterController.java
@@ -33,6 +33,7 @@ import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
 
 import java.awt.EventQueue;
+import java.util.Objects;
 
 import javax.inject.Named;
 import javax.swing.JTable;
@@ -54,7 +55,8 @@ public class IndexFilterController extends AbstractIndexController implements Au
         this.filterModel = parentFilterModel;
 
         this.filter = filter;
-        logModelFilter = new IndexFilter(new CompoundFilterModel(parentFilterModel, filter));
+        logModelFilter = new IndexFilter(
+                new CompoundFilterModel(Objects.requireNonNull(parentFilterModel.findSubModel(filter)), filter));
 
         IndexFrameDi.IndexFrameComponent component = DaggerIndexFrameDi_IndexFrameComponent.builder()
                 .logRecordTableModel(logModel)

--- a/src/name/mlopatkin/andlogview/ui/indexfilter/IndexFilterController.java
+++ b/src/name/mlopatkin/andlogview/ui/indexfilter/IndexFilterController.java
@@ -18,6 +18,7 @@ package name.mlopatkin.andlogview.ui.indexfilter;
 
 import static name.mlopatkin.andlogview.ui.mainframe.MainFrameDependencies.FOR_MAIN_FRAME;
 
+import name.mlopatkin.andlogview.features.Features;
 import name.mlopatkin.andlogview.filters.ChildModelFilter;
 import name.mlopatkin.andlogview.filters.CompoundFilterModel;
 import name.mlopatkin.andlogview.filters.MutableFilterModel;
@@ -50,13 +51,17 @@ public class IndexFilterController extends AbstractIndexController implements Au
             DialogFactory dialogFactory,
             MutableFilterModel parentFilterModel,
             @Named(FOR_MAIN_FRAME) JTable mainTable,
+            Features features,
             @Assisted ChildModelFilter filter) {
         super(mainTable);
         this.filterModel = parentFilterModel;
 
         this.filter = filter;
+        var parent = !features.useFilterTree.isEnabled()
+                ? parentFilterModel
+                : Objects.requireNonNull(parentFilterModel.findSubModel(filter));
         logModelFilter = new IndexFilter(
-                new CompoundFilterModel(Objects.requireNonNull(parentFilterModel.findSubModel(filter)), filter));
+                new CompoundFilterModel(parent, filter));
 
         IndexFrameDi.IndexFrameComponent component = DaggerIndexFrameDi_IndexFrameComponent.builder()
                 .logRecordTableModel(logModel)

--- a/test/name/mlopatkin/andlogview/ui/filterdialog/IndexWindowFilterTest.java
+++ b/test/name/mlopatkin/andlogview/ui/filterdialog/IndexWindowFilterTest.java
@@ -44,7 +44,7 @@ class IndexWindowFilterTest {
     @Test
     void nonMatchingRecordsCannotReappearBecauseOfChildFilters() {
         var filter = createFilterForTags("ActivityManager");
-        filter.getFilters()
+        filter.getChildren()
                 .addFilter(show(r -> true));
         assertThat(asPredicate(filter))
                 .accepts(forTag("ActivityManager"))
@@ -61,7 +61,7 @@ class IndexWindowFilterTest {
     }
 
     private Predicate<LogRecord> asPredicate(IndexWindowFilter filter) {
-        var filterChain = new FilterChain(filter.getFilters());
+        var filterChain = new FilterChain(filter.getChildren());
         return filterChain::shouldShow;
     }
 }

--- a/test/name/mlopatkin/andlogview/ui/filters/IndexWindowFilterDataTest.java
+++ b/test/name/mlopatkin/andlogview/ui/filters/IndexWindowFilterDataTest.java
@@ -47,13 +47,13 @@ class IndexWindowFilterDataTest {
     void canSerializeAndDeserializeFilterWithChild() throws Exception {
         var filter = createFilter("ActivityManager", "PackageManager");
         var childFilter = createFilter("ActivityManager");
-        filter.getFilters().addFilter(childFilter);
+        filter.getChildren().addFilter(childFilter);
 
         var data = new IndexWindowFilterData(filter);
 
         var restoredFilter = roundTrip(data);
 
-        assertThatFilters(restoredFilter.getFilters()).contains(childFilter);
+        assertThatFilters(restoredFilter.getChildren()).contains(childFilter);
     }
 
     private static IndexWindowFilter createFilter(String... tags) throws RequestCompilationException {


### PR DESCRIPTION
The index filter window is now affected only by the filters that were added before it. Combined with filter reordering, this may improve the usability.

You need to enable new UI (with a listview) for this feature to work.

Fixes #164.