### PR TITLE
Reformat release notes to accommodate for GitHub quirks

### DIFF
--- a/docs/releases/release_1.1.md
+++ b/docs/releases/release_1.1.md
@@ -19,3 +19,7 @@ No new features announced yet.
 ### More info:
 * [Full Changelog](https://github.com/mlopatkin/andlogview/compare/1.0.1...master)
 * [Known issues](https://github.com/mlopatkin/andlogview/issues?q=is%3Aissue%20is%3Aopen%20(label%3Aa%3Abug%20OR%20label%3Aa%3Aregression))
+
+## Contributors
+
+Thanks to [pokla6](https://github.com/pokla6) for their contributions.


### PR DESCRIPTION
GitHub release notes render Markdown with hard breaks for each EOLN. This isn't something I intended to have.

Also, add the missing item to the notes, while I'm here.

Issue: n/a