### PR TITLE
Do not leak provisional device observer when changing ADB servers

### DIFF
--- a/device/src/main/java/name/mlopatkin/andlogview/device/DeviceProvisioner.java
+++ b/device/src/main/java/name/mlopatkin/andlogview/device/DeviceProvisioner.java
@@ -18,6 +18,9 @@ package name.mlopatkin.andlogview.device;
 
 import java.util.concurrent.CompletableFuture;
 
-interface DeviceProvisioner {
+interface DeviceProvisioner extends AutoCloseable {
     CompletableFuture<DeviceImpl> provisionDevice(ProvisionalDeviceImpl provisionalDevice);
+
+    @Override
+    void close();
 }

--- a/device/src/test/java/name/mlopatkin/andlogview/device/DispatchingDeviceListTest.java
+++ b/device/src/test/java/name/mlopatkin/andlogview/device/DispatchingDeviceListTest.java
@@ -318,6 +318,9 @@ class DispatchingDeviceListTest {
                                         "product", "30", null, "fingerprint"
                                 )));
             }
+
+            @Override
+            public void close() {}
         };
     }
 

--- a/device/src/test/java/name/mlopatkin/andlogview/device/FakeDeviceProvisioner.java
+++ b/device/src/test/java/name/mlopatkin/andlogview/device/FakeDeviceProvisioner.java
@@ -54,4 +54,11 @@ class FakeDeviceProvisioner implements DeviceProvisioner {
                                 "product", "30", null, "fingerprint"))
         );
     }
+
+    @Override
+    public void close() {
+        provisioningDevices.forEach(
+                (s, completableFuture) -> completableFuture.completeExceptionally(
+                        new DeviceGoneException("Provisioner abandoned")));
+    }
 }


### PR DESCRIPTION
Issue: fixes #434