### PR TITLE
Remove old Log4j 1.2 dependency

### DIFF
--- a/base/build.gradle.kts
+++ b/base/build.gradle.kts
@@ -27,7 +27,7 @@ description = "Common utilities that every other model can use"
 dependencies {
     api(libs.dagger.runtime)
 
-    implementation(libs.log4j)
+    implementation(libs.slf4j.api)
 
     testFixturesApi(platform(libs.test.assertj.bom))
     testFixturesApi(libs.test.assertj.core)

--- a/base/src/main/java/name/mlopatkin/andlogview/base/AtExitManager.java
+++ b/base/src/main/java/name/mlopatkin/andlogview/base/AtExitManager.java
@@ -16,7 +16,8 @@
 
 package name.mlopatkin.andlogview.base;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +30,7 @@ import javax.inject.Singleton;
  */
 @Singleton
 public class AtExitManager {
-    private static final Logger logger = Logger.getLogger(AtExitManager.class);
+    private static final Logger logger = LoggerFactory.getLogger(AtExitManager.class);
 
     private final List<Runnable> actions = new ArrayList<>();
     private final Thread atExitWorker = new Thread(this::onExit, "AtExitWorker");

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,8 +51,11 @@ dependencies {
     implementation(libs.flatlaf.extras)
     implementation(libs.gson)
     implementation(libs.jopt)
+    implementation(libs.slf4j.api)
     implementation(libs.log4j)
     implementation(libs.miglayout)
+
+    runtimeOnly(libs.slf4j.reload4j)
 
     annotationProcessor(buildLibs.dagger.compiler)
 

--- a/device/build.gradle.kts
+++ b/device/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     implementation(project(":base"))
     implementation(libs.ddmlib)
     implementation(libs.gson)
-    implementation(libs.log4j)
+    implementation(libs.slf4j.api)
 
     testFixturesApi(libs.test.hamcrest.hamcrest)
     testFixturesImplementation(testFixtures(project(":base")))

--- a/device/src/main/java/name/mlopatkin/andlogview/device/AdbManagerImpl.java
+++ b/device/src/main/java/name/mlopatkin/andlogview/device/AdbManagerImpl.java
@@ -23,15 +23,16 @@ import com.android.ddmlib.DdmPreferences;
 import com.android.ddmlib.Log;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Executor;
 
 class AdbManagerImpl implements AdbManager {
     // AdbManagerImpl is responsible for the state of the DDMLIB as a whole. The manager lazily initializes the library
     // when the AdbServer is first requested.
-    private static final Logger logger = Logger.getLogger(AdbManagerImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(AdbManagerImpl.class);
 
     private final AtExitManager atExitManager;
     private final Executor ioExecutor;

--- a/device/src/main/java/name/mlopatkin/andlogview/device/AdbServerImpl.java
+++ b/device/src/main/java/name/mlopatkin/andlogview/device/AdbServerImpl.java
@@ -23,8 +23,9 @@ import com.android.ddmlib.IDevice;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,7 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 class AdbServerImpl implements AdbServer {
     // AdbServerImpl wraps the current connection to the adb server. The connection cannot be replaced within the same
     // server instance, a new server instance should be created instead.
-    private static final Logger logger = Logger.getLogger(AdbServerImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(AdbServerImpl.class);
     private final AdbFacade adbFacade;
     private final DeviceProvisioner deviceProvisioner;
 
@@ -54,7 +55,7 @@ class AdbServerImpl implements AdbServer {
         File adbExecutable = adbLocation.getExecutable()
                 .orElseThrow(
                         () -> new AdbException("ADB location '" + adbLocation.getExecutableString() + "' is invalid"));
-        logger.debug("ADB server executable: " + adbExecutable.getAbsolutePath());
+        logger.debug("ADB server executable: {}", adbExecutable.getAbsolutePath());
         final @Nullable AndroidDebugBridge bridge;
         try {
             bridge = AndroidDebugBridge.createBridge(adbExecutable.getAbsolutePath(), false);

--- a/device/src/main/java/name/mlopatkin/andlogview/device/CommandImpl.java
+++ b/device/src/main/java/name/mlopatkin/andlogview/device/CommandImpl.java
@@ -24,14 +24,15 @@ import com.android.ddmlib.CollectingOutputReceiver;
 import com.android.ddmlib.IDevice;
 import com.android.ddmlib.MultiLineReceiver;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
 
 class CommandImpl implements Command {
-    private static final Logger logger = Logger.getLogger(CommandImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(CommandImpl.class);
 
     private final IDevice device;
     private final List<String> commandLine;
@@ -66,7 +67,7 @@ class CommandImpl implements Command {
             CollectingOutputReceiver exitCodeReceiver = new CollectingOutputReceiver();
             DeviceUtils.executeShellCommand(device, commandLineWithRedirects, exitCodeReceiver);
             String exitCode = exitCodeReceiver.getOutput().trim();
-            logger.debug("exit code output=" + exitCode);
+            logger.debug("exit code output={}", exitCode);
 
             return new Result(exitCode);
         }

--- a/device/src/main/java/name/mlopatkin/andlogview/device/DdmlibToLog4jWrapper.java
+++ b/device/src/main/java/name/mlopatkin/andlogview/device/DdmlibToLog4jWrapper.java
@@ -18,10 +18,11 @@ package name.mlopatkin.andlogview.device;
 import com.android.ddmlib.Log.ILogOutput;
 import com.android.ddmlib.Log.LogLevel;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class DdmlibToLog4jWrapper implements ILogOutput {
-    private static final Logger logger = Logger.getLogger("DDMLIB");
+    private static final Logger logger = LoggerFactory.getLogger("DDMLIB");
 
     @Override
     public void printLog(LogLevel logLevel, String tag, String message) {

--- a/device/src/main/java/name/mlopatkin/andlogview/device/DispatchingDeviceList.java
+++ b/device/src/main/java/name/mlopatkin/andlogview/device/DispatchingDeviceList.java
@@ -31,8 +31,9 @@ import com.google.common.collect.Iterables;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -42,7 +43,7 @@ import java.util.List;
  * This is the primary dispatcher for AdbDeviceList implementations.
  */
 class DispatchingDeviceList implements AdbDeviceList {
-    private static final Logger logger = Logger.getLogger(DispatchingDeviceList.class);
+    private static final Logger logger = LoggerFactory.getLogger(DispatchingDeviceList.class);
 
     private final AdbFacade adb;
     private final DeviceProvisioner deviceProvisioner;

--- a/device/src/main/java/name/mlopatkin/andlogview/device/LoggingDevice.java
+++ b/device/src/main/java/name/mlopatkin/andlogview/device/LoggingDevice.java
@@ -22,7 +22,8 @@ import com.android.ddmlib.IShellOutputReceiver;
 import com.android.ddmlib.ShellCommandUnresponsiveException;
 import com.android.ddmlib.TimeoutException;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -31,7 +32,7 @@ import java.util.concurrent.TimeUnit;
  * Delegating IDevice wrapper that logs essential commands.
  */
 class LoggingDevice extends DelegatingDevice {
-    private static final Logger logger = Logger.getLogger(LoggingDevice.class);
+    private static final Logger logger = LoggerFactory.getLogger(LoggingDevice.class);
 
     private final String logPrefix;
 
@@ -73,6 +74,6 @@ class LoggingDevice extends DelegatingDevice {
     }
 
     private void debug(String message) {
-        logger.debug(logPrefix + message);
+        logger.debug("{}{}", logPrefix, message);
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,9 +27,12 @@ flatlaf-extras = { module = "com.formdev:flatlaf-extras", version.ref = "flatlaf
 gson = "com.google.code.gson:gson:2.10.1"
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 jopt = "net.sf.jopt-simple:jopt-simple:5.0.4"
-log4j = "log4j:log4j:1.2.17"
+# Reload4j is a drop-in replacement for log4j 1.x
+log4j = "ch.qos.reload4j:reload4j:1.2.26"
 # MigLayout 11.x requires Java 11, so we stick with 5.x for now.
 miglayout = "com.miglayout:miglayout-swing:5.3"
+slf4j-api = "org.slf4j:slf4j-api:2.0.16"
+slf4j-reload4j = "org.slf4j:slf4j-reload4j:2.0.16"
 test-assertj-bom = "org.assertj:assertj-bom:3.24.2"
 test-assertj-core = { module = "org.assertj:assertj-core" }
 test-assertj-guava = { module = "org.assertj:assertj-guava" }

--- a/parsers/build.gradle.kts
+++ b/parsers/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 dependencies {
     api(project(":logmodel"))
     implementation(project(":base"))
-    implementation(libs.log4j)
+    implementation(libs.slf4j.api)
 
     testFixturesApi(platform(libs.test.junit5.bom))
     testFixturesApi(libs.test.junit5.jupiter)

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/dumpstate/LogcatSectionHandler.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/dumpstate/LogcatSectionHandler.java
@@ -23,11 +23,13 @@ import name.mlopatkin.andlogview.parsers.logcat.LogcatFormatSniffer;
 import name.mlopatkin.andlogview.parsers.logcat.LogcatParsers;
 import name.mlopatkin.andlogview.parsers.logcat.LogcatPushParser;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class LogcatSectionHandler implements SectionHandler {
-    private static final Logger logger = Logger.getLogger(LogcatSectionHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(LogcatSectionHandler.class);
+
     private static final int MAX_LOOKAHEAD_LINES = 128;
 
     private final ReplayParser<LogcatFormatSniffer> replayParser;
@@ -58,7 +60,7 @@ class LogcatSectionHandler implements SectionHandler {
             LogcatFormatSniffer formatSniffer = replayParser.getDelegate();
             if (formatSniffer.isFormatDetected()) {
                 boolean shouldProceed = eventsHandler.logcatSectionBegin(buffer).map(h -> {
-                    logger.debug("Detected format " + formatSniffer.getDetectedFormatDescription() + " for " + buffer);
+                    logger.debug("Detected format {} for {}", formatSniffer.getDetectedFormatDescription(), buffer);
                     delegate = formatSniffer.createParser(h);
                     return replayParser.replayInto(delegate);
                 }).orElse(false);

--- a/src/name/mlopatkin/andlogview/FileTransferHandler.java
+++ b/src/name/mlopatkin/andlogview/FileTransferHandler.java
@@ -15,7 +15,8 @@
  */
 package name.mlopatkin.andlogview;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
@@ -27,7 +28,7 @@ import java.util.List;
 import javax.swing.TransferHandler;
 
 public class FileTransferHandler extends TransferHandler {
-    private static final Logger logger = Logger.getLogger(FileTransferHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(FileTransferHandler.class);
     private final MainFrame frame;
 
     public FileTransferHandler(MainFrame frame) {
@@ -50,7 +51,7 @@ public class FileTransferHandler extends TransferHandler {
             @SuppressWarnings("unchecked")
             List<File> l = (List<File>) t.getTransferData(DataFlavor.javaFileListFlavor);
             File file = l.get(0);
-            logger.debug("Start importing " + file);
+            logger.debug("Start importing {}", file);
 
             frame.openFile(file);
         } catch (UnsupportedFlavorException | IOException e) {

--- a/src/name/mlopatkin/andlogview/GlobalsModule.java
+++ b/src/name/mlopatkin/andlogview/GlobalsModule.java
@@ -22,7 +22,8 @@ import name.mlopatkin.andlogview.utils.SystemPathResolver;
 import dagger.Module;
 import dagger.Provides;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,7 +32,7 @@ import javax.inject.Singleton;
 
 @Module
 public class GlobalsModule {
-    private static final Logger logger = Logger.getLogger(GlobalsModule.class);
+    private static final Logger logger = LoggerFactory.getLogger(GlobalsModule.class);
 
     private final File appConfigDir;
 
@@ -45,7 +46,7 @@ public class GlobalsModule {
         try {
             return factory.createForFile(new File(appConfigDir, "logview.json"));
         } catch (IOException e) {
-            logger.fatal("Cannot start at all", e);
+            logger.error("Cannot start at all", e);
             System.exit(-1);
             // Dummy return that won't happen because of System.exit
             throw new AssertionError("System.exit not working");

--- a/src/name/mlopatkin/andlogview/Main.java
+++ b/src/name/mlopatkin/andlogview/Main.java
@@ -23,7 +23,8 @@ import name.mlopatkin.andlogview.utils.properties.PropertyUtils;
 
 import com.formdev.flatlaf.util.SystemInfo;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.awt.EventQueue;
 import java.io.File;
@@ -33,7 +34,7 @@ import javax.inject.Provider;
 import javax.swing.JOptionPane;
 
 public class Main {
-    private static final Logger logger = Logger.getLogger(Main.class);
+    private static final Logger logger = LoggerFactory.getLogger(Main.class);
 
     private static final String THEME_SYSTEM_PROPERTY = "name.mlopatkin.andlogview.theme";
 
@@ -69,8 +70,8 @@ public class Main {
                 commandLine,
                 theme);
 
-        logger.info(APP_NAME + " " + getVersionString());
-        logger.info("Revision " + BuildInfo.REVISION);
+        logger.info("{} {}", APP_NAME, getVersionString());
+        logger.info("Revision {}", BuildInfo.REVISION);
 
         EventQueue.invokeLater(() -> globals.getMain().start(configurationState));
     }
@@ -141,7 +142,7 @@ public class Main {
 
     private static void uncaughtHandler(Thread thread, Throwable throwable) {
         try {
-            logger.error("Uncaught exception in " + thread.getName(), throwable);
+            logger.error("Uncaught exception in {}", thread.getName(), throwable);
             ErrorDialogsHelper.showError(null,
                     "<html>Unhandled exception occured. Please collect log file at<br>"
                             + new File(SystemUtils.getJavaIoTmpDir(), "logview.log").getAbsolutePath()

--- a/src/name/mlopatkin/andlogview/MainFrame.java
+++ b/src/name/mlopatkin/andlogview/MainFrame.java
@@ -64,8 +64,9 @@ import name.mlopatkin.andlogview.widgets.UiHelper;
 
 import com.google.common.io.Files;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
@@ -105,7 +106,7 @@ import javax.swing.KeyStroke;
 import javax.swing.TransferHandler;
 
 public class MainFrame implements MainFrameSearchUi, DeviceDisconnectedHandler.DeviceAwaiter {
-    private static final Logger logger = Logger.getLogger(MainFrame.class);
+    private static final Logger logger = LoggerFactory.getLogger(MainFrame.class);
 
     private static final KeyStroke KEY_HIDE = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
     private static final KeyStroke KEY_SHOW_SEARCH_FIELD = UiHelper.createPlatformKeystroke(KeyEvent.VK_F);

--- a/src/name/mlopatkin/andlogview/config/ConfigStorageImpl.java
+++ b/src/name/mlopatkin/andlogview/config/ConfigStorageImpl.java
@@ -29,7 +29,8 @@ import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.stream.JsonWriter;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -46,7 +47,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
 class ConfigStorageImpl implements ConfigStorage {
-    private static final Logger logger = Logger.getLogger(ConfigStorageImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(ConfigStorageImpl.class);
 
     private final Gson gson;
     private final CharSource inStorage;
@@ -150,7 +151,7 @@ class ConfigStorageImpl implements ConfigStorage {
     public <T> void saveConfig(ConfigStorageClient<T> client, T value) {
         String name = client.getName();
         JsonElement json = client.toJson(gson, value);
-        logger.debug("Client " + name + " changed the config");
+        logger.debug("Client {} changed the config", name);
         synchronized (serializedConfig) {
             serializedConfig.put(name, json);
             scheduleCommitLocked();
@@ -177,7 +178,7 @@ class ConfigStorageImpl implements ConfigStorage {
                     scheduleCommitLocked();
                 }
             }
-            logger.error("Failed to parse config data of " + client.getName(), e);
+            logger.error("Failed to parse config data of {}", client.getName(), e);
         }
         // failed to load/parse, provide fallback
         return client.getDefault();

--- a/src/name/mlopatkin/andlogview/config/Configuration.java
+++ b/src/name/mlopatkin/andlogview/config/Configuration.java
@@ -37,8 +37,9 @@ import name.mlopatkin.andlogview.utils.properties.SynchronizedConfiguration;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.awt.Color;
 import java.awt.Point;
@@ -168,7 +169,7 @@ public class Configuration {
         }
     }
 
-    private static final Logger logger = Logger.getLogger(Configuration.class);
+    private static final Logger logger = LoggerFactory.getLogger(Configuration.class);
 
     private Configuration() {}
 

--- a/src/name/mlopatkin/andlogview/config/Utils.java
+++ b/src/name/mlopatkin/andlogview/config/Utils.java
@@ -22,7 +22,8 @@ import name.mlopatkin.andlogview.utils.properties.Parser;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.awt.Color;
 import java.io.BufferedInputStream;
@@ -34,7 +35,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 public class Utils {
-    private static final Logger logger = Logger.getLogger(Configuration.class);
+    @SuppressWarnings("LoggerInitializedWithForeignClass")
+    private static final Logger logger = LoggerFactory.getLogger(Configuration.class);
 
     private Utils() {}
 

--- a/src/name/mlopatkin/andlogview/liblogcat/ddmlib/AdbBuffer.java
+++ b/src/name/mlopatkin/andlogview/liblogcat/ddmlib/AdbBuffer.java
@@ -24,7 +24,8 @@ import name.mlopatkin.andlogview.parsers.logcat.Format;
 import name.mlopatkin.andlogview.parsers.logcat.LogcatParsers;
 import name.mlopatkin.andlogview.utils.Threads;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Map;
@@ -41,7 +42,7 @@ class AdbBuffer {
         void pushRecord(LogRecord record);
     }
 
-    private static final Logger logger = Logger.getLogger(AdbBuffer.class);
+    private static final Logger logger = LoggerFactory.getLogger(AdbBuffer.class);
     private static final Format FORMAT = Format.LONG;
 
     private final BufferReceiver receiver;
@@ -78,7 +79,7 @@ class AdbBuffer {
 
             @Override
             public ParserControl unparseableLine(CharSequence line) {
-                logger.debug("Non-parsed line: " + line);
+                logger.debug("Non-parsed line: {}", line);
                 return ParserControl.proceed();
             }
         };

--- a/src/name/mlopatkin/andlogview/liblogcat/ddmlib/AdbDataSource.java
+++ b/src/name/mlopatkin/andlogview/liblogcat/ddmlib/AdbDataSource.java
@@ -29,8 +29,9 @@ import name.mlopatkin.andlogview.utils.events.Observable;
 import name.mlopatkin.andlogview.utils.events.ScopedObserver;
 import name.mlopatkin.andlogview.utils.events.Subject;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -64,7 +65,7 @@ public class AdbDataSource implements DataSource, BufferReceiver {
         default void onDataSourceClosed() {}
     }
 
-    private static final Logger logger = Logger.getLogger(AdbDataSource.class);
+    private static final Logger logger = LoggerFactory.getLogger(AdbDataSource.class);
 
     private final Device device;
     private final AdbPidToProcessConverter converter;
@@ -89,14 +90,14 @@ public class AdbDataSource implements DataSource, BufferReceiver {
         deviceChangeObserver = device.asObservable().addScopedObserver(new DeviceChangeObserver() {
             @Override
             public void onDeviceDisconnected(ProvisionalDevice device) {
-                logger.debug("Device " + device.getSerialNumber() + " was disconnected, closing the source");
+                logger.debug("Device {} was disconnected, closing the source", device.getSerialNumber());
                 invalidateAndClose(InvalidationReason.DISCONNECT);
             }
 
             @Override
             public void onDeviceChanged(Device device) {
                 if (!device.isOnline()) {
-                    logger.debug("Device " + device.getSerialNumber() + " is offline, closing the source");
+                    logger.debug("Device {} is offline, closing the source", device.getSerialNumber());
                     invalidateAndClose(InvalidationReason.OFFLINE);
                 }
             }

--- a/src/name/mlopatkin/andlogview/liblogcat/ddmlib/AdbPidToProcessConverter.java
+++ b/src/name/mlopatkin/andlogview/liblogcat/ddmlib/AdbPidToProcessConverter.java
@@ -25,8 +25,9 @@ import name.mlopatkin.andlogview.utils.Threads;
 
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Map;
@@ -36,7 +37,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 class AdbPidToProcessConverter {
-    private static final Logger logger = Logger.getLogger(AdbPidToProcessConverter.class);
+    private static final Logger logger = LoggerFactory.getLogger(AdbPidToProcessConverter.class);
 
     private static final String[] PS_COMMAND_LINE = {"ps"};
     private static final String[] PS_COMMAND_LINE_API_26 = {"ps", "-A"};
@@ -90,7 +91,7 @@ class AdbPidToProcessConverter {
 
             @Override
             public ParserControl unparseableLine(CharSequence line) {
-                logger.debug("Failed to parse line: " + line);
+                logger.debug("Failed to parse line: {}", line);
                 return ParserControl.proceed();
             }
         };

--- a/src/name/mlopatkin/andlogview/liblogcat/ddmlib/LogcatCommand.java
+++ b/src/name/mlopatkin/andlogview/liblogcat/ddmlib/LogcatCommand.java
@@ -24,7 +24,8 @@ import name.mlopatkin.andlogview.device.OutputTarget;
 import name.mlopatkin.andlogview.logmodel.LogRecord;
 import name.mlopatkin.andlogview.parsers.logcat.Format;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -34,7 +35,7 @@ import java.util.function.Consumer;
  * Represents various flavors of {@code adb logcat -b buffer} command.
  */
 class LogcatCommand {
-    private static final Logger logger = Logger.getLogger(LogcatCommand.class);
+    private static final Logger logger = LoggerFactory.getLogger(LogcatCommand.class);
 
     private final Device device;
     private final String bufferName;

--- a/src/name/mlopatkin/andlogview/liblogcat/file/DumpstateFileDataSource.java
+++ b/src/name/mlopatkin/andlogview/liblogcat/file/DumpstateFileDataSource.java
@@ -32,8 +32,9 @@ import name.mlopatkin.andlogview.parsers.logcat.CollectingHandler;
 import name.mlopatkin.andlogview.parsers.logcat.LogcatParseEventsHandler;
 import name.mlopatkin.andlogview.parsers.ps.PsParseEventsHandler;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,7 +49,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 public final class DumpstateFileDataSource implements DataSource {
-    private static final Logger logger = Logger.getLogger(DumpstateFileDataSource.class);
+    private static final Logger logger = LoggerFactory.getLogger(DumpstateFileDataSource.class);
 
     private final String fileName;
     private final SourceMetadata sourceMetadata;
@@ -149,7 +150,7 @@ public final class DumpstateFileDataSource implements DataSource {
                         @Override
                         public ParserControl unparseableLine(CharSequence line) {
                             if (line.length() > 0) {
-                                logger.debug("Failed to parse dumpstate logcat line: " + line);
+                                logger.debug("Failed to parse dumpstate logcat line: {}", line);
                             }
                             return ParserControl.proceed();
                         }
@@ -169,7 +170,7 @@ public final class DumpstateFileDataSource implements DataSource {
                         @Override
                         public ParserControl unparseableLine(CharSequence line) {
                             psSectionHadUnparseableLines = true;
-                            logger.debug("Failed to parse ps output line: " + line);
+                            logger.debug("Failed to parse ps output line: {}", line);
                             return ParserControl.proceed();
                         }
                     });

--- a/src/name/mlopatkin/andlogview/liblogcat/file/FileDataSourceFactory.java
+++ b/src/name/mlopatkin/andlogview/liblogcat/file/FileDataSourceFactory.java
@@ -28,14 +28,15 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.CharSource;
 import com.google.common.io.Files;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 public class FileDataSourceFactory {
-    private static final Logger logger = Logger.getLogger(FileDataSourceFactory.class);
+    private static final Logger logger = LoggerFactory.getLogger(FileDataSourceFactory.class);
     private static final int MAX_LOOKAHEAD_LINES = 100;
 
     private FileDataSourceFactory() {}
@@ -58,10 +59,10 @@ public class FileDataSourceFactory {
                 while ((line = in.readLine()) != null) {
                     boolean parserStopped = !parser.nextLine(line);
                     if (dumpstateSniffer.isFormatDetected()) {
-                        logger.debug("Recognized " + file + " as a dumpstate data");
+                        logger.debug("Recognized {} as a dumpstate data", file);
                         return createDumpstateFileSource(file, dumpstateSniffer, parser, in);
                     } else if (logcatSniffer.isFormatDetected()) {
-                        logger.debug("Recognized " + file + " as a logcat data");
+                        logger.debug("Recognized {} as a logcat data", file);
                         return createLogFileSource(file, logcatSniffer, parser, in);
                     }
                     if (parserStopped) {

--- a/src/name/mlopatkin/andlogview/preferences/WindowsPositionsPref.java
+++ b/src/name/mlopatkin/andlogview/preferences/WindowsPositionsPref.java
@@ -31,8 +31,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.EnumMap;
@@ -64,7 +65,7 @@ public class WindowsPositionsPref {
         }
     }
 
-    private static final Logger logger = Logger.getLogger(WindowsPositionsPref.class);
+    private static final Logger logger = LoggerFactory.getLogger(WindowsPositionsPref.class);
 
     private static final ConfigStorageClient<Map<Frame, FrameInfo>> STORAGE_CLIENT =
             new NamedClient<>("windows") {
@@ -85,7 +86,7 @@ public class WindowsPositionsPref {
                                         gson.fromJson(frameData, FrameInfoSerialized.class);
                                 result.put(frame, frameInfoSerialized.tryDeserialize());
                             } catch (JsonSyntaxException | InvalidJsonContentException e) {
-                                logger.error("Incorrect entry for frame " + frame, e);
+                                logger.error("Incorrect entry for frame {}", frame, e);
                             }
                         }
                     }

--- a/src/name/mlopatkin/andlogview/ui/device/AdbServicesBridge.java
+++ b/src/name/mlopatkin/andlogview/ui/device/AdbServicesBridge.java
@@ -39,8 +39,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Stopwatch;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -62,7 +63,7 @@ public class AdbServicesBridge implements AdbServicesStatus {
     // device selection or the actual logcat retrieval. Moreover, ADB initialization code shows error dialogs if
     // something goes wrong, so it has some UI dependency already. If this becomes problematic then the class may be
     // split into two in the future.
-    private static final Logger logger = Logger.getLogger(AdbServicesBridge.class);
+    private static final Logger logger = LoggerFactory.getLogger(AdbServicesBridge.class);
 
     private final AdbManager adbManager;
     private final AdbConfigurationPref adbConfigurationPref;
@@ -154,7 +155,7 @@ public class AdbServicesBridge implements AdbServicesStatus {
             // Our initialization was cancelled by this point. We shouldn't propagate notifications further.
             return;
         }
-        logger.info("Initialized adb server in " + timeTracing.elapsed(TimeUnit.MILLISECONDS) + "ms");
+        logger.info("Initialized adb server in {}ms", timeTracing.elapsed(TimeUnit.MILLISECONDS));
         if (maybeFailure != null) {
             logger.error("Failed to initialize ADB", maybeFailure);
             notifyStatusChange(StatusValue.failed(getAdbFailureString(maybeFailure)));

--- a/src/name/mlopatkin/andlogview/ui/device/DeviceListModel.java
+++ b/src/name/mlopatkin/andlogview/ui/device/DeviceListModel.java
@@ -23,7 +23,8 @@ import name.mlopatkin.andlogview.device.ProvisionalDevice;
 
 import com.google.common.collect.Iterables;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +33,7 @@ import java.util.Objects;
 import javax.swing.AbstractListModel;
 
 class DeviceListModel extends AbstractListModel<ProvisionalDevice> implements DeviceChangeObserver {
-    private static final Logger logger = Logger.getLogger(DeviceListModel.class);
+    private static final Logger logger = LoggerFactory.getLogger(DeviceListModel.class);
 
     private final AdbDeviceList adbDeviceList;
     private final List<ProvisionalDevice> devices;
@@ -54,7 +55,7 @@ class DeviceListModel extends AbstractListModel<ProvisionalDevice> implements De
 
     @Override
     public void onProvisionalDeviceConnected(ProvisionalDevice device) {
-        logger.debug("provisional device added " + device);
+        logger.debug("provisional device added {}", device);
         assert findIndexOfDevice(device) < 0;
         devices.add(device);
         fireIntervalAdded(this, devices.size() - 1, devices.size() - 1);
@@ -62,7 +63,7 @@ class DeviceListModel extends AbstractListModel<ProvisionalDevice> implements De
 
     @Override
     public void onDeviceConnected(Device device) {
-        logger.debug("device provisioned " + device);
+        logger.debug("device provisioned {}", device);
         int index = findIndexOfDevice(device);
         if (index >= 0) {
             devices.set(index, device);
@@ -75,7 +76,7 @@ class DeviceListModel extends AbstractListModel<ProvisionalDevice> implements De
 
     @Override
     public void onDeviceDisconnected(ProvisionalDevice device) {
-        logger.debug("device removed " + device);
+        logger.debug("device removed {}", device);
         int index = findIndexOfDevice(device);
         if (index >= 0) {
             devices.remove(index);
@@ -85,7 +86,7 @@ class DeviceListModel extends AbstractListModel<ProvisionalDevice> implements De
 
     @Override
     public void onDeviceChanged(Device device) {
-        logger.debug("Device changed: " + device);
+        logger.debug("Device changed: {}", device);
         int index = findIndexOfDevice(device);
         assert index >= 0;
         fireContentsChanged(DeviceListModel.this, index, index);

--- a/src/name/mlopatkin/andlogview/ui/device/DumpDevicePresenter.java
+++ b/src/name/mlopatkin/andlogview/ui/device/DumpDevicePresenter.java
@@ -25,8 +25,9 @@ import name.mlopatkin.andlogview.ui.mainframe.DialogFactory;
 
 import com.google.common.io.Files;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.concurrent.Executor;
@@ -39,7 +40,7 @@ import javax.swing.JOptionPane;
  * This presenter handles "Dump Device..." menu command.
  */
 public class DumpDevicePresenter {
-    private static final Logger logger = Logger.getLogger(DumpDevicePresenter.class);
+    private static final Logger logger = LoggerFactory.getLogger(DumpDevicePresenter.class);
 
     private final DialogFactory dialogFactory;
     private final DeviceDumpFactory dumpFactory;

--- a/src/name/mlopatkin/andlogview/ui/file/FileOpener.java
+++ b/src/name/mlopatkin/andlogview/ui/file/FileOpener.java
@@ -29,8 +29,9 @@ import name.mlopatkin.andlogview.ui.mainframe.DialogFactory;
 import name.mlopatkin.andlogview.utils.CommonChars;
 import name.mlopatkin.andlogview.utils.TextUtils;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,7 +46,7 @@ import javax.swing.JOptionPane;
  * properly.
  */
 public class FileOpener {
-    private static final Logger logger = Logger.getLogger(FileOpener.class);
+    private static final Logger logger = LoggerFactory.getLogger(FileOpener.class);
     private static final int MAX_PROBLEMS_DISPLAYED = 10;
 
     private final DialogFactory dialogFactory;
@@ -100,11 +101,11 @@ public class FileOpener {
             showImportProblemsIfNeeded(importResult.getProblems());
             return CompletableFuture.completedFuture(importResult.getDataSource());
         } catch (UnrecognizedFormatException e) {
-            logger.error("Unrecognized file format for " + file, e);
+            logger.error("Unrecognized file format for {}", file, e);
             ErrorDialogsHelper.showError(dialogFactory.getOwner(), "Unrecognized file format for " + file);
             return failedFuture(e);
         } catch (IOException e) {
-            logger.error("Cannot open " + file, e);
+            logger.error("Cannot open {}", file, e);
             ErrorDialogsHelper.showError(dialogFactory.getOwner(), "Cannot read " + file);
             return failedFuture(e);
         }

--- a/src/name/mlopatkin/andlogview/ui/filters/FiltersCodec.java
+++ b/src/name/mlopatkin/andlogview/ui/filters/FiltersCodec.java
@@ -24,7 +24,8 @@ import name.mlopatkin.andlogview.search.RequestCompilationException;
 import name.mlopatkin.andlogview.ui.filterdialog.FilterFromDialog;
 import name.mlopatkin.andlogview.ui.filterdialog.IndexWindowFilter;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
@@ -34,7 +35,7 @@ import java.util.stream.Stream;
  * Converts filters to and from serialized forms.
  */
 class FiltersCodec {
-    private static final Logger logger = Logger.getLogger(FiltersCodec.class);
+    private static final Logger logger = LoggerFactory.getLogger(FiltersCodec.class);
 
     private Stream<SavedFilterData> encodeFilter(Filter filter) {
         if (filter instanceof IndexWindowFilter indexWindowFilter) {

--- a/src/name/mlopatkin/andlogview/ui/mainframe/popupmenu/TablePopupMenuPresenter.java
+++ b/src/name/mlopatkin/andlogview/ui/mainframe/popupmenu/TablePopupMenuPresenter.java
@@ -32,8 +32,9 @@ import name.mlopatkin.andlogview.ui.mainframe.DialogFactory;
 import name.mlopatkin.andlogview.utils.CommonChars;
 import name.mlopatkin.andlogview.utils.events.Observable;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.awt.Color;
 import java.util.Collections;
@@ -60,7 +61,7 @@ public class TablePopupMenuPresenter extends PopupMenuPresenter<TablePopupMenuPr
         Observable<Consumer<Color>> addHighlightFilterAction(String title, List<Color> highlightColors);
     }
 
-    private static final Logger logger = Logger.getLogger(TablePopupMenuPresenter.class);
+    private static final Logger logger = LoggerFactory.getLogger(TablePopupMenuPresenter.class);
 
     private final BookmarkModel bookmarkModel;
     private final MenuFilterCreator filterCreator;

--- a/src/name/mlopatkin/andlogview/ui/themes/BasicTheme.java
+++ b/src/name/mlopatkin/andlogview/ui/themes/BasicTheme.java
@@ -16,7 +16,8 @@
 
 package name.mlopatkin.andlogview.ui.themes;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
@@ -25,7 +26,8 @@ import javax.swing.UnsupportedLookAndFeelException;
  * Default Java L&amp;F (Metal).
  */
 class BasicTheme implements Theme {
-    private static final Logger logger = Logger.getLogger(BasicTheme.class);
+    @SuppressWarnings("LoggerInitializedWithForeignClass")
+    private static final Logger logger = LoggerFactory.getLogger(Theme.class);
 
     @Override
     public String getName() {

--- a/src/name/mlopatkin/andlogview/ui/themes/FlatLafTheme.java
+++ b/src/name/mlopatkin/andlogview/ui/themes/FlatLafTheme.java
@@ -22,7 +22,8 @@ import com.formdev.flatlaf.IntelliJTheme;
 import com.formdev.flatlaf.util.ColorFunctions;
 import com.google.common.io.Resources;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -33,7 +34,8 @@ import javax.swing.UIManager;
  * FlatLaf L&amp;F with Light Flat IDEA theme.
  */
 class FlatLafTheme implements Theme {
-    private static final Logger logger = Logger.getLogger(Theme.class);
+    @SuppressWarnings("LoggerInitializedWithForeignClass")
+    private static final Logger logger = LoggerFactory.getLogger(Theme.class);
 
     @Override
     public String getName() {
@@ -65,9 +67,7 @@ class FlatLafTheme implements Theme {
             UIManager.put("Tree.dropCellBackground", dropBackground);
             UIManager.put("Tree.dropLineColor", dropBackground);
         } catch (IOException e) {
-            logger.error(
-                    String.format("Failed to load %s theme", FlatLafThemes.LIGHTFLAT.name().toLowerCase(Locale.ROOT)),
-                    e);
+            logger.error("Failed to load {} theme", FlatLafThemes.LIGHTFLAT.name().toLowerCase(Locale.ROOT), e);
             return false;
         }
         return true;

--- a/src/name/mlopatkin/andlogview/ui/themes/MacOsSystemTheme.java
+++ b/src/name/mlopatkin/andlogview/ui/themes/MacOsSystemTheme.java
@@ -18,7 +18,8 @@ package name.mlopatkin.andlogview.ui.themes;
 
 import name.mlopatkin.andlogview.thirdparty.systemutils.SystemUtils;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
@@ -27,7 +28,8 @@ import javax.swing.UnsupportedLookAndFeelException;
  * System L&amp;F to be used on Mac OS X.
  */
 class MacOsSystemTheme implements Theme {
-    private static final Logger logger = Logger.getLogger(Theme.class);
+    @SuppressWarnings("LoggerInitializedWithForeignClass")
+    private static final Logger logger = LoggerFactory.getLogger(Theme.class);
 
     @Override
     public String getName() {

--- a/third-party/libs/notices/ch.qos.reload4j.reload4j.1.2.26.NOTICE
+++ b/third-party/libs/notices/ch.qos.reload4j.reload4j.1.2.26.NOTICE
@@ -1,6 +1,7 @@
 ================================================================================
-NOTICE for log4j:log4j:1.2.17
+NOTICE for ch.qos.reload4j:reload4j:1.2.26
 --------------------------------------------------------------------------------
+
 Apache log4j
 Copyright 2007 The Apache Software Foundation
 

--- a/third-party/libs/notices/org.slf4j.slf4j-api.2.0.16.NOTICE
+++ b/third-party/libs/notices/org.slf4j.slf4j-api.2.0.16.NOTICE
@@ -1,0 +1,29 @@
+================================================================================
+NOTICE for org.slf4j:slf4j-api:2.0.16
+--------------------------------------------------------------------------------
+
+Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland)
+All rights reserved.
+
+Permission is hereby granted, free  of charge, to any person obtaining
+a  copy  of this  software  and  associated  documentation files  (the
+"Software"), to  deal in  the Software without  restriction, including
+without limitation  the rights to  use, copy, modify,  merge, publish,
+distribute,  sublicense, and/or sell  copies of  the Software,  and to
+permit persons to whom the Software  is furnished to do so, subject to
+the following conditions:
+
+The  above  copyright  notice  and  this permission  notice  shall  be
+included in all copies or substantial portions of the Software.
+
+THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+

--- a/third-party/libs/notices/org.slf4j.slf4j-reload4j.2.0.16.NOTICE
+++ b/third-party/libs/notices/org.slf4j.slf4j-reload4j.2.0.16.NOTICE
@@ -1,0 +1,25 @@
+================================================================================
+NOTICE for org.slf4j:slf4j-reload4j:2.0.16
+--------------------------------------------------------------------------------
+
+Copyright (c) 2004-2023 QOS.ch Sarl (Switzerland)
+All rights reserved.
+
+Permission is hereby granted, free  of charge, to any person obtaining
+a  copy  of this  software  and  associated  documentation files  (the
+"Software"), to  deal in  the Software without  restriction, including
+without limitation  the rights to  use, copy, modify,  merge, publish,
+distribute,  sublicense, and/or sell  copies of  the Software,  and to
+permit persons to whom the Software  is furnished to do so, subject to
+the following conditions:
+
+The  above  copyright  notice  and  this permission  notice  shall  be
+included in all copies or substantial portions of the Software.
+
+THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
It may trigger vulnerability scanners. Now we're using slf4j+reload4j as the logging framework

Issue: fixes #422