### PR TITLE
Emit lines of long message as we're sure they aren't delimiters

### DIFF
--- a/docs/releases/release_1.1.md
+++ b/docs/releases/release_1.1.md
@@ -1,6 +1,8 @@
 No new features announced yet.
 
 ### 🛠 Improvements and bugfixes
+* Fixed issue when the last message in the buffer may not be displayed until the
+  next message comes ([#513](https://github.com/mlopatkin/andlogview/issues/513)).
 * Converted changelog to markdown format and added more historical contents
   ([#232](https://github.com/mlopatkin/andlogview/issues/232)).
 

--- a/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateLong.java
+++ b/parsers/src/main/java/name/mlopatkin/andlogview/parsers/logcat/DelegateLong.java
@@ -29,8 +29,6 @@ import com.google.common.base.CharMatcher;
 import org.jspecify.annotations.Nullable;
 
 import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -199,7 +197,6 @@ class DelegateLong extends RegexLogcatParserDelegate {
         private final int tid;
         private final Priority priority;
         private final String tag;
-        private final List<CharSequence> messageLines = new ArrayList<>();
 
         public CurrentMessage(Matcher matcher) {
             timestamp = parseTimestamp(matcher.group(1));
@@ -211,13 +208,11 @@ class DelegateLong extends RegexLogcatParserDelegate {
         }
 
         public void addMessageLine(CharSequence line) {
-            messageLines.add(line);
+            eventsHandler.logRecord(timestamp, pid, tid, priority, tag, line.toString());
         }
 
         public void commit() {
-            for (var messageLine : messageLines) {
-                eventsHandler.logRecord(timestamp, pid, tid, priority, tag, messageLine.toString());
-            }
+            // Do nothing, we emitted all lines as we went through them.
         }
     }
 


### PR DESCRIPTION
When at the end of the log, it may take some time for the new message to appear, especially with low-traffic buffers like `crash`. Waiting for the next message until flushing caused the last message to stuck in the parser, so the user could not see the last logged entry. Again, for crashes it is particularly nasty, because you may not be able to see the crash you're looking for.

This commit changes the way we emit log records for log messages to emit lines without any buffering as soon as we're sure they're part of the message. We're not doing anything to compose multiline messages anyway.

Fixed #513