### PR TITLE
Use object format to store Color instances

### DIFF
--- a/src/name/mlopatkin/andlogview/config/ColorTypeAdapter.java
+++ b/src/name/mlopatkin/andlogview/config/ColorTypeAdapter.java
@@ -19,17 +19,9 @@ class ColorTypeAdapter extends TypeAdapter<Color> {
             out.nullValue();
             return;
         }
-        if (value.getAlpha() == 0xFF) {
-            // write RGB value
-            out.value(String.format(
-                    "#%02X%02X%02X", value.getRed(), value.getGreen(), value.getBlue())
-            );
-        } else {
-            // write ARGB value
-            out.value(String.format(
-                    "#%02X%02X%02X%02X", value.getAlpha(), value.getRed(), value.getGreen(), value.getBlue()
-            ));
-        }
+        out.beginObject();
+        out.name("value").value(value.getRGB());
+        out.endObject();
     }
 
     @Override


### PR DESCRIPTION
To make configuration file backwards compatible with 1.0

Fixes #524