### PR TITLE
Use identity for filter comparisons

### DIFF
--- a/filters/build.gradle.kts
+++ b/filters/build.gradle.kts
@@ -32,5 +32,4 @@ dependencies {
     testFixturesApi(libs.test.assertj.core)
 
     testImplementation(testFixtures(project(":logmodel")))
-    testImplementation(libs.test.guavaTestlib)
 }

--- a/filters/src/main/java/name/mlopatkin/andlogview/filters/BufferFilter.java
+++ b/filters/src/main/java/name/mlopatkin/andlogview/filters/BufferFilter.java
@@ -23,7 +23,6 @@ import name.mlopatkin.andlogview.logmodel.LogRecord;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Collection;
-import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -68,19 +67,6 @@ public final class BufferFilter extends AbstractFilter<BufferFilter> implements 
 
         return new BufferFilter(allowedBuffers.stream().filter(b -> !b.equals(buffer)).collect(toImmutableSet()),
                 isEnabled());
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        return o == this || (
-                o instanceof BufferFilter that
-                        && Objects.equals(allowedBuffers, that.allowedBuffers)
-                        && isEnabled() == that.isEnabled());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(allowedBuffers, isEnabled());
     }
 
     public Set<LogRecord.Buffer> getAllowedBuffers() {

--- a/filters/src/test/java/name/mlopatkin/andlogview/filters/BufferFilterTest.java
+++ b/filters/src/test/java/name/mlopatkin/andlogview/filters/BufferFilterTest.java
@@ -27,7 +27,6 @@ import name.mlopatkin.andlogview.logmodel.LogRecord.Buffer;
 import name.mlopatkin.andlogview.logmodel.LogRecordUtils;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.testing.EqualsTester;
 
 import org.junit.jupiter.api.Test;
 
@@ -91,21 +90,6 @@ class BufferFilterTest {
 
         assertThat(filter.getAllowedBuffers()).containsOnly(Buffer.EVENTS);
         assertThat(filter.isEnabled()).isTrue();
-    }
-
-    @Test
-    void testEquality() {
-        new EqualsTester()
-                .addEqualityGroup(createFilter(), createFilter().disabled().enabled(),
-                        createFilter(Buffer.EVENTS).disallowBuffer(Buffer.EVENTS))
-                .addEqualityGroup(createFilter().disabled())
-                .addEqualityGroup(createFilter(Buffer.EVENTS), createFilter().allowBuffer(Buffer.EVENTS))
-                .addEqualityGroup(createFilter(Buffer.EVENTS).disabled(),
-                        createFilter().allowBuffer(Buffer.EVENTS).disabled())
-                .addEqualityGroup(createFilter(Buffer.MAIN), createFilter().allowBuffer(Buffer.MAIN))
-                .addEqualityGroup(createFilter(Buffer.MAIN, Buffer.EVENTS).disabled(),
-                        createFilter().allowBuffer(Buffer.MAIN).allowBuffer(Buffer.EVENTS).disabled())
-                .testEquals();
     }
 
     private BufferFilter createFilter(Buffer... buffers) {

--- a/filters/src/testFixtures/java/name/mlopatkin/andlogview/filters/AbstractToggleFilter.java
+++ b/filters/src/testFixtures/java/name/mlopatkin/andlogview/filters/AbstractToggleFilter.java
@@ -18,7 +18,6 @@ package name.mlopatkin.andlogview.filters;
 
 import name.mlopatkin.andlogview.logmodel.LogRecord;
 
-import java.util.Objects;
 import java.util.function.Predicate;
 
 public abstract class AbstractToggleFilter<T extends AbstractToggleFilter<T>> extends AbstractFilter<T>
@@ -33,17 +32,5 @@ public abstract class AbstractToggleFilter<T extends AbstractToggleFilter<T>> ex
     @Override
     public boolean test(LogRecord logRecord) {
         return predicate.test(logRecord);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(mode, predicate);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj == this
-                || (obj instanceof AbstractToggleFilter<?> filter && mode.equals(filter.mode)
-                && isEnabled() == filter.isEnabled() && predicate.equals(filter.predicate));
     }
 }

--- a/filters/src/testFixtures/java/name/mlopatkin/andlogview/filters/ColoringToggleFilter.java
+++ b/filters/src/testFixtures/java/name/mlopatkin/andlogview/filters/ColoringToggleFilter.java
@@ -21,7 +21,6 @@ import name.mlopatkin.andlogview.logmodel.LogRecord;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.awt.Color;
-import java.util.Objects;
 import java.util.function.Predicate;
 
 public class ColoringToggleFilter extends AbstractToggleFilter<ColoringToggleFilter> implements ColoringFilter {
@@ -40,15 +39,5 @@ public class ColoringToggleFilter extends AbstractToggleFilter<ColoringToggleFil
     @Override
     protected ColoringToggleFilter copy(boolean enabled) {
         return new ColoringToggleFilter(color, enabled, predicate);
-    }
-
-    @Override
-    public int hashCode() {
-        return super.hashCode() * 37 + Objects.hashCode(color);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return super.equals(obj) && (obj instanceof ColoringToggleFilter filter && Objects.equals(color, filter.color));
     }
 }

--- a/filters/src/testFixtures/java/name/mlopatkin/andlogview/filters/Filters.java
+++ b/filters/src/testFixtures/java/name/mlopatkin/andlogview/filters/Filters.java
@@ -18,8 +18,6 @@ package name.mlopatkin.andlogview.filters;
 
 import com.google.common.collect.ImmutableList;
 
-import java.util.Objects;
-
 /**
  * Helpers to create filters in tests.
  */
@@ -35,8 +33,8 @@ public final class Filters {
     }
 
     /**
-     * Creates an enabled filter with a nice {@code toString} representation based on {@code name}. Name is also used
-     * for equality checks, alongside enabled status. The returned filter doesn't implement any other interfaces.
+     * Creates an enabled filter with a nice {@code toString} representation based on {@code name}.
+     * The returned filter doesn't implement any other interfaces.
      *
      * @param name the name of the filter
      * @return the named filter
@@ -61,17 +59,6 @@ public final class Filters {
         @Override
         public String toString() {
             return name;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            return obj == this || (obj instanceof NamedFilter named && (named.isEnabled() == isEnabled())
-                    && Objects.equals(name, named.name));
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(isEnabled(), name);
         }
     }
 }

--- a/filters/src/testFixtures/java/name/mlopatkin/andlogview/filters/ToggleFilter.java
+++ b/filters/src/testFixtures/java/name/mlopatkin/andlogview/filters/ToggleFilter.java
@@ -30,16 +30,6 @@ public class ToggleFilter extends AbstractToggleFilter<ToggleFilter> {
         return new ToggleFilter(mode, enabled, predicate);
     }
 
-    @Override
-    public int hashCode() {
-        return super.hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return super.equals(obj) && obj instanceof ToggleFilter;
-    }
-
     public static ToggleFilter show(Predicate<? super LogRecord> predicate) {
         return new ToggleFilter(FilteringMode.SHOW, true, predicate);
     }

--- a/src/name/mlopatkin/andlogview/ui/filterdialog/FilterFromDialogImpl.java
+++ b/src/name/mlopatkin/andlogview/ui/filterdialog/FilterFromDialogImpl.java
@@ -74,22 +74,6 @@ public class FilterFromDialogImpl extends AbstractFilter<FilterFromDialogImpl>
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(isEnabled(), data);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == this) {
-            return true;
-        }
-        if (obj instanceof FilterFromDialogImpl that) {
-            return isEnabled() == that.isEnabled() && Objects.equals(data, that.data);
-        }
-        return false;
-    }
-
-    @Override
     public String toString() {
         return MoreObjects.toStringHelper(this).add("enabled", isEnabled()).add("data", getData()).toString();
     }

--- a/src/name/mlopatkin/andlogview/ui/filterdialog/IndexWindowFilter.java
+++ b/src/name/mlopatkin/andlogview/ui/filterdialog/IndexWindowFilter.java
@@ -28,7 +28,6 @@ import name.mlopatkin.andlogview.search.RequestCompilationException;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Collection;
-import java.util.Objects;
 import java.util.function.Predicate;
 
 public class IndexWindowFilter extends AbstractFilter<IndexWindowFilter> implements FilterFromDialog, ChildModelFilter {
@@ -88,21 +87,5 @@ public class IndexWindowFilter extends AbstractFilter<IndexWindowFilter> impleme
     @Override
     public MutableFilterModel getChildren() {
         return model;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(isEnabled(), filterData);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == this) {
-            return true;
-        }
-        if (obj instanceof IndexWindowFilter that) {
-            return that.isEnabled() == isEnabled() && Objects.equals(that.filterData, filterData);
-        }
-        return false;
     }
 }

--- a/test/name/mlopatkin/andlogview/filters/FilterChainTest.java
+++ b/test/name/mlopatkin/andlogview/filters/FilterChainTest.java
@@ -66,16 +66,18 @@ public class FilterChainTest {
 
     @Test
     public void testRemoveFilter() throws Exception {
-        model.addFilter(hide(MATCH_ALL));
-        model.removeFilter(hide(MATCH_ALL));
+        var filter = hide(MATCH_ALL);
+        model.addFilter(filter);
+        model.removeFilter(filter);
         assertTrue(chain.shouldShow(RECORD1));
         assertTrue(chain.shouldShow(RECORD2));
     }
 
     @Test
     public void testReplace() throws Exception {
-        model.addFilter(hide(MATCH_ALL));
-        model.replaceFilter(hide(MATCH_ALL), hide(MATCH_FIRST));
+        var filter1 = hide(MATCH_ALL);
+        model.addFilter(filter1);
+        model.replaceFilter(filter1, hide(MATCH_FIRST));
 
         assertFalse(chain.shouldShow(RECORD1));
         assertTrue(chain.shouldShow(RECORD2));
@@ -83,12 +85,14 @@ public class FilterChainTest {
 
     @Test
     public void testSetEnabled() throws Exception {
-        model.addFilter(hide(MATCH_FIRST));
-        model.replaceFilter(hide(MATCH_FIRST), hide(MATCH_FIRST).disabled());
+        var filter1 = hide(MATCH_FIRST);
+        var filter2 = filter1.disabled();
+        model.addFilter(filter1);
+        model.replaceFilter(filter1, filter2);
 
         assertTrue(chain.shouldShow(RECORD1));
         assertTrue(chain.shouldShow(RECORD2));
-        model.replaceFilter(hide(MATCH_FIRST).disabled(), hide(MATCH_FIRST));
+        model.replaceFilter(filter2, filter1);
         assertFalse(chain.shouldShow(RECORD1));
         assertTrue(chain.shouldShow(RECORD2));
     }

--- a/test/name/mlopatkin/andlogview/filters/LogRecordHighlighterTest.java
+++ b/test/name/mlopatkin/andlogview/filters/LogRecordHighlighterTest.java
@@ -114,10 +114,11 @@ public class LogRecordHighlighterTest {
     @Test
     public void testEnable() throws Exception {
         model.addFilter(MATCH_FIRST_COLOR1);
-        model.replaceFilter(MATCH_FIRST_COLOR1, MATCH_FIRST_COLOR1.disabled());
+        var disabled = MATCH_FIRST_COLOR1.disabled();
+        model.replaceFilter(MATCH_FIRST_COLOR1, disabled);
         assertNull(highlighter.getColor(RECORD1));
 
-        model.replaceFilter(MATCH_FIRST_COLOR1.disabled(), MATCH_FIRST_COLOR1.enabled());
+        model.replaceFilter(disabled, MATCH_FIRST_COLOR1.enabled());
         assertEquals(COLOR1, highlighter.getColor(RECORD1));
     }
 
@@ -128,8 +129,9 @@ public class LogRecordHighlighterTest {
 
         assertEquals(COLOR1, highlighter.getColor(RECORD1));
 
-        model.replaceFilter(MATCH_FIRST_COLOR2, MATCH_FIRST_COLOR2.disabled());
-        model.replaceFilter(MATCH_FIRST_COLOR2.disabled(), MATCH_FIRST_COLOR2.enabled());
+        var disabled = MATCH_FIRST_COLOR2.disabled();
+        model.replaceFilter(MATCH_FIRST_COLOR2, disabled);
+        model.replaceFilter(disabled, MATCH_FIRST_COLOR2.enabled());
 
         assertEquals(COLOR1, highlighter.getColor(RECORD1));
     }

--- a/test/name/mlopatkin/andlogview/ui/filters/IndexWindowFilterDataTest.java
+++ b/test/name/mlopatkin/andlogview/ui/filters/IndexWindowFilterDataTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import name.mlopatkin.andlogview.config.Utils;
 import name.mlopatkin.andlogview.filters.FilteringMode;
 import name.mlopatkin.andlogview.search.RequestCompilationException;
+import name.mlopatkin.andlogview.ui.filterdialog.FilterFromDialog;
 import name.mlopatkin.andlogview.ui.filterdialog.FilterFromDialogData;
 import name.mlopatkin.andlogview.ui.filterdialog.IndexWindowFilter;
 
@@ -30,6 +31,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
 
 class IndexWindowFilterDataTest {
     @Test
@@ -53,7 +56,15 @@ class IndexWindowFilterDataTest {
 
         var restoredFilter = roundTrip(data);
 
-        assertThatFilters(restoredFilter.getChildren()).contains(childFilter);
+        // A first element of a child filter is always
+        assertThatFilters(restoredFilter.getChildren()).satisfiesExactly(
+                first -> assertThat(first.getMode()).isEqualTo(FilteringMode.HIDE),
+                second -> assertThat(second).matches(restoredChild ->
+                        (restoredChild instanceof FilterFromDialog ffd)
+                                && ffd.isEnabled() == childFilter.isEnabled()
+                                && Objects.equals(ffd.getData(), childFilter.getData())
+                )
+        );
     }
 
     private static IndexWindowFilter createFilter(String... tags) throws RequestCompilationException {

--- a/test/name/mlopatkin/andlogview/ui/filters/SavedDialogFilterDataTest.java
+++ b/test/name/mlopatkin/andlogview/ui/filters/SavedDialogFilterDataTest.java
@@ -46,9 +46,8 @@ class SavedDialogFilterDataTest {
 
         var deserialized = roundTrip(original);
 
-        assertThat(deserialized).isEqualTo(original);
         assertThat(deserialized.isEnabled()).isEqualTo(isFilterEnabled);
-        assertThat(deserialized.getData().getTags()).singleElement().isEqualTo(tagPattern);
+        assertThat(deserialized.getData()).isEqualTo(original.getData());
 
         assertThat(((PredicateFilter) deserialized).test(TestData.RECORD1)).isEqualTo(expectedMatch);
     }


### PR DESCRIPTION
This allows to have duplicate filters in model and avoids some nasty situations when none-identical filters become identical after editing or toggling.

Thinking more about it, it makes sense to have two index filters with the same filters, but different positions, because they are position-sensitive now.

Issue: fixes #372, fixes #389