### PR TITLE
Change nightly tag after accidentally publishing an immutable release

### DIFF
--- a/.github/workflow-templates/releasing.yaml.ftl
+++ b/.github/workflow-templates/releasing.yaml.ftl
@@ -14,14 +14,14 @@ on:
 env:
   PYTHON_BINARY: python3
 jobs:
-  <@releases.releasePipeline "snapshot" "latest-snapshot">
+  <@releases.releasePipeline "snapshot" "nightly">
     # Only build snapshots on master
     if: github.ref == 'refs/heads/master'
   </@releases.releasePipeline>
 
   <@releases.releasePipeline "tag" "${{ github.ref_name }}">
     # Only build releases out of tags
-    if: github.ref_type == 'tag' && !endsWith(github.ref, '-snapshot')
+    if: github.ref_type == 'tag' && !endsWith(github.ref, 'nightly')
   </@releases.releasePipeline>
 
   mirror-to-bitbucket:

--- a/.github/workflows/releasing.yaml
+++ b/.github/workflows/releasing.yaml
@@ -45,24 +45,24 @@ jobs:
       - name: Update Snapshot Tag
         if: ${{ success() }}
         run: |
-          git tag --force "latest-snapshot" $GITHUB_SHA && \
-          git push --force origin "latest-snapshot"
+          git tag --force "nightly" $GITHUB_SHA && \
+          git push --force origin "nightly"
       - name: Remove old release
         if: ${{ success() }}
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
-          tools/remove-release.sh "latest-snapshot" "$GITHUB_REPOSITORY"
+          tools/remove-release.sh "nightly" "$GITHUB_REPOSITORY"
       - name: Create new release
         if: ${{ success() }}
         run: >
-          gh release create "latest-snapshot"
+          gh release create "nightly"
           --draft
           --latest=false
           --notes-file docs/releases/release_0.24.md
           --prerelease=true
-          --title "latest-snapshot"
+          --title "nightly"
           --verify-tag
         shell: bash
         env:
@@ -70,7 +70,7 @@ jobs:
       - name: Publish Linux and cross-platform installers
         if: ${{ success() }}
         shell: bash
-        run: gh release upload "latest-snapshot" build/distributions/*
+        run: gh release upload "nightly" build/distributions/*
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -107,7 +107,7 @@ jobs:
       - name: Add Windows Installers to release
         if: ${{ success() }}
         shell: bash
-        run: gh release upload "latest-snapshot" build/distributions/*
+        run: gh release upload "nightly" build/distributions/*
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -141,7 +141,7 @@ jobs:
       - name: Add macOS Installers to release
         if: ${{ success() }}
         shell: bash
-        run: gh release upload "latest-snapshot" build/distributions/*
+        run: gh release upload "nightly" build/distributions/*
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -157,7 +157,7 @@ jobs:
       - name: Publish draft release as pre-release
         if: ${{ success() }}
         run: >
-          gh release edit "latest-snapshot"
+          gh release edit "nightly"
           --draft=false
           --latest=false
           --prerelease=true
@@ -173,7 +173,7 @@ jobs:
     env:
       LOGVIEW_SNAPSHOT_BUILD: false
     # Only build releases out of tags
-    if: github.ref_type == 'tag' && !endsWith(github.ref, '-snapshot')
+    if: github.ref_type == 'tag' && !endsWith(github.ref, 'nightly')
     steps:
       - uses: actions/checkout@v4
       - name: Setup Gradle
@@ -222,7 +222,7 @@ jobs:
     needs:
       - build-tag  # We need the release to be prepared first.
     # Only build releases out of tags
-    if: github.ref_type == 'tag' && !endsWith(github.ref, '-snapshot')
+    if: github.ref_type == 'tag' && !endsWith(github.ref, 'nightly')
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -256,7 +256,7 @@ jobs:
     needs:
       - build-tag  # We need the release to be prepared first.
     # Only build releases out of tags
-    if: github.ref_type == 'tag' && !endsWith(github.ref, '-snapshot')
+    if: github.ref_type == 'tag' && !endsWith(github.ref, 'nightly')
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/buildSrc/src/main/kotlin/name/mlopatkin/andlogview/building/GitRevCountValueSource.kt
+++ b/buildSrc/src/main/kotlin/name/mlopatkin/andlogview/building/GitRevCountValueSource.kt
@@ -35,7 +35,7 @@ abstract class GitRevCountValueSource : ValueSource<Int, GitRevCountValueSource.
                 "describe",
                 "--abbrev=0",
                 "--tags",
-                "latest-snapshot^" // Exclude latest-snapshot tag
+                "nightly^" // Exclude nightly tag
             )
             require(lastReleaseTag.matches("[0-9]+\\.[0-9]+(\\.[0-9]+)?".toRegex())) {
                 "Invalid version tag '$lastReleaseTag'"

--- a/docs/site/content/user_manual/install/_index.en.md
+++ b/docs/site/content/user_manual/install/_index.en.md
@@ -57,7 +57,7 @@ Mint) is required.
 AndLogView should be available in the application list of your Desktop
 Environment (Start Menu) and as `andlogview` in the terminal.
 
-[gh_nightly_release]: https://github.com/mlopatkin/andlogview/releases/tag/latest-snapshot
+[gh_nightly_release]: https://github.com/mlopatkin/andlogview/releases/tag/nightly
 {{< /tab >}}
 
 {{< tab "Windows" >}}
@@ -71,7 +71,7 @@ Environment (Start Menu) and as `andlogview` in the terminal.
 AndLogView should be available in the Start Menu or on Desktop, depending
 on your choices during installation.
 
-[gh_nightly_release]: https://github.com/mlopatkin/andlogview/releases/tag/latest-snapshot
+[gh_nightly_release]: https://github.com/mlopatkin/andlogview/releases/tag/nightly
 {{< /tab >}}
 
 {{< /tabs >}}


### PR DESCRIPTION
`latest-snapshot` is likely forever tainted by Github's immutable release feature. The tag can no longer be updated, and we need another location for nightlies.

This commit changes the tag from `latest-snapshot` to `nightly`. I also disabled Immutable Releases for the repo.

See https://github.blog/changelog/2025-10-28-immutable-releases-are-now-generally-available/

Issue: n/a.