### PR TITLE
Prevent ADB error dialog from appearing over configuration dialog

### DIFF
--- a/src/name/mlopatkin/andlogview/ui/device/AdbOpener.java
+++ b/src/name/mlopatkin/andlogview/ui/device/AdbOpener.java
@@ -45,7 +45,7 @@ public class AdbOpener {
     private final Executor uiExecutor;
 
     @Inject
-    AdbOpener(AdbServicesInitializationPresenter presenter,
+    public AdbOpener(AdbServicesInitializationPresenter presenter,
             AdbDataSourceFactory adbDataSourceFactory,
             @Named(AppExecutors.UI_EXECUTOR) Executor uiExecutor) {
         this.presenter = presenter;

--- a/src/name/mlopatkin/andlogview/ui/device/GlobalAdbDeviceList.java
+++ b/src/name/mlopatkin/andlogview/ui/device/GlobalAdbDeviceList.java
@@ -39,7 +39,7 @@ import javax.inject.Named;
  * A holder for per-AdbServer instances of {@link AdbDeviceList}. Changes to the underlying list become opaque to the
  * clients.
  */
-class GlobalAdbDeviceList implements AdbDeviceList {
+public class GlobalAdbDeviceList implements AdbDeviceList {
     private final Subject<DeviceChangeObserver> deviceChangeObservers = new Subject<>();
     private final SequentialExecutor uiExecutor;
 

--- a/src/name/mlopatkin/andlogview/ui/preferences/ConfigurationDialogPresenter.java
+++ b/src/name/mlopatkin/andlogview/ui/preferences/ConfigurationDialogPresenter.java
@@ -97,6 +97,8 @@ public class ConfigurationDialogPresenter {
         view.setAutoReconnectEnabled(adbConfigurationPref.isAutoReconnectEnabled());
         view.setAdbInstallAvailable(!adbConfigurationPref.hasValidAdbLocation() && adbInstaller.isAvailable());
         view.setAdbInstallerAction(this::startAdbInstall);
+
+        adbServicesPresenter.postponeErrorDialogs();
         view.show();
     }
 
@@ -131,9 +133,14 @@ public class ConfigurationDialogPresenter {
         if (hasLocationChanged || adbServicesStatus.getStatus().isFailed()) {
             adbServicesPresenter.restartAdb();
         }
+
+        // Show any postponed ADB errors if we didn't restart ADB above.
+        adbServicesPresenter.resumeErrorDialogs();
     }
 
     private void discard() {
         view.hide();
+        // Show any postponed ADB errors since the dialog closed without changes.
+        adbServicesPresenter.resumeErrorDialogs();
     }
 }

--- a/test/name/mlopatkin/andlogview/ui/preferences/AdbErrorHandlingIntegTest.java
+++ b/test/name/mlopatkin/andlogview/ui/preferences/AdbErrorHandlingIntegTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 the Andlogview authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.mlopatkin.andlogview.ui.preferences;
+
+import static name.mlopatkin.andlogview.utils.MyFutures.errorHandler;
+import static name.mlopatkin.andlogview.utils.MyFutures.ignoreCancellations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+import name.mlopatkin.andlogview.base.concurrent.TestSequentialExecutor;
+import name.mlopatkin.andlogview.config.FakeInMemoryConfigStorage;
+import name.mlopatkin.andlogview.device.AdbException;
+import name.mlopatkin.andlogview.preferences.AdbConfigurationPref;
+import name.mlopatkin.andlogview.ui.device.AdbOpener;
+import name.mlopatkin.andlogview.ui.device.AdbServices;
+import name.mlopatkin.andlogview.ui.device.AdbServicesBridge;
+import name.mlopatkin.andlogview.ui.device.AdbServicesInitializationPresenter;
+import name.mlopatkin.andlogview.ui.device.GlobalAdbDeviceList;
+import name.mlopatkin.andlogview.utils.FakePathResolver;
+
+import com.google.common.util.concurrent.MoreExecutors;
+
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.Issue;
+import org.mockito.Mockito;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+/**
+ * Integration tests for ADB error handling that involve multiple moving parts.
+ */
+class AdbErrorHandlingIntegTest {
+
+    @Test
+    @Issue("https://github.com/mlopatkin/andlogview/issues/491")
+    void noSecondConfigurationDialogOpensIfAdbErrorOccursWhileConfigurationDialogIsOnScreen() {
+        var uiExecutor = new TestSequentialExecutor(MoreExecutors.directExecutor());
+
+        var adbPref = new AdbConfigurationPref(new FakeInMemoryConfigStorage(), FakePathResolver.acceptsAnything());
+        adbPref.trySetAdbLocation("/usr/bin/adb");
+
+        AdbServicesBridge bridge = mock();
+        CompletableFuture<AdbServices> result = new CompletableFuture<>();
+        when(bridge.getAdbServicesAsync()).thenReturn(result);
+        when(bridge.prepareAdbDeviceList(any())).then(args -> {
+                    Consumer<Throwable> th = args.getArgument(0);
+                    var ignored = result.handle(errorHandler(ignoreCancellations(th)));
+                    return new GlobalAdbDeviceList(uiExecutor);
+                }
+        );
+
+        AdbServicesInitializationPresenter.View adbInitView = mock();
+        ConfigurationDialogPresenter.View configurationView = mock();
+        var inOrder = Mockito.inOrder(adbInitView, configurationView);
+
+        var adbInitPresenter = new AdbServicesInitializationPresenter(
+                adbInitView,
+                bridge,
+                adbPref,
+                uiExecutor,
+                mock()
+        );
+
+        var configurationDialogPresenter = new ConfigurationDialogPresenter(
+                configurationView,
+                adbPref,
+                adbInitPresenter,
+                bridge,
+                mock(),
+                uiExecutor
+        );
+
+        var adbOpener = new AdbOpener(adbInitPresenter, mock(), uiExecutor);
+
+        var ignored = adbOpener.awaitDevice();
+
+        configurationDialogPresenter.openDialog();
+
+        result.completeExceptionally(new AdbException("Simulated failure"));
+
+        inOrder.verify(configurationView).show();
+        inOrder.verify(adbInitView, never()).showAdbLoadingError(any(), anyBoolean());
+        inOrder.verifyNoMoreInteractions();
+    }
+}


### PR DESCRIPTION
It was possible for the ADB failure during first initialization to come while the user already has opened the ADB configuration dialog. This commit postpones ADB error dialogs when the configuration dialog is open to avoid stealing focus, confusing the user, or allowing multiple configuration dialogs to appear.

Pending errors are shown after the dialog closes, or discarded if the user commits ADB configuration changes (making the error obsolete).

Fixes #491