### PR TITLE
Disable shadowJar output caching as it handles resources incorrectly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -420,6 +420,10 @@ tasks.startShadowScripts {
 }
 
 tasks.named<ShadowJar>("shadowJar") {
+    outputs.doNotCacheIf("Incorrectly handles metadata resource") {
+        true
+    }
+
     // NOTICES and licenses are included into ours NOTICE file manually.
     // Maven metadata isn't necessary also.
     exclude("**/NOTICE")

--- a/docs/releases/release_1.0.1.md
+++ b/docs/releases/release_1.0.1.md
@@ -1,0 +1,46 @@
+## What's New
+
+This is a bugfix release for release 1.0.
+
+### Fixed issues of 1.0
+
+* Incorrect version information (`-SNAPSHOT`) ([#501](https://github.com/mlopatkin/andlogview/issues/501)).
+
+### Breaking Changes
+
+* **Minimal supported JDK to run AndLogView is now 17**.
+
+  Starting with AndLogView version 1.0, JDK 17 or higher is required to run it. Before, only Java 8 was required.
+  You can use new distributions with bundled JDK if you don't want to manage JDK yourself.
+
+### New Features
+* **Semi-automated ADB installation** ([#239](https://github.com/mlopatkin/andlogview/issues/239)).
+  AndLogView can now download and install Android SDK platform-tools for you.
+
+  This makes it easier to start working with devices and emulators without manually downloading the SDK.
+
+* **Platform-specific installers with bundled Java runtime** ([#428](https://github.com/mlopatkin/andlogview/issues/428)).
+
+  There is no need to install JDK manually if you use one of these. So far, these platforms are supported:
+    * Linux (x64 aka amd64), only for DEB-based distributions, e.g. Debian, Ubuntu, Mint ([#437](https://github.com/mlopatkin/andlogview/issues/437)).
+    * Windows (x64), as EXE installer ([#436](https://github.com/mlopatkin/andlogview/issues/436)).
+    * macOS (arm64 aka M1+), as DMG image ([#438](https://github.com/mlopatkin/andlogview/issues/438)).
+
+  Users on other platforms should continue use the `noJRE` distribution with manually installed JDK 17+ for now.
+
+### Improvements
+* **App Icon**.
+
+  The app now has a custom icon.
+
+* **About dialog** ([#426](https://github.com/mlopatkin/andlogview/issues/426)).
+
+  A new Help → About menu item shows application version, build information, and open-source component licenses.
+
+* **Better error reporting**.
+
+  Error dialogs now include expandable stack traces to help diagnose issues and provide better context when things go wrong.
+
+### More info:
+* [Full Changelog](https://github.com/mlopatkin/andlogview/compare/0.23...master)
+* [Known issues](https://github.com/mlopatkin/andlogview/issues?q=sort%3Aupdated-desc%20is%3Aissue%20label%3Aa%3Abug%2Ca%3Aregression%20label%3Aaffects-version%3A1.0%20is%3Aopen)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-andlogview = "1.0"
+andlogview = "1.0.1"
 checkstyle = "10.21.1"
 dagger = "2.55"
 errorprone = "2.45.0"


### PR DESCRIPTION
This caused accidental cache reuse between snapshot and release pipelines, causing broken version (with SNAPSHOT) in the 1.0 release.

Fixes #501