### PR TITLE
Discard listeners when tearing down ADB on SIGTERM

### DIFF
--- a/device/src/main/java/name/mlopatkin/andlogview/device/AdbFacade.java
+++ b/device/src/main/java/name/mlopatkin/andlogview/device/AdbFacade.java
@@ -30,4 +30,6 @@ interface AdbFacade {
     void removeDeviceChangeListener(AndroidDebugBridge.IDeviceChangeListener deviceChangeListener);
 
     boolean hasRegisteredListeners();
+
+    void discardListeners();
 }

--- a/device/src/main/java/name/mlopatkin/andlogview/device/AdbManagerImpl.java
+++ b/device/src/main/java/name/mlopatkin/andlogview/device/AdbManagerImpl.java
@@ -94,6 +94,7 @@ class AdbManagerImpl implements AdbManager {
             var theServer = server;
             if (theServer != null) {
                 logger.info("Stop ADB server");
+                theServer.discardListeners();
                 theServer.stop();
             }
             AndroidDebugBridge.terminate();

--- a/device/src/main/java/name/mlopatkin/andlogview/device/AdbServerImpl.java
+++ b/device/src/main/java/name/mlopatkin/andlogview/device/AdbServerImpl.java
@@ -98,6 +98,13 @@ class AdbServerImpl implements AdbServer {
         }
     }
 
+    /**
+     * Removes all registered listeners. Mostly useful when tearing down the whole ADB infrastructure.
+     */
+    public void discardListeners() {
+        adbFacade.discardListeners();
+    }
+
     public void stop() {
         deviceProvisioner.close();
         Preconditions.checkState(!adbFacade.hasRegisteredListeners(), "There are leftover listeners");
@@ -132,6 +139,11 @@ class AdbServerImpl implements AdbServer {
         @Override
         public boolean hasRegisteredListeners() {
             return !listeners.isEmpty();
+        }
+
+        @Override
+        public void discardListeners() {
+            listeners.forEach(this::removeDeviceChangeListener);
         }
     }
 }

--- a/device/src/test/java/name/mlopatkin/andlogview/device/FakeAdbFacade.java
+++ b/device/src/test/java/name/mlopatkin/andlogview/device/FakeAdbFacade.java
@@ -96,4 +96,9 @@ public class FakeAdbFacade implements AdbFacade {
     public boolean hasRegisteredListeners() {
         return !deviceChangeListeners.isEmpty();
     }
+
+    @Override
+    public void discardListeners() {
+        deviceChangeListeners.clear();
+    }
 }


### PR DESCRIPTION
Now ADB correctly goes down with the app. The registered listeners on the AdbServer will never be notified after that, but that looks benign.

Fixes #460