### PR TITLE
Allow native access for the app

### DIFF
--- a/gradle/plugins/jpackage/src/main/kotlin/name/mlopatkin/gradleplugins/jpackage/InstallerExtension.kt
+++ b/gradle/plugins/jpackage/src/main/kotlin/name/mlopatkin/gradleplugins/jpackage/InstallerExtension.kt
@@ -85,6 +85,11 @@ abstract class InstallerExtension @Inject constructor(
     abstract val version: Property<String>
 
     /**
+     * Additional JVM options to set up when running the application through launcher executable.
+     */
+    abstract val jvmOptions: ListProperty<String>
+
+    /**
      * Linux distribution configuration.
      */
     val linux: PackageExtension = objects.newInstance()

--- a/gradle/plugins/jpackage/src/main/kotlin/name/mlopatkin/gradleplugins/jpackage/JpackagePlugin.kt
+++ b/gradle/plugins/jpackage/src/main/kotlin/name/mlopatkin/gradleplugins/jpackage/JpackagePlugin.kt
@@ -174,6 +174,8 @@ abstract class JpackagePlugin : Plugin<Project> {
                         addAll(forCurrentPlatform.imageOptions.get())
                     }
 
+                    jvmArgs = jvmOptions.get()
+
                     installerOptions = buildList {
                         withOptionalSwitch("--vendor", vendor)
                         withOptionalSwitch("--license-file", forCurrentPlatform.licenseFile.asPath)

--- a/src/name/mlopatkin/andlogview/Main.java
+++ b/src/name/mlopatkin/andlogview/Main.java
@@ -64,6 +64,12 @@ public class Main {
         logger.info("{} {}", APP_NAME, getVersionString());
         logger.info("Revision {}", BuildInfo.REVISION);
         logger.info("Configuration: {}", configurationLoc.getConfigurationDir().getAbsolutePath());
+        logger.info(
+                "JVM: {} {} {}",
+                System.getProperty("java.vendor"),
+                System.getProperty("java.vm.name"),
+                Runtime.version()
+        );
 
         Theme theme = initLaf();
 


### PR DESCRIPTION
FlatLaF needs it to inject platform-specific capabilities.

This commit enables it in all flavors:
- IDEA-generated run configurations
- Application plugin's `run`
- Shadow JAR `runShadow` and the `noJRE` distribution
- jpackage-built distributions

Fixes #511